### PR TITLE
P2p Wasm Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2049,6 +2049,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-utils"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "graphql-parser"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3167,7 +3180,7 @@ dependencies = [
  "clap",
  "derive_more",
  "fuzzcheck",
- "gloo-utils",
+ "gloo-utils 0.1.7",
  "hex",
  "mina-curves",
  "mina-hasher",
@@ -3805,6 +3818,7 @@ dependencies = [
  "serde",
  "sha2 0.10.8",
  "slab",
+ "tokio",
  "tracing",
 ]
 
@@ -3888,7 +3902,9 @@ dependencies = [
  "derive_more",
  "ecies-ed25519",
  "ed25519-dalek 2.0.0",
+ "gloo-utils 0.2.0",
  "hyper",
+ "js-sys",
  "libp2p",
  "libp2p-rpc-behaviour",
  "mina-p2p-messages",
@@ -3906,6 +3922,9 @@ dependencies = [
  "thiserror",
  "tokio",
  "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
  "webrtc 0.8.0",
 ]
 
@@ -4529,7 +4548,6 @@ version = "0.1.0"
 dependencies = [
  "cli",
  "node",
- "openmina-core",
  "openmina-node-native",
 ]
 

--- a/cli/replay_dynamic_effects/Cargo.toml
+++ b/cli/replay_dynamic_effects/Cargo.toml
@@ -8,7 +8,6 @@ crate-type = ["dylib"]
 name = "replay_dynamic_effects"
 
 [dependencies]
-openmina-core = { path = "../../core" }
 node = { path = "../../node", features = ["replay"] }
 openmina-node-native = { path = "../../node/native" }
 cli = { path = "../" }

--- a/cli/src/commands/node/mod.rs
+++ b/cli/src/commands/node/mod.rs
@@ -10,9 +10,10 @@ use mina_p2p_messages::v2::{
 use rand::prelude::*;
 
 use tokio::select;
-use tokio::sync::mpsc;
 
 use node::account::AccountPublicKey;
+use node::core::channels::mpsc;
+use node::core::log::inner::Level;
 use node::event_source::{
     EventSourceProcessEventsAction, EventSourceWaitForEventsAction, EventSourceWaitTimeoutAction,
 };
@@ -20,8 +21,8 @@ use node::ledger::LedgerCtx;
 use node::p2p::channels::ChannelId;
 use node::p2p::connection::outgoing::P2pConnectionOutgoingInitOpts;
 use node::p2p::identity::SecretKey;
-use node::p2p::service_impl::webrtc_rs::P2pServiceCtx;
-use node::p2p::service_impl::webrtc_rs_with_libp2p::{self, P2pServiceWebrtcRsWithLibp2p};
+use node::p2p::service_impl::webrtc::P2pServiceCtx;
+use node::p2p::service_impl::webrtc_with_libp2p::{self, P2pServiceWebrtcWithLibp2p};
 use node::p2p::{P2pConfig, P2pEvent};
 use node::service::{Recorder, Service};
 use node::snark::{get_srs, get_verifier_index, VerifierKind};
@@ -30,7 +31,6 @@ use node::{
     BuildEnv, Config, GlobalConfig, LedgerConfig, SnarkConfig, SnarkerConfig, State,
     TransitionFrontierConfig,
 };
-use openmina_core::log::inner::Level;
 
 use openmina_node_native::rpc::RpcService;
 use openmina_node_native::{http_server, tracing, NodeService, P2pTaskSpawner, RpcSender};
@@ -180,10 +180,10 @@ impl Node {
 
         let (p2p_event_sender, mut rx) = mpsc::unbounded_channel::<P2pEvent>();
 
-        let webrtc_rs_with_libp2p::P2pServiceCtx {
+        let webrtc_with_libp2p::P2pServiceCtx {
             libp2p,
             webrtc: P2pServiceCtx { cmd_sender, peers },
-        } = <NodeService as P2pServiceWebrtcRsWithLibp2p>::init(
+        } = <NodeService as P2pServiceWebrtcWithLibp2p>::init(
             secret_key,
             self.chain_id,
             p2p_event_sender.clone(),

--- a/cli/src/commands/replay/replay_state_with_input_actions.rs
+++ b/cli/src/commands/replay/replay_state_with_input_actions.rs
@@ -1,5 +1,6 @@
 use std::cell::RefCell;
 
+use node::core::channels::mpsc;
 use node::p2p::service_impl::libp2p::Libp2pService;
 use node::recorder::{Recorder, StateWithInputActionsReader};
 use node::snark::VerifierKind;
@@ -7,7 +8,6 @@ use node::{ActionWithMeta, BuildEnv, Store};
 use openmina_node_native::{rpc::RpcService, NodeService, ReplayerState};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
-use tokio::sync::mpsc;
 
 #[derive(Debug, clap::Args)]
 /// Replay node using initial state and input actions.

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,6 +10,7 @@ slab = { version = "0.4.7", features = ["serde"] }
 tracing = { version = "0.1", features = ["std"] }
 sha2 = "0.10.6"
 redux = { git = "https://github.com/openmina/redux-rs.git", features = ["serde"] }
+tokio = { version = "1.26", features = ["sync"] }
 
 mina-hasher = { git = "https://github.com/o1-labs/proof-systems" }
 mina-p2p-messages = { workspace = true }

--- a/core/src/channels.rs
+++ b/core/src/channels.rs
@@ -1,0 +1,1 @@
+pub use tokio::sync::{mpsc, oneshot};

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -2,3 +2,5 @@ pub mod block;
 pub mod log;
 pub mod requests;
 pub mod snark;
+
+pub mod channels;

--- a/node/native/src/ext_snark_worker.rs
+++ b/node/native/src/ext_snark_worker.rs
@@ -14,6 +14,7 @@ use mina_p2p_messages::v2::{
     SnarkWorkerWorkerRpcsVersionedGetWorkV2TResponseA0, TransactionSnarkWorkTStableV2Proofs,
 };
 
+use node::core::channels::{mpsc, oneshot};
 use node::event_source::Event;
 use node::external_snark_worker::{
     ExternalSnarkWorkerError, ExternalSnarkWorkerEvent, ExternalSnarkWorkerService,
@@ -22,8 +23,6 @@ use node::external_snark_worker::{
 
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader};
 use tokio::process::Command;
-
-use tokio::sync::{mpsc, oneshot};
 
 use super::NodeService;
 
@@ -442,12 +441,12 @@ mod tests {
         CurrencyFeeStableV1, NonZeroCurvePoint, SnarkWorkerWorkerRpcsVersionedGetWorkV2TResponse,
         SnarkWorkerWorkerRpcsVersionedGetWorkV2TResponseA0,
     };
+    use node::core::channels::mpsc;
+    use node::core::log::inner::Level;
     use node::{
         event_source::Event,
         external_snark_worker::{ExternalSnarkWorkerEvent, SnarkWorkSpec},
     };
-    use openmina_core::log::inner::Level;
-    use tokio::sync::mpsc;
 
     use super::super::tracing;
     use super::ExternalSnarkWorkerFacade;

--- a/node/native/src/rpc.rs
+++ b/node/native/src/rpc.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
-use tokio::sync::{mpsc, oneshot};
 
+use node::core::channels::{mpsc, oneshot};
+use node::core::requests::PendingRequests;
 use node::p2p::connection::P2pConnectionResponse;
 pub use node::rpc::{
     ActionStatsResponse, RespondError, RpcActionStatsGetResponse, RpcId, RpcIdType,
@@ -10,7 +11,6 @@ pub use node::rpc::{
 };
 use node::State;
 use node::{event_source::Event, rpc::RpcSnarkPoolJobGetResponse};
-use openmina_core::requests::PendingRequests;
 
 use super::{NodeRpcRequest, NodeService};
 

--- a/node/native/src/service.rs
+++ b/node/native/src/service.rs
@@ -8,14 +8,14 @@ use rand::prelude::*;
 use redux::ActionMeta;
 use serde::Serialize;
 
-use tokio::sync::{mpsc, oneshot};
-
+use node::core::channels::{mpsc, oneshot};
+use node::core::snark::Snark;
 use node::event_source::Event;
 use node::ledger::LedgerCtx;
 use node::p2p::connection::outgoing::P2pConnectionOutgoingInitOpts;
 use node::p2p::service_impl::libp2p::Libp2pService;
-use node::p2p::service_impl::webrtc_rs::{Cmd, P2pServiceWebrtcRs, PeerState};
-use node::p2p::service_impl::webrtc_rs_with_libp2p::P2pServiceWebrtcRsWithLibp2p;
+use node::p2p::service_impl::webrtc::{Cmd, P2pServiceWebrtc, PeerState};
+use node::p2p::service_impl::webrtc_with_libp2p::P2pServiceWebrtcWithLibp2p;
 use node::p2p::service_impl::TaskSpawner;
 use node::p2p::{P2pEvent, PeerId};
 use node::rpc::{RpcP2pConnectionOutgoingResponse, RpcRequest};
@@ -27,7 +27,6 @@ use node::snark::work_verify::{SnarkWorkVerifyError, SnarkWorkVerifyId, SnarkWor
 use node::snark::{SnarkEvent, VerifierIndex, VerifierSRS};
 use node::stats::Stats;
 use node::ActionKind;
-use openmina_core::snark::Snark;
 
 use crate::ext_snark_worker;
 use crate::rpc::RpcService;
@@ -106,7 +105,7 @@ impl EventSourceService for NodeService {
     }
 }
 
-impl P2pServiceWebrtcRs for NodeService {
+impl P2pServiceWebrtc for NodeService {
     fn random_pick(
         &mut self,
         list: &[P2pConnectionOutgoingInitOpts],
@@ -127,7 +126,7 @@ impl P2pServiceWebrtcRs for NodeService {
     }
 }
 
-impl P2pServiceWebrtcRsWithLibp2p for NodeService {
+impl P2pServiceWebrtcWithLibp2p for NodeService {
     fn libp2p(&mut self) -> &mut Libp2pService {
         &mut self.libp2p
     }

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -1,3 +1,5 @@
+pub use openmina_core as core;
+
 #[macro_use]
 mod action;
 pub use action::*;

--- a/node/testing/src/cluster/mod.rs
+++ b/node/testing/src/cluster/mod.rs
@@ -10,6 +10,8 @@ pub use node_id::ClusterNodeId;
 use std::{collections::VecDeque, sync::Arc};
 
 use ledger::proofs::{VerifierIndex, VerifierSRS};
+use node::core::channels::mpsc;
+use node::core::requests::RpcId;
 use node::{
     event_source::Event,
     ledger::LedgerCtx,
@@ -17,8 +19,8 @@ use node::{
         channels::ChannelId,
         identity::SecretKey as P2pSecretKey,
         service_impl::{
-            webrtc_rs::P2pServiceCtx,
-            webrtc_rs_with_libp2p::{self, P2pServiceWebrtcRsWithLibp2p},
+            webrtc::P2pServiceCtx,
+            webrtc_with_libp2p::{self, P2pServiceWebrtcWithLibp2p},
         },
         P2pEvent,
     },
@@ -26,11 +28,9 @@ use node::{
     snark::{get_srs, get_verifier_index, VerifierKind},
     BuildEnv, Config, GlobalConfig, LedgerConfig, P2pConfig, SnarkConfig, TransitionFrontierConfig,
 };
-use openmina_core::requests::RpcId;
 use openmina_node_native::{http_server, rpc::RpcService, NodeService, RpcSender};
 use rand::{rngs::StdRng, SeedableRng};
 use serde::Serialize;
-use tokio::sync::mpsc;
 
 use crate::{
     node::{Node, NodeTestingConfig, RustNodeTestingConfig},
@@ -122,10 +122,10 @@ impl Cluster {
 
         let (p2p_event_sender, mut rx) = mpsc::unbounded_channel::<P2pEvent>();
 
-        let webrtc_rs_with_libp2p::P2pServiceCtx {
+        let webrtc_with_libp2p::P2pServiceCtx {
             libp2p,
             webrtc: P2pServiceCtx { cmd_sender, peers },
-        } = <NodeService as P2pServiceWebrtcRsWithLibp2p>::init(
+        } = <NodeService as P2pServiceWebrtcWithLibp2p>::init(
             secret_key,
             testing_config.chain_id,
             p2p_event_sender.clone(),

--- a/node/testing/src/cluster/p2p_task_spawner.rs
+++ b/node/testing/src/cluster/p2p_task_spawner.rs
@@ -1,5 +1,5 @@
+use node::core::channels::mpsc;
 use node::p2p::service_impl::TaskSpawner;
-use tokio::sync::mpsc;
 
 #[derive(Clone)]
 pub struct P2pTaskSpawner {

--- a/node/testing/src/service/mod.rs
+++ b/node/testing/src/service/mod.rs
@@ -4,6 +4,9 @@ use std::time::Duration;
 use std::{collections::BTreeMap, ffi::OsStr, sync::Arc};
 
 use mina_p2p_messages::v2::{CurrencyFeeStableV1, NonZeroCurvePoint};
+use node::core::channels::mpsc;
+use node::core::requests::{PendingRequests, RequestId};
+use node::core::snark::Snark;
 use node::recorder::Recorder;
 use node::snark::block_verify::{
     SnarkBlockVerifyId, SnarkBlockVerifyService, VerifiableBlockWithHash,
@@ -19,18 +22,15 @@ use node::{
         connection::outgoing::P2pConnectionOutgoingInitOpts,
         service_impl::{
             libp2p::Libp2pService,
-            webrtc_rs::{Cmd, P2pServiceWebrtcRs, PeerState},
-            webrtc_rs_with_libp2p::P2pServiceWebrtcRsWithLibp2p,
+            webrtc::{Cmd, P2pServiceWebrtc, PeerState},
+            webrtc_with_libp2p::P2pServiceWebrtcWithLibp2p,
         },
         webrtc, P2pEvent, PeerId,
     },
 };
-use openmina_core::requests::{PendingRequests, RequestId};
-use openmina_core::snark::Snark;
 use openmina_node_native::NodeService;
 use rand::seq::SliceRandom;
 use redux::Instant;
-use tokio::sync::mpsc;
 
 #[derive(Hash, Ord, PartialOrd, Eq, PartialEq)]
 pub struct PendingEventIdType;
@@ -133,7 +133,7 @@ impl node::event_source::EventSourceService for NodeTestingService {
     }
 }
 
-impl P2pServiceWebrtcRs for NodeTestingService {
+impl P2pServiceWebrtc for NodeTestingService {
     fn random_pick(
         &mut self,
         list: &[P2pConnectionOutgoingInitOpts],
@@ -162,7 +162,7 @@ impl P2pServiceWebrtcRs for NodeTestingService {
     }
 }
 
-impl P2pServiceWebrtcRsWithLibp2p for NodeTestingService {
+impl P2pServiceWebrtcWithLibp2p for NodeTestingService {
     fn libp2p(&mut self) -> &mut Libp2pService {
         &mut self.real.libp2p
     }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -11,6 +11,7 @@ serde_json = "1.0.94"
 strum = "0.24.1"
 strum_macros = "0.24.3"
 derive_more = "0.99.17"
+rand = "0.8"
 bytes = "*"
 bs58 = "0.4.0"
 anyhow = "1.0.70"
@@ -22,19 +23,23 @@ sha2 = "0.10.6"
 ecies-ed25519 = "0.5.1"
 ed25519-dalek = { version = "2.0.0-rc.2", features = ["serde"] }
 
-tokio = { version = "1.26.0", features = ["rt"] }
-webrtc = { git = "https://github.com/openmina/webrtc.git", branch = "openmina-dd340dd" }
-# webrtc = { version = "0.7.1", optional = true }
-hyper = { version = "0.14.25", features = ["client", "http1", "tcp"] }
-libp2p = { git = "https://github.com/openmina/rust-libp2p", branch="webrtc-v0.51.3", default-features = false, features = ["macros", "serde", "tcp", "dns", "tokio", "yamux", "pnet", "noise", "gossipsub"] }
-libp2p-rpc-behaviour = { path = "libp2p-rpc-behaviour" }
-
 redux = { git = "https://github.com/openmina/redux-rs.git", features = ["serde"] }
 mina-p2p-messages = { workspace = true }
 
 openmina-core = { path = "../core" }
 snark = { path = "../snark" }
-rand = "0.8"
 
-# [features]
-# service_impl_webrtc_rs = ["webrtc"]
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { version = "1.26", features = ["rt"] }
+webrtc = { git = "https://github.com/openmina/webrtc.git", branch = "openmina-dd340dd" }
+hyper = { version = "0.14.25", features = ["client", "http1", "tcp"] }
+libp2p = { git = "https://github.com/openmina/rust-libp2p", branch="webrtc-v0.51.3", default-features = false, features = ["macros", "serde", "tcp", "dns", "tokio", "yamux", "pnet", "noise", "gossipsub"] }
+libp2p-rpc-behaviour = { path = "libp2p-rpc-behaviour" }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4.37"
+gloo-utils = "0.2"
+js-sys = "0.3.64"
+web-sys = { version = "0.3", features = ["RtcPeerConnection", "RtcConfiguration", "RtcIceTransportPolicy", "RtcDataChannel", "RtcDataChannelInit", "RtcSessionDescription", "RtcSessionDescriptionInit", "RtcSdpType", "RtcPeerConnectionState", "RtcIceGatheringState", "Window", "Request", "RequestInit", "Headers", "Response"] }
+tokio = { version = "1.26", features = ["macros"] }

--- a/p2p/src/connection/outgoing/p2p_connection_outgoing_effects.rs
+++ b/p2p/src/connection/outgoing/p2p_connection_outgoing_effects.rs
@@ -120,6 +120,7 @@ impl P2pConnectionOutgoingOfferReadyAction {
         };
         let signaling_method = match opts {
             P2pConnectionOutgoingInitOpts::WebRTC { signaling, .. } => signaling,
+            #[allow(unreachable_patterns)]
             _ => return,
         };
         match signaling_method {

--- a/p2p/src/identity/peer_id.rs
+++ b/p2p/src/identity/peer_id.rs
@@ -36,6 +36,10 @@ impl PeerId {
     pub fn from_public_key(key: PublicKey) -> Self {
         Self::from_bytes(key.to_bytes())
     }
+
+    pub fn to_public_key(self) -> Result<PublicKey, ed25519_dalek::SignatureError> {
+        PublicKey::from_bytes(self.to_bytes())
+    }
 }
 
 impl fmt::Display for PeerId {
@@ -75,6 +79,7 @@ impl From<PeerId> for [u8; 32] {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl From<libp2p::PeerId> for PeerId {
     fn from(value: libp2p::PeerId) -> Self {
         let protobuf = value.as_ref().digest();
@@ -84,6 +89,7 @@ impl From<libp2p::PeerId> for PeerId {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl From<PeerId> for libp2p::PeerId {
     fn from(value: PeerId) -> Self {
         let key = libp2p::identity::ed25519::PublicKey::decode(&value.to_bytes()).unwrap();

--- a/p2p/src/service_impl/libp2p/behavior.rs
+++ b/p2p/src/service_impl/libp2p/behavior.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use libp2p::{gossipsub, swarm::NetworkBehaviour, PeerId};
-use tokio::sync::mpsc;
+use openmina_core::channels::mpsc;
 
 use crate::P2pEvent;
 

--- a/p2p/src/service_impl/libp2p/mod.rs
+++ b/p2p/src/service_impl/libp2p/mod.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 use mina_p2p_messages::binprot::{self, BinProtRead, BinProtWrite};
 use mina_p2p_messages::v2::NetworkPoolSnarkPoolDiffVersionedStableV2;
 use multihash::{Blake2b256, Hasher};
+use openmina_core::channels::mpsc;
 use openmina_core::snark::Snark;
-use tokio::sync::mpsc;
 
 use libp2p::core::muxing::StreamMuxerBox;
 use libp2p::core::transport;

--- a/p2p/src/service_impl/mod.rs
+++ b/p2p/src/service_impl/mod.rs
@@ -1,7 +1,8 @@
-// #[cfg(feature = "service_impl_webrtc_rs")]
+#[cfg(not(target_arch = "wasm32"))]
 pub mod libp2p;
-pub mod webrtc_rs;
-pub mod webrtc_rs_with_libp2p;
+pub mod webrtc;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod webrtc_with_libp2p;
 
 use std::future::Future;
 

--- a/p2p/src/service_impl/webrtc/native.rs
+++ b/p2p/src/service_impl/webrtc/native.rs
@@ -1,0 +1,226 @@
+use std::future::Future;
+use std::sync::Arc;
+
+use webrtc::{
+    api::APIBuilder,
+    data_channel::{data_channel_init::RTCDataChannelInit, RTCDataChannel},
+    ice_transport::{
+        ice_credential_type::RTCIceCredentialType, ice_gatherer_state::RTCIceGathererState,
+        ice_gathering_state::RTCIceGatheringState, ice_server::RTCIceServer,
+    },
+    peer_connection::{
+        configuration::RTCConfiguration, peer_connection_state::RTCPeerConnectionState,
+        policy::ice_transport_policy::RTCIceTransportPolicy,
+        sdp::session_description::RTCSessionDescription, RTCPeerConnection,
+    },
+};
+
+use crate::{
+    connection::P2pConnectionResponse,
+    webrtc::{Answer, Offer},
+};
+
+use super::{OnConnectionStateChangeHdlrFn, RTCChannelConfig, RTCConfig};
+
+pub type Result<T> = std::result::Result<T, webrtc::Error>;
+
+pub type RTCConnectionState = RTCPeerConnectionState;
+
+pub struct RTCConnection(Arc<RTCPeerConnection>, bool);
+
+pub struct RTCChannel(Arc<RTCDataChannel>, bool);
+
+#[derive(thiserror::Error, derive_more::From, Debug)]
+pub enum RTCSignalingError {
+    #[error("serialization failed: {0}")]
+    SerializeError(serde_json::Error),
+    #[error("http request failed: {0}")]
+    HyperError(hyper::Error),
+    #[error("http request failed: {0}")]
+    HttpError(hyper::http::Error),
+}
+
+impl RTCConnection {
+    pub async fn create(config: RTCConfig) -> Result<Self> {
+        let webrtc = APIBuilder::new().build();
+        webrtc
+            .new_peer_connection(config.into())
+            .await
+            .map(|v| Self(v.into(), true))
+    }
+
+    pub fn is_main(&self) -> bool {
+        self.1
+    }
+
+    pub async fn channel_create(&self, config: RTCChannelConfig) -> Result<RTCChannel> {
+        self.0
+            .create_data_channel(
+                &config.label,
+                Some(RTCDataChannelInit {
+                    ordered: Some(true),
+                    max_packet_life_time: None,
+                    max_retransmits: None,
+                    negotiated: config.negotiated,
+                    ..Default::default()
+                }),
+            )
+            .await
+            .map(|chan| RTCChannel(chan, true))
+    }
+
+    pub async fn offer_create(&self) -> Result<RTCSessionDescription> {
+        self.0.create_offer(None).await
+    }
+
+    pub async fn answer_create(&self) -> Result<RTCSessionDescription> {
+        self.0.create_answer(None).await
+    }
+
+    pub async fn local_desc_set(&self, desc: RTCSessionDescription) -> Result<()> {
+        self.0.set_local_description(desc).await
+    }
+
+    pub async fn remote_desc_set(&self, desc: RTCSessionDescription) -> Result<()> {
+        self.0.set_remote_description(desc).await
+    }
+
+    pub async fn local_sdp(&self) -> Option<String> {
+        self.0.local_description().await.map(|v| v.sdp)
+    }
+
+    pub fn connection_state(&self) -> RTCConnectionState {
+        self.0.connection_state()
+    }
+
+    pub async fn wait_for_ice_gathering_complete(&self) {
+        if !matches!(self.0.ice_gathering_state(), RTCIceGatheringState::Complete) {
+            let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+            let mut tx = Some(tx);
+            self.0.on_ice_gathering_state_change(Box::new(move |state| {
+                if matches!(state, RTCIceGathererState::Complete) {
+                    if let Some(tx) = tx.take() {
+                        let _ = tx.send(());
+                    }
+                }
+                Box::pin(std::future::ready(()))
+            }));
+            let _ = rx.await;
+        }
+    }
+
+    pub fn on_connection_state_change(&self, handler: OnConnectionStateChangeHdlrFn) {
+        self.0.on_peer_connection_state_change(handler)
+    }
+
+    pub async fn close(self) {
+        let _ = self.0.close().await;
+    }
+}
+
+impl RTCChannel {
+    pub fn is_main(&self) -> bool {
+        self.1
+    }
+
+    pub fn on_open<Fut>(&self, f: impl FnOnce() -> Fut + Send + Sync + 'static)
+    where
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        self.0.on_open(Box::new(move || Box::pin(f())))
+    }
+
+    pub fn on_message<Fut>(&self, mut f: impl FnMut(&[u8]) -> Fut + Send + Sync + 'static)
+    where
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        self.0
+            .on_message(Box::new(move |msg| Box::pin(f(msg.data.as_ref()))));
+    }
+
+    pub fn on_error<Fut>(&self, mut f: impl FnMut(webrtc::Error) -> Fut + Send + Sync + 'static)
+    where
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        self.0.on_error(Box::new(move |err| Box::pin(f(err))))
+    }
+
+    pub fn on_close<Fut>(&self, mut f: impl FnMut() -> Fut + Send + Sync + 'static)
+    where
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        self.0.on_close(Box::new(move || Box::pin(f())))
+    }
+
+    pub async fn send(&self, data: &bytes::Bytes) -> Result<usize> {
+        self.0.send(data).await
+    }
+
+    pub async fn close(&self) {
+        let _ = self.0.close().await;
+    }
+}
+
+pub async fn webrtc_signal_send(
+    url: &str,
+    offer: Offer,
+) -> std::result::Result<P2pConnectionResponse, RTCSignalingError> {
+    let client = hyper::Client::new();
+    let req = hyper::Request::post(url).body(serde_json::to_string(&offer)?.into())?;
+    let body = client.request(req).await?.into_body();
+    let bytes = hyper::body::to_bytes(body).await?;
+    Ok(serde_json::from_slice(bytes.as_ref())?)
+}
+
+impl Clone for RTCConnection {
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), false)
+    }
+}
+
+impl Clone for RTCChannel {
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), false)
+    }
+}
+
+impl From<RTCConfig> for RTCConfiguration {
+    fn from(value: RTCConfig) -> Self {
+        RTCConfiguration {
+            ice_servers: value.ice_servers.0.into_iter().map(Into::into).collect(),
+            ice_transport_policy: RTCIceTransportPolicy::All,
+            ..Default::default()
+        }
+    }
+}
+
+impl From<super::RTCConfigIceServer> for RTCIceServer {
+    fn from(value: super::RTCConfigIceServer) -> Self {
+        let credential_type = match value.credential.is_some() {
+            false => RTCIceCredentialType::Unspecified,
+            true => RTCIceCredentialType::Password,
+        };
+        RTCIceServer {
+            urls: value.urls,
+            username: value.username.unwrap_or(String::new()),
+            credential: value.credential.unwrap_or(String::new()),
+            credential_type,
+        }
+    }
+}
+
+impl TryFrom<Offer> for RTCSessionDescription {
+    type Error = webrtc::Error;
+
+    fn try_from(value: Offer) -> Result<Self> {
+        Self::offer(value.sdp)
+    }
+}
+
+impl TryFrom<Answer> for RTCSessionDescription {
+    type Error = webrtc::Error;
+
+    fn try_from(value: Answer) -> Result<Self> {
+        Self::answer(value.sdp)
+    }
+}

--- a/p2p/src/service_impl/webrtc/web.rs
+++ b/p2p/src/service_impl/webrtc/web.rs
@@ -1,0 +1,301 @@
+use std::future::Future;
+
+use gloo_utils::format::JsValueSerdeExt;
+use wasm_bindgen::{convert::FromWasmAbi, prelude::*};
+use wasm_bindgen_futures::{spawn_local, JsFuture};
+use web_sys::{
+    MessageEvent, RtcConfiguration, RtcDataChannel, RtcDataChannelInit, RtcIceGatheringState,
+    RtcIceTransportPolicy, RtcPeerConnection, RtcPeerConnectionState, RtcSdpType,
+    RtcSessionDescriptionInit,
+};
+
+use openmina_core::channels::oneshot;
+
+use crate::{
+    connection::P2pConnectionResponse,
+    webrtc::{Answer, Offer},
+};
+
+use super::{OnConnectionStateChangeHdlrFn, RTCChannelConfig, RTCConfig};
+
+pub type Result<T> = std::result::Result<T, JsValue>;
+
+pub type RTCConnectionState = RtcPeerConnectionState;
+
+pub struct RTCConnection(RtcPeerConnection, bool);
+
+pub struct RTCChannel(RtcDataChannel, bool);
+
+#[derive(thiserror::Error, derive_more::From, Debug)]
+pub enum RTCSignalingError {
+    #[error("serialization failed: {0}")]
+    SerializeError(serde_json::Error),
+    #[error("http request failed: {0}")]
+    HttpError(String),
+}
+
+impl From<JsValue> for RTCSignalingError {
+    fn from(value: JsValue) -> Self {
+        Self::HttpError(format!("{value:?}"))
+    }
+}
+
+impl RTCConnection {
+    pub async fn create(config: RTCConfig) -> Result<Self> {
+        RtcPeerConnection::new_with_configuration(&config.into()).map(|v| Self(v, true))
+    }
+
+    pub fn is_main(&self) -> bool {
+        self.1
+    }
+
+    pub async fn channel_create(&self, config: RTCChannelConfig) -> Result<RTCChannel> {
+        let chan = self
+            .0
+            .create_data_channel_with_data_channel_dict(&config.label, &(&config).into());
+        Ok(RTCChannel(chan, true))
+    }
+
+    pub async fn offer_create(&self) -> Result<RtcSessionDescriptionInit> {
+        Ok(JsFuture::from(self.0.create_offer()).await?.into())
+    }
+
+    pub async fn answer_create(&self) -> Result<RtcSessionDescriptionInit> {
+        Ok(JsFuture::from(self.0.create_answer()).await?.into())
+    }
+
+    pub async fn local_desc_set(&self, desc: RtcSessionDescriptionInit) -> Result<()> {
+        JsFuture::from(self.0.set_local_description(&desc)).await?;
+        Ok(())
+    }
+
+    pub async fn remote_desc_set(&self, desc: RtcSessionDescriptionInit) -> Result<()> {
+        JsFuture::from(self.0.set_remote_description(&desc)).await?;
+        Ok(())
+    }
+
+    pub async fn local_sdp(&self) -> Option<String> {
+        self.0.local_description().map(|v| v.sdp())
+    }
+
+    // pub async fn remote_sdp(&self) -> Option<String> {
+    //     self.0.remote_description().map(|v| v.sdp())
+    // }
+
+    pub fn connection_state(&self) -> RTCConnectionState {
+        self.0.connection_state()
+    }
+
+    pub async fn wait_for_ice_gathering_complete(&self) {
+        if !matches!(self.0.ice_gathering_state(), RtcIceGatheringState::Complete) {
+            let (tx, rx) = oneshot::channel::<()>();
+            let mut tx = Some(tx);
+            let conn = self.0.clone();
+            let callback = Closure::<dyn FnMut()>::new(move || {
+                if matches!(conn.ice_gathering_state(), RtcIceGatheringState::Complete) {
+                    if let Some(tx) = tx.take() {
+                        let _ = tx.send(());
+                    }
+                }
+            });
+            self.0
+                .set_onicegatheringstatechange(Some(callback.as_ref().unchecked_ref()));
+            callback.forget();
+            let _ = rx.await;
+        }
+    }
+
+    pub fn on_connection_state_change(&self, mut f: OnConnectionStateChangeHdlrFn) {
+        // Closure::wrap(data)
+        let callback = Closure::new(move |state: RTCConnectionState| {
+            spawn_local(f(state));
+        });
+        self.0
+            .set_onconnectionstatechange(Some(callback.as_ref().unchecked_ref()));
+        callback.forget();
+    }
+
+    pub async fn close(&self) {
+        self.0.close();
+    }
+}
+
+impl RTCChannel {
+    pub fn is_main(&self) -> bool {
+        self.1
+    }
+
+    pub fn on_open<Fut>(&self, mut f: impl FnMut() -> Fut + 'static)
+    where
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        leaking_channel_event_handler(
+            |f| self.0.set_onopen(f),
+            move |_: JsValue| {
+                spawn_local(f());
+            },
+        );
+        // let callback = Closure::new::<dyn FnMut(_)>(move || {
+        //     spawn_local(f());
+        // });
+        // self.0
+        //     .set_onopen(Some(callback.as_ref().unchecked_ref()));
+        // callback.forget();
+    }
+
+    pub fn on_message<Fut>(&self, mut f: impl FnMut(Vec<u8>) -> Fut + 'static)
+    where
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        leaking_channel_event_handler(
+            |f| self.0.set_onopen(f),
+            move |event: MessageEvent| {
+                if let Ok(arraybuf) = event.data().dyn_into::<js_sys::ArrayBuffer>() {
+                    let uarray = js_sys::Uint8Array::new(&arraybuf);
+                    let data = uarray.to_vec();
+                    spawn_local(f(data));
+                }
+            },
+        );
+    }
+
+    pub fn on_error<Fut>(&self, mut f: impl FnMut(JsValue) -> Fut + 'static)
+    where
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        //     pub fn on_error<Fut, Err>(&self, mut f: impl FnMut(Err) -> Fut + 'static)
+        // where
+        //     Fut: Future<Output = ()> + Send + 'static,
+        //     Err: From<JsValue>,
+        // {
+        leaking_channel_event_handler(
+            |f| self.0.set_onerror(f),
+            move |err: JsValue| {
+                spawn_local(f(err));
+            },
+        );
+        // let callback = Closure::new::<dyn FnMut(_)>(move || {
+        //     spawn_local(f());
+        // });
+        // self.0
+        //     .set_onopen(Some(callback.as_ref().unchecked_ref()));
+        // callback.forget();
+
+        // self.0.on_error(Box::new(move |err| Box::pin(f(err))))
+    }
+
+    pub fn on_close<Fut>(&self, mut f: impl FnMut() -> Fut + 'static)
+    where
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        leaking_channel_event_handler(
+            |f| self.0.set_onclose(f),
+            move |_: JsValue| {
+                spawn_local(f());
+            },
+        );
+    }
+
+    pub async fn send(&self, data: &bytes::Bytes) -> Result<usize> {
+        let len = data.len();
+        self.0.send_with_u8_array(data).map(|_| len)
+    }
+
+    pub async fn close(&self) {
+        let _ = self.0.close();
+    }
+}
+
+pub async fn webrtc_signal_send(
+    url: &str,
+    offer: Offer,
+) -> std::result::Result<P2pConnectionResponse, RTCSignalingError> {
+    use web_sys::{Request, RequestInit, Response};
+
+    let mut opts = RequestInit::new();
+    opts.method("POST");
+    opts.body(Some(&JsValue::from_serde(&offer)?));
+    let request = Request::new_with_str_and_init(url, &opts)?;
+
+    request.headers().set("content-type", "application/json")?;
+
+    let window = web_sys::window().unwrap();
+    let resp_value = JsFuture::from(window.fetch_with_request(&request)).await?;
+
+    assert!(resp_value.is_instance_of::<Response>());
+    let resp: Response = resp_value.dyn_into().unwrap();
+    let json = JsFuture::from(resp.json()?).await?;
+
+    Ok(json.into_serde()?)
+}
+
+impl Clone for RTCConnection {
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), false)
+    }
+}
+
+impl Clone for RTCChannel {
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), false)
+    }
+}
+
+impl From<RTCConfig> for RtcConfiguration {
+    fn from(value: RTCConfig) -> Self {
+        let mut config = Self::new();
+        config
+            .ice_servers(&JsValue::from_serde(&value.ice_servers).unwrap())
+            .ice_transport_policy(RtcIceTransportPolicy::All);
+        config
+    }
+}
+
+impl From<&RTCChannelConfig> for RtcDataChannelInit {
+    fn from(value: &RTCChannelConfig) -> Self {
+        let mut config = Self::new();
+
+        if let Some(negotiated) = value.negotiated {
+            config.negotiated(true).id(negotiated);
+        }
+
+        config
+    }
+}
+
+impl TryFrom<Offer> for RtcSessionDescriptionInit {
+    type Error = JsValue;
+
+    fn try_from(value: Offer) -> Result<Self> {
+        let mut sdp = RtcSessionDescriptionInit::new(RtcSdpType::Offer);
+        sdp.sdp(&value.sdp);
+        Ok(sdp)
+    }
+}
+
+impl TryFrom<Answer> for RtcSessionDescriptionInit {
+    type Error = JsValue;
+
+    fn try_from(value: Answer) -> Result<Self> {
+        let mut sdp = RtcSessionDescriptionInit::new(RtcSdpType::Answer);
+        sdp.sdp(&value.sdp);
+        Ok(sdp)
+    }
+}
+
+/// Copied from https://github.com/johanhelsing/matchbox/blob/main/matchbox_socket/src/webrtc_socket/wasm.rs
+///
+/// Note that this function leaks some memory because the rust closure is dropped but still needs to
+/// be accessed by javascript of the browser
+///
+/// See also: https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/closure/struct.Closure.html#method.into_js_value
+fn leaking_channel_event_handler<T: FromWasmAbi + 'static>(
+    mut setter: impl FnMut(Option<&js_sys::Function>),
+    handler: impl FnMut(T) + 'static,
+) {
+    let closure: Closure<dyn FnMut(T)> = Closure::wrap(Box::new(handler));
+
+    setter(Some(closure.as_ref().unchecked_ref()));
+
+    closure.forget();
+}

--- a/p2p/src/service_impl/webrtc_with_libp2p.rs
+++ b/p2p/src/service_impl/webrtc_with_libp2p.rs
@@ -1,6 +1,6 @@
 use libp2p::swarm::dial_opts::DialOpts;
+use openmina_core::channels::mpsc;
 use openmina_core::snark::Snark;
-use tokio::sync::mpsc;
 
 use crate::{
     channels::{ChannelId, ChannelMsg, MsgId, P2pChannelsService},
@@ -10,14 +10,14 @@ use crate::{
     P2pChannelEvent, P2pEvent, PeerId,
 };
 
-use super::{libp2p::Libp2pService, webrtc_rs::P2pServiceWebrtcRs, TaskSpawner};
+use super::{libp2p::Libp2pService, webrtc::P2pServiceWebrtc, TaskSpawner};
 
 pub struct P2pServiceCtx {
-    pub webrtc: super::webrtc_rs::P2pServiceCtx,
+    pub webrtc: super::webrtc::P2pServiceCtx,
     pub libp2p: Libp2pService,
 }
 
-pub trait P2pServiceWebrtcRsWithLibp2p: P2pServiceWebrtcRs {
+pub trait P2pServiceWebrtcWithLibp2p: P2pServiceWebrtc {
     fn libp2p(&mut self) -> &mut Libp2pService;
 
     fn init<S: TaskSpawner>(
@@ -27,24 +27,24 @@ pub trait P2pServiceWebrtcRsWithLibp2p: P2pServiceWebrtcRs {
         spawner: S,
     ) -> P2pServiceCtx {
         P2pServiceCtx {
-            webrtc: <Self as P2pServiceWebrtcRs>::init(secret_key.clone(), spawner.clone()),
+            webrtc: <Self as P2pServiceWebrtc>::init(secret_key.clone(), spawner.clone()),
             libp2p: Libp2pService::run(secret_key, chain_id, event_source_sender, spawner),
         }
     }
 }
 
-impl<T: P2pServiceWebrtcRsWithLibp2p> P2pConnectionService for T {
+impl<T: P2pServiceWebrtcWithLibp2p> P2pConnectionService for T {
     fn random_pick(
         &mut self,
         list: &[P2pConnectionOutgoingInitOpts],
     ) -> P2pConnectionOutgoingInitOpts {
-        P2pServiceWebrtcRs::random_pick(self, list)
+        P2pServiceWebrtc::random_pick(self, list)
     }
 
     fn outgoing_init(&mut self, opts: P2pConnectionOutgoingInitOpts) {
         match opts {
             P2pConnectionOutgoingInitOpts::WebRTC { peer_id, .. } => {
-                P2pServiceWebrtcRs::outgoing_init(self, peer_id);
+                P2pServiceWebrtc::outgoing_init(self, peer_id);
             }
             P2pConnectionOutgoingInitOpts::LibP2P { peer_id, maddr } => {
                 let opts = DialOpts::peer_id(peer_id.into())
@@ -57,19 +57,19 @@ impl<T: P2pServiceWebrtcRsWithLibp2p> P2pConnectionService for T {
     }
 
     fn incoming_init(&mut self, peer_id: PeerId, offer: crate::webrtc::Offer) {
-        P2pServiceWebrtcRs::incoming_init(self, peer_id, offer)
+        P2pServiceWebrtc::incoming_init(self, peer_id, offer)
     }
 
     fn set_answer(&mut self, peer_id: PeerId, answer: crate::webrtc::Answer) {
-        P2pServiceWebrtcRs::set_answer(self, peer_id, answer)
+        P2pServiceWebrtc::set_answer(self, peer_id, answer)
     }
 
     fn http_signaling_request(&mut self, url: String, offer: crate::webrtc::Offer) {
-        P2pServiceWebrtcRs::http_signaling_request(self, url, offer)
+        P2pServiceWebrtc::http_signaling_request(self, url, offer)
     }
 }
 
-impl<T: P2pServiceWebrtcRsWithLibp2p> P2pDisconnectionService for T {
+impl<T: P2pServiceWebrtcWithLibp2p> P2pDisconnectionService for T {
     fn disconnect(&mut self, peer_id: PeerId) {
         // By removing the peer, `cmd_sender` gets dropped which will
         // cause `peer_loop` to end.
@@ -84,10 +84,10 @@ impl<T: P2pServiceWebrtcRsWithLibp2p> P2pDisconnectionService for T {
     }
 }
 
-impl<T: P2pServiceWebrtcRsWithLibp2p> P2pChannelsService for T {
+impl<T: P2pServiceWebrtcWithLibp2p> P2pChannelsService for T {
     fn channel_open(&mut self, peer_id: PeerId, id: ChannelId) {
         if self.peers().contains_key(&peer_id) {
-            P2pServiceWebrtcRs::channel_open(self, peer_id, id)
+            P2pServiceWebrtc::channel_open(self, peer_id, id)
         } else {
             let result = match id.supported_by_libp2p() {
                 false => Err("channel not supported".to_owned()),
@@ -103,7 +103,7 @@ impl<T: P2pServiceWebrtcRsWithLibp2p> P2pChannelsService for T {
 
     fn channel_send(&mut self, peer_id: PeerId, msg_id: MsgId, msg: ChannelMsg) {
         if self.peers().contains_key(&peer_id) {
-            P2pServiceWebrtcRs::channel_send(self, peer_id, msg_id, msg)
+            P2pServiceWebrtc::channel_send(self, peer_id, msg_id, msg)
         } else {
             use super::libp2p::Cmd;
             let _ = self


### PR DESCRIPTION
Extract common api and use `web-sys` crate for WebRTC backend in WASM target.