### PR TITLE
Add rate limiter for rpc calls in p2p layer

### DIFF
--- a/cli/src/commands/node/mod.rs
+++ b/cli/src/commands/node/mod.rs
@@ -84,6 +84,9 @@ pub struct Node {
 
     #[arg(long, default_value = "none")]
     pub additional_ledgers_path: Option<PathBuf>,
+
+    #[arg(long, default_value = "10")]
+    pub requests_per_duration: u64,
 }
 
 fn default_peers() -> Vec<P2pConnectionOutgoingInitOpts> {
@@ -178,6 +181,7 @@ impl Node {
             Some(self.libp2p_port),
             secret_key,
             CHAIN_ID.to_owned(),
+            self.requests_per_duration,
             p2p_event_sender.clone(),
             P2pTaskSpawner {},
         );

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,6 +1,9 @@
+#![feature(test)]
+extern crate test;
+
 pub mod block;
 pub mod log;
 pub mod requests;
 pub mod snark;
-
+pub mod rate_limiter;
 pub mod channels;

--- a/core/src/rate_limiter/mod.rs
+++ b/core/src/rate_limiter/mod.rs
@@ -1,0 +1,77 @@
+use std::time::{Duration, Instant};
+
+pub struct RateLimiter {
+    requests_per_duration: u64,
+    instant: Instant,
+    requests: u64,
+}
+
+impl RateLimiter {
+    /// TODO: Maybe move this to value inside struct so it can be changed, while running
+    const DURATION: Duration = Duration::from_secs(1);
+
+    pub fn new(requests_per_duration: u64) -> RateLimiter {
+        RateLimiter {
+            requests_per_duration,
+            instant: Instant::now(),
+            requests: 0,
+        }
+    }
+
+    pub fn check(&mut self) -> bool {
+        let can_run = self.check_requests() || self.check_time();
+        if can_run {
+            self.requests += 1;
+        }
+
+        can_run
+    }
+
+    fn check_requests(&mut self) -> bool {
+        self.requests < self.requests_per_duration
+    }
+
+    fn check_time(&mut self) -> bool {
+        let now = Instant::now();
+        let bench = now - Self::DURATION;
+        let reclaimed = self.instant < bench;
+
+        if reclaimed {
+            self.instant = now;
+            self.requests = 0;
+        }
+
+        reclaimed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use test::Bencher;
+
+    use super::RateLimiter;
+
+    #[bench]
+    /// Benchmark the rate limiter to see how long does it take to execute
+    /// result is about 14ns per iter
+    fn bench_rate_limiter(bencher: &mut Bencher) {
+        let mut rate_limiter = RateLimiter::new(10);
+
+        bencher.iter(|| rate_limiter.check());
+    }
+
+    #[test]
+    /// Check the rate limit and that it works correctly
+    fn test_rate_limiter() {
+        let rate_limit = 10;
+        let mut rate_limiter = RateLimiter::new(rate_limit);
+
+        for _ in 0..rate_limit {
+            assert!(rate_limiter.check());
+        }
+
+        for _ in 0..10 {
+            assert!(!rate_limiter.check());
+        }
+    }
+}

--- a/node/testing/Cargo.toml
+++ b/node/testing/Cargo.toml
@@ -42,3 +42,7 @@ openmina-node-native = { path = "../../node/native" }
 [features]
 scenario-generators = ["documented"]
 p2p-webrtc = ["openmina-node-native/p2p-webrtc"]
+
+[[test]]
+name = "node_libp2p_only"
+required-features = ["scenario-generators"]

--- a/node/testing/src/cluster/mod.rs
+++ b/node/testing/src/cluster/mod.rs
@@ -165,6 +165,7 @@ impl Cluster {
             Some(libp2p_port),
             secret_key,
             testing_config.chain_id,
+            testing_config.requests_per_duration,
             p2p_event_sender.clone(),
             P2pTaskSpawner::new(shutdown_tx.clone()),
         );

--- a/node/testing/src/node/config.rs
+++ b/node/testing/src/node/config.rs
@@ -14,6 +14,7 @@ pub struct RustNodeTestingConfig {
     pub initial_time: redux::Timestamp,
     pub max_peers: usize,
     pub ask_initial_peers_interval: Duration,
+    pub requests_per_duration: u64
 }
 
 impl RustNodeTestingConfig {
@@ -23,6 +24,7 @@ impl RustNodeTestingConfig {
             initial_time: redux::Timestamp::ZERO,
             max_peers: 100,
             ask_initial_peers_interval: Duration::from_secs(10),
+            requests_per_duration: 10
         }
     }
 

--- a/p2p/libp2p-rpc-behaviour/src/handler.rs
+++ b/p2p/libp2p-rpc-behaviour/src/handler.rs
@@ -13,6 +13,15 @@ use libp2p::{
         SubstreamProtocol,
     },
 };
+use mina_p2p_messages::{
+    rpc::{
+        AnswerSyncLedgerQueryV1, BanNotifyV1, GetAncestryV1, GetBestTipV1, GetEpochLedgerV1,
+        GetNodeStatusV1, GetSomeInitialPeersV1, GetStagedLedgerAuxAndPendingCoinbasesAtHashV1,
+        GetTransitionChainProofV1, GetTransitionChainV1, GetTransitionKnowledgeV1,
+        VersionedRpcMenuV1,
+    },
+    rpc_kernel::RpcMethod,
+};
 
 use super::{
     behaviour::{Event, StreamId},
@@ -38,6 +47,22 @@ pub struct Handler {
 
 impl Handler {
     const PROTOCOL_NAME: [u8; 15] = *b"coda/rpcs/0.0.1";
+
+    /// These are functions `coda/rpcs/0.0.1` here are selected v1 but v2 have same name
+    pub const PROTOCOL_FUNCTIONS: [&'static str; 12] = [
+        GetSomeInitialPeersV1::NAME,
+        GetStagedLedgerAuxAndPendingCoinbasesAtHashV1::NAME,
+        AnswerSyncLedgerQueryV1::NAME,
+        GetAncestryV1::NAME,
+        GetBestTipV1::NAME,
+        GetNodeStatusV1::NAME,
+        GetTransitionChainProofV1::NAME,
+        GetTransitionChainV1::NAME,
+        GetTransitionKnowledgeV1::NAME,
+        GetEpochLedgerV1::NAME,
+        VersionedRpcMenuV1::NAME,
+        BanNotifyV1::NAME,
+    ];
 
     pub fn new(menu: Arc<BTreeSet<(&'static str, i32)>>) -> Self {
         Handler {

--- a/p2p/libp2p-rpc-behaviour/src/lib.rs
+++ b/p2p/libp2p-rpc-behaviour/src/lib.rs
@@ -2,6 +2,7 @@ mod behaviour;
 pub use self::behaviour::{Behaviour, BehaviourBuilder, Event, StreamId};
 
 mod handler;
+pub use handler::Handler;
 
 mod stream;
 

--- a/p2p/src/service_impl/webrtc_with_libp2p.rs
+++ b/p2p/src/service_impl/webrtc_with_libp2p.rs
@@ -24,6 +24,7 @@ pub trait P2pServiceWebrtcWithLibp2p: P2pServiceWebrtc {
         libp2p_port: Option<u16>,
         secret_key: SecretKey,
         chain_id: String,
+        requests_per_duration: u64,
         event_source_sender: mpsc::UnboundedSender<P2pEvent>,
         spawner: S,
     ) -> P2pServiceCtx {
@@ -33,6 +34,7 @@ pub trait P2pServiceWebrtcWithLibp2p: P2pServiceWebrtc {
                 libp2p_port,
                 secret_key,
                 chain_id,
+                requests_per_duration,
                 event_source_sender,
                 spawner,
             ),


### PR DESCRIPTION
Added rate limiter for rpc calls for `coda/rpcs/0.0.1` in p2p layer, to prevent spamming. This rate can be changed by passing `--requests-per-duration` with desired number of allowed requests per second, when running `openmina node`. 

There is benchmark for rate limiter to see how much it takes to check if request can be processed. Benchmark can be ran with:
```sh
cargo bench -p openmina-core -- bench_rate_limiter
```
Output(results will vary):
```sh
   Compiling mina-tree v0.1.0 (/home/mimir/0xMimir/openmina/ledger)
   Compiling openmina-core v0.1.0 (/home/mimir/0xMimir/openmina/core)
    Finished bench [optimized] target(s) in 11.07s
     Running unittests src/lib.rs (target/release/deps/openmina_core-d34b31a3c94dc818)

running 1 test
test rate_limiter::tests::bench_rate_limiter ... bench:          14 ns/iter (+/- 0)

test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured; 2 filtered out; finished in 0.29s
```

And test for correctness of rate limiter can be ran with:
```sh
 cargo test -p openmina-core -- test_rate_limiter
```