### PR TITLE
Add docker compose for demo

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,7 @@
 target/
 Dockerfile
+Dockerfile_FE
+docker-compose.yml
 .dockerignore
 cli/bin
 cli/tests

--- a/Dockerfile_FE
+++ b/Dockerfile_FE
@@ -9,10 +9,11 @@
 #COPY --from=BUILD_IMAGE /app/nginx.conf /etc/nginx/nginx.conf
 
 FROM node:18 AS BUILD_IMAGE
+ARG BUILD_CONFIGURATION=production
 WORKDIR /app
 COPY frontend/ .
 RUN npm install
-RUN node_modules/.bin/ng build --configuration production
+RUN node_modules/.bin/ng build --configuration ${BUILD_CONFIGURATION}
 RUN npm prune --production
 FROM nginx:alpine
 RUN pwd

--- a/README.md
+++ b/README.md
@@ -36,7 +36,17 @@ In the future, we plan to implement:
 * The ability to record/replay all blocks
 
 
-## How to launch:
+## How to launch (with docker compose):
+
+Run:
+
+```
+docker compose up
+```
+
+Then visit http://localhost:8070 in your browser.
+
+## How to launch (without docker compose):
 
 This installation guide has been tested on Debian and Ubuntu and should work on most distributions of Linux.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3.8'
+
+services:
+  openmina_node:
+    build:
+      context: ./
+      dockerfile: Dockerfile
+    command: [ "node" ]
+    ports:
+      - "3000:3000"
+    environment:
+      - MINA_SNARK_WORKER_TAG=0.0.9
+    networks:
+      - app-network
+
+  frontend:
+    build:
+      context: ./
+      dockerfile: Dockerfile_FE
+      args:
+        BUILD_CONFIGURATION: local
+    ports:
+      - "8070:80"
+    networks:
+      - app-network
+
+networks:
+  app-network:
+    driver: bridge


### PR DESCRIPTION
Just a very quick way to launch both the node and the frontend.

Note:
- should instead use a v0.1 tagged version instead of building?
- ~I am trying to have the dockerfile build the frontend with the local environment but somehow it is still showing me the production version, any idea @directcuteo ?~ (fixed, was probably some cache)