### PR TITLE
Refactor: Inline action group definitions into the parent enum type 

### DIFF
--- a/node/src/action_kind.rs
+++ b/node/src/action_kind.rs
@@ -29,53 +29,16 @@ use crate::block_producer::{
     BlockProducerWonSlotDiscardAction, BlockProducerWonSlotProduceInitAction,
     BlockProducerWonSlotSearchAction, BlockProducerWonSlotWaitAction,
 };
-use crate::consensus::{
-    ConsensusAction, ConsensusBestTipUpdateAction, ConsensusBlockChainProofUpdateAction,
-    ConsensusBlockReceivedAction, ConsensusBlockSnarkVerifyPendingAction,
-    ConsensusBlockSnarkVerifySuccessAction, ConsensusDetectForkRangeAction,
-    ConsensusLongRangeForkResolveAction, ConsensusPruneAction,
-    ConsensusShortRangeForkResolveAction,
-};
+use crate::consensus::ConsensusAction;
 use crate::event_source::{
     EventSourceAction, EventSourceNewEventAction, EventSourceProcessEventsAction,
     EventSourceWaitForEventsAction, EventSourceWaitTimeoutAction,
 };
-use crate::external_snark_worker::{
-    ExternalSnarkWorkerAction, ExternalSnarkWorkerCancelWorkAction, ExternalSnarkWorkerErrorAction,
-    ExternalSnarkWorkerKillAction, ExternalSnarkWorkerKilledAction,
-    ExternalSnarkWorkerPruneWorkAction, ExternalSnarkWorkerStartAction,
-    ExternalSnarkWorkerStartTimeoutAction, ExternalSnarkWorkerStartedAction,
-    ExternalSnarkWorkerSubmitWorkAction, ExternalSnarkWorkerWorkCancelledAction,
-    ExternalSnarkWorkerWorkErrorAction, ExternalSnarkWorkerWorkResultAction,
-    ExternalSnarkWorkerWorkTimeoutAction,
-};
-use crate::p2p::channels::best_tip::{
-    P2pChannelsBestTipAction, P2pChannelsBestTipInitAction, P2pChannelsBestTipPendingAction,
-    P2pChannelsBestTipReadyAction, P2pChannelsBestTipReceivedAction,
-    P2pChannelsBestTipRequestReceivedAction, P2pChannelsBestTipRequestSendAction,
-    P2pChannelsBestTipResponseSendAction,
-};
-use crate::p2p::channels::rpc::{
-    P2pChannelsRpcAction, P2pChannelsRpcInitAction, P2pChannelsRpcPendingAction,
-    P2pChannelsRpcReadyAction, P2pChannelsRpcRequestReceivedAction,
-    P2pChannelsRpcRequestSendAction, P2pChannelsRpcResponseReceivedAction,
-    P2pChannelsRpcResponseSendAction, P2pChannelsRpcTimeoutAction,
-};
-use crate::p2p::channels::snark::{
-    P2pChannelsSnarkAction, P2pChannelsSnarkInitAction, P2pChannelsSnarkLibp2pBroadcastAction,
-    P2pChannelsSnarkLibp2pReceivedAction, P2pChannelsSnarkPendingAction,
-    P2pChannelsSnarkPromiseReceivedAction, P2pChannelsSnarkReadyAction,
-    P2pChannelsSnarkReceivedAction, P2pChannelsSnarkRequestReceivedAction,
-    P2pChannelsSnarkRequestSendAction, P2pChannelsSnarkResponseSendAction,
-};
-use crate::p2p::channels::snark_job_commitment::{
-    P2pChannelsSnarkJobCommitmentAction, P2pChannelsSnarkJobCommitmentInitAction,
-    P2pChannelsSnarkJobCommitmentPendingAction, P2pChannelsSnarkJobCommitmentPromiseReceivedAction,
-    P2pChannelsSnarkJobCommitmentReadyAction, P2pChannelsSnarkJobCommitmentReceivedAction,
-    P2pChannelsSnarkJobCommitmentRequestReceivedAction,
-    P2pChannelsSnarkJobCommitmentRequestSendAction,
-    P2pChannelsSnarkJobCommitmentResponseSendAction,
-};
+use crate::external_snark_worker::ExternalSnarkWorkerAction;
+use crate::p2p::channels::best_tip::P2pChannelsBestTipAction;
+use crate::p2p::channels::rpc::P2pChannelsRpcAction;
+use crate::p2p::channels::snark::P2pChannelsSnarkAction;
+use crate::p2p::channels::snark_job_commitment::P2pChannelsSnarkJobCommitmentAction;
 use crate::p2p::channels::{P2pChannelsAction, P2pChannelsMessageReceivedAction};
 use crate::p2p::connection::incoming::{
     P2pConnectionIncomingAction, P2pConnectionIncomingAnswerReadyAction,
@@ -126,29 +89,11 @@ use crate::rpc::{
     RpcSnarkerConfigGetAction, RpcSnarkerJobCommitAction, RpcSnarkerJobSpecAction,
     RpcSnarkersWorkersGetAction, RpcSyncStatsGetAction,
 };
-use crate::snark::block_verify::{
-    SnarkBlockVerifyAction, SnarkBlockVerifyErrorAction, SnarkBlockVerifyFinishAction,
-    SnarkBlockVerifyInitAction, SnarkBlockVerifyPendingAction, SnarkBlockVerifySuccessAction,
-};
-use crate::snark::work_verify::{
-    SnarkWorkVerifyAction, SnarkWorkVerifyErrorAction, SnarkWorkVerifyFinishAction,
-    SnarkWorkVerifyInitAction, SnarkWorkVerifyPendingAction, SnarkWorkVerifySuccessAction,
-};
+use crate::snark::block_verify::SnarkBlockVerifyAction;
+use crate::snark::work_verify::SnarkWorkVerifyAction;
 use crate::snark::SnarkAction;
-use crate::snark_pool::candidate::{
-    SnarkPoolCandidateAction, SnarkPoolCandidateInfoReceivedAction,
-    SnarkPoolCandidatePeerPruneAction, SnarkPoolCandidateWorkFetchAllAction,
-    SnarkPoolCandidateWorkFetchInitAction, SnarkPoolCandidateWorkFetchPendingAction,
-    SnarkPoolCandidateWorkReceivedAction, SnarkPoolCandidateWorkVerifyErrorAction,
-    SnarkPoolCandidateWorkVerifyNextAction, SnarkPoolCandidateWorkVerifyPendingAction,
-    SnarkPoolCandidateWorkVerifySuccessAction,
-};
-use crate::snark_pool::{
-    SnarkPoolAction, SnarkPoolAutoCreateCommitmentAction, SnarkPoolCheckTimeoutsAction,
-    SnarkPoolCommitmentCreateAction, SnarkPoolJobCommitmentAddAction,
-    SnarkPoolJobCommitmentTimeoutAction, SnarkPoolJobsUpdateAction, SnarkPoolP2pSendAction,
-    SnarkPoolP2pSendAllAction, SnarkPoolWorkAddAction,
-};
+use crate::snark_pool::candidate::SnarkPoolCandidateAction;
+use crate::snark_pool::SnarkPoolAction;
 use crate::transition_frontier::sync::ledger::snarked::{
     TransitionFrontierSyncLedgerSnarkedAction,
     TransitionFrontierSyncLedgerSnarkedChildAccountsReceivedAction,
@@ -284,14 +229,6 @@ pub enum ActionKind {
     P2pChannelsRpcResponseSend,
     P2pChannelsRpcTimeout,
     P2pChannelsSnarkInit,
-    P2pChannelsSnarkJobCommitmentInit,
-    P2pChannelsSnarkJobCommitmentPending,
-    P2pChannelsSnarkJobCommitmentPromiseReceived,
-    P2pChannelsSnarkJobCommitmentReady,
-    P2pChannelsSnarkJobCommitmentReceived,
-    P2pChannelsSnarkJobCommitmentRequestReceived,
-    P2pChannelsSnarkJobCommitmentRequestSend,
-    P2pChannelsSnarkJobCommitmentResponseSend,
     P2pChannelsSnarkLibp2pBroadcast,
     P2pChannelsSnarkLibp2pReceived,
     P2pChannelsSnarkPending,
@@ -301,6 +238,14 @@ pub enum ActionKind {
     P2pChannelsSnarkRequestReceived,
     P2pChannelsSnarkRequestSend,
     P2pChannelsSnarkResponseSend,
+    P2pChannelsSnarkJobCommitmentInit,
+    P2pChannelsSnarkJobCommitmentPending,
+    P2pChannelsSnarkJobCommitmentPromiseReceived,
+    P2pChannelsSnarkJobCommitmentReady,
+    P2pChannelsSnarkJobCommitmentReceived,
+    P2pChannelsSnarkJobCommitmentRequestReceived,
+    P2pChannelsSnarkJobCommitmentRequestSend,
+    P2pChannelsSnarkJobCommitmentResponseSend,
     P2pConnectionIncomingAnswerReady,
     P2pConnectionIncomingAnswerSdpCreateError,
     P2pConnectionIncomingAnswerSdpCreatePending,
@@ -375,6 +320,14 @@ pub enum ActionKind {
     SnarkBlockVerifyPending,
     SnarkBlockVerifySuccess,
     SnarkPoolAutoCreateCommitment,
+    SnarkPoolCheckTimeouts,
+    SnarkPoolCommitmentAdd,
+    SnarkPoolCommitmentCreate,
+    SnarkPoolJobCommitmentTimeout,
+    SnarkPoolJobsUpdate,
+    SnarkPoolP2pSend,
+    SnarkPoolP2pSendAll,
+    SnarkPoolWorkAdd,
     SnarkPoolCandidateInfoReceived,
     SnarkPoolCandidatePeerPrune,
     SnarkPoolCandidateWorkFetchAll,
@@ -385,14 +338,6 @@ pub enum ActionKind {
     SnarkPoolCandidateWorkVerifyNext,
     SnarkPoolCandidateWorkVerifyPending,
     SnarkPoolCandidateWorkVerifySuccess,
-    SnarkPoolCheckTimeouts,
-    SnarkPoolCommitmentCreate,
-    SnarkPoolJobCommitmentAdd,
-    SnarkPoolJobCommitmentTimeout,
-    SnarkPoolJobsUpdate,
-    SnarkPoolP2pSend,
-    SnarkPoolP2pSendAll,
-    SnarkPoolWorkAdd,
     SnarkWorkVerifyError,
     SnarkWorkVerifyFinish,
     SnarkWorkVerifyInit,
@@ -527,15 +472,15 @@ impl ActionKindGet for SnarkAction {
 impl ActionKindGet for ConsensusAction {
     fn kind(&self) -> ActionKind {
         match self {
-            Self::BlockReceived(a) => a.kind(),
-            Self::BlockChainProofUpdate(a) => a.kind(),
-            Self::BlockSnarkVerifyPending(a) => a.kind(),
-            Self::BlockSnarkVerifySuccess(a) => a.kind(),
-            Self::DetectForkRange(a) => a.kind(),
-            Self::ShortRangeForkResolve(a) => a.kind(),
-            Self::LongRangeForkResolve(a) => a.kind(),
-            Self::BestTipUpdate(a) => a.kind(),
-            Self::Prune(a) => a.kind(),
+            Self::BlockReceived { .. } => ActionKind::ConsensusBlockReceived,
+            Self::BlockChainProofUpdate { .. } => ActionKind::ConsensusBlockChainProofUpdate,
+            Self::BlockSnarkVerifyPending { .. } => ActionKind::ConsensusBlockSnarkVerifyPending,
+            Self::BlockSnarkVerifySuccess { .. } => ActionKind::ConsensusBlockSnarkVerifySuccess,
+            Self::DetectForkRange { .. } => ActionKind::ConsensusDetectForkRange,
+            Self::ShortRangeForkResolve { .. } => ActionKind::ConsensusShortRangeForkResolve,
+            Self::LongRangeForkResolve { .. } => ActionKind::ConsensusLongRangeForkResolve,
+            Self::BestTipUpdate { .. } => ActionKind::ConsensusBestTipUpdate,
+            Self::Prune => ActionKind::ConsensusPrune,
         }
     }
 }
@@ -553,15 +498,15 @@ impl ActionKindGet for SnarkPoolAction {
     fn kind(&self) -> ActionKind {
         match self {
             Self::Candidate(a) => a.kind(),
-            Self::JobsUpdate(a) => a.kind(),
-            Self::AutoCreateCommitment(a) => a.kind(),
-            Self::CommitmentCreate(a) => a.kind(),
-            Self::CommitmentAdd(a) => a.kind(),
-            Self::WorkAdd(a) => a.kind(),
-            Self::P2pSendAll(a) => a.kind(),
-            Self::P2pSend(a) => a.kind(),
-            Self::CheckTimeouts(a) => a.kind(),
-            Self::JobCommitmentTimeout(a) => a.kind(),
+            Self::JobsUpdate { .. } => ActionKind::SnarkPoolJobsUpdate,
+            Self::AutoCreateCommitment => ActionKind::SnarkPoolAutoCreateCommitment,
+            Self::CommitmentCreate { .. } => ActionKind::SnarkPoolCommitmentCreate,
+            Self::CommitmentAdd { .. } => ActionKind::SnarkPoolCommitmentAdd,
+            Self::WorkAdd { .. } => ActionKind::SnarkPoolWorkAdd,
+            Self::P2pSendAll => ActionKind::SnarkPoolP2pSendAll,
+            Self::P2pSend { .. } => ActionKind::SnarkPoolP2pSend,
+            Self::CheckTimeouts => ActionKind::SnarkPoolCheckTimeouts,
+            Self::JobCommitmentTimeout { .. } => ActionKind::SnarkPoolJobCommitmentTimeout,
         }
     }
 }
@@ -569,19 +514,19 @@ impl ActionKindGet for SnarkPoolAction {
 impl ActionKindGet for ExternalSnarkWorkerAction {
     fn kind(&self) -> ActionKind {
         match self {
-            Self::Start(a) => a.kind(),
-            Self::Started(a) => a.kind(),
-            Self::StartTimeout(a) => a.kind(),
-            Self::Kill(a) => a.kind(),
-            Self::Killed(a) => a.kind(),
-            Self::SubmitWork(a) => a.kind(),
-            Self::WorkResult(a) => a.kind(),
-            Self::WorkError(a) => a.kind(),
-            Self::WorkTimeout(a) => a.kind(),
-            Self::CancelWork(a) => a.kind(),
-            Self::WorkCancelled(a) => a.kind(),
-            Self::PruneWork(a) => a.kind(),
-            Self::Error(a) => a.kind(),
+            Self::Start => ActionKind::ExternalSnarkWorkerStart,
+            Self::Started => ActionKind::ExternalSnarkWorkerStarted,
+            Self::StartTimeout { .. } => ActionKind::ExternalSnarkWorkerStartTimeout,
+            Self::Kill => ActionKind::ExternalSnarkWorkerKill,
+            Self::Killed => ActionKind::ExternalSnarkWorkerKilled,
+            Self::SubmitWork { .. } => ActionKind::ExternalSnarkWorkerSubmitWork,
+            Self::WorkResult { .. } => ActionKind::ExternalSnarkWorkerWorkResult,
+            Self::WorkError { .. } => ActionKind::ExternalSnarkWorkerWorkError,
+            Self::WorkTimeout { .. } => ActionKind::ExternalSnarkWorkerWorkTimeout,
+            Self::CancelWork => ActionKind::ExternalSnarkWorkerCancelWork,
+            Self::WorkCancelled => ActionKind::ExternalSnarkWorkerWorkCancelled,
+            Self::PruneWork => ActionKind::ExternalSnarkWorkerPruneWork,
+            Self::Error { .. } => ActionKind::ExternalSnarkWorkerError,
         }
     }
 }
@@ -745,11 +690,11 @@ impl ActionKindGet for P2pPeerAction {
 impl ActionKindGet for SnarkBlockVerifyAction {
     fn kind(&self) -> ActionKind {
         match self {
-            Self::Init(a) => a.kind(),
-            Self::Pending(a) => a.kind(),
-            Self::Error(a) => a.kind(),
-            Self::Success(a) => a.kind(),
-            Self::Finish(a) => a.kind(),
+            Self::Init { .. } => ActionKind::SnarkBlockVerifyInit,
+            Self::Pending { .. } => ActionKind::SnarkBlockVerifyPending,
+            Self::Error { .. } => ActionKind::SnarkBlockVerifyError,
+            Self::Success { .. } => ActionKind::SnarkBlockVerifySuccess,
+            Self::Finish { .. } => ActionKind::SnarkBlockVerifyFinish,
         }
     }
 }
@@ -757,66 +702,12 @@ impl ActionKindGet for SnarkBlockVerifyAction {
 impl ActionKindGet for SnarkWorkVerifyAction {
     fn kind(&self) -> ActionKind {
         match self {
-            Self::Init(a) => a.kind(),
-            Self::Pending(a) => a.kind(),
-            Self::Error(a) => a.kind(),
-            Self::Success(a) => a.kind(),
-            Self::Finish(a) => a.kind(),
+            Self::Init { .. } => ActionKind::SnarkWorkVerifyInit,
+            Self::Pending { .. } => ActionKind::SnarkWorkVerifyPending,
+            Self::Error { .. } => ActionKind::SnarkWorkVerifyError,
+            Self::Success { .. } => ActionKind::SnarkWorkVerifySuccess,
+            Self::Finish { .. } => ActionKind::SnarkWorkVerifyFinish,
         }
-    }
-}
-
-impl ActionKindGet for ConsensusBlockReceivedAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::ConsensusBlockReceived
-    }
-}
-
-impl ActionKindGet for ConsensusBlockChainProofUpdateAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::ConsensusBlockChainProofUpdate
-    }
-}
-
-impl ActionKindGet for ConsensusBlockSnarkVerifyPendingAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::ConsensusBlockSnarkVerifyPending
-    }
-}
-
-impl ActionKindGet for ConsensusBlockSnarkVerifySuccessAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::ConsensusBlockSnarkVerifySuccess
-    }
-}
-
-impl ActionKindGet for ConsensusDetectForkRangeAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::ConsensusDetectForkRange
-    }
-}
-
-impl ActionKindGet for ConsensusShortRangeForkResolveAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::ConsensusShortRangeForkResolve
-    }
-}
-
-impl ActionKindGet for ConsensusLongRangeForkResolveAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::ConsensusLongRangeForkResolve
-    }
-}
-
-impl ActionKindGet for ConsensusBestTipUpdateAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::ConsensusBestTipUpdate
-    }
-}
-
-impl ActionKindGet for ConsensusPruneAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::ConsensusPrune
     }
 }
 
@@ -857,149 +748,17 @@ impl ActionKindGet for TransitionFrontierSyncedAction {
 impl ActionKindGet for SnarkPoolCandidateAction {
     fn kind(&self) -> ActionKind {
         match self {
-            Self::InfoReceived(a) => a.kind(),
-            Self::WorkFetchAll(a) => a.kind(),
-            Self::WorkFetchInit(a) => a.kind(),
-            Self::WorkFetchPending(a) => a.kind(),
-            Self::WorkReceived(a) => a.kind(),
-            Self::WorkVerifyNext(a) => a.kind(),
-            Self::WorkVerifyPending(a) => a.kind(),
-            Self::WorkVerifyError(a) => a.kind(),
-            Self::WorkVerifySuccess(a) => a.kind(),
-            Self::PeerPrune(a) => a.kind(),
+            Self::InfoReceived { .. } => ActionKind::SnarkPoolCandidateInfoReceived,
+            Self::WorkFetchAll => ActionKind::SnarkPoolCandidateWorkFetchAll,
+            Self::WorkFetchInit { .. } => ActionKind::SnarkPoolCandidateWorkFetchInit,
+            Self::WorkFetchPending { .. } => ActionKind::SnarkPoolCandidateWorkFetchPending,
+            Self::WorkReceived { .. } => ActionKind::SnarkPoolCandidateWorkReceived,
+            Self::WorkVerifyNext => ActionKind::SnarkPoolCandidateWorkVerifyNext,
+            Self::WorkVerifyPending { .. } => ActionKind::SnarkPoolCandidateWorkVerifyPending,
+            Self::WorkVerifyError { .. } => ActionKind::SnarkPoolCandidateWorkVerifyError,
+            Self::WorkVerifySuccess { .. } => ActionKind::SnarkPoolCandidateWorkVerifySuccess,
+            Self::PeerPrune { .. } => ActionKind::SnarkPoolCandidatePeerPrune,
         }
-    }
-}
-
-impl ActionKindGet for SnarkPoolJobsUpdateAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::SnarkPoolJobsUpdate
-    }
-}
-
-impl ActionKindGet for SnarkPoolAutoCreateCommitmentAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::SnarkPoolAutoCreateCommitment
-    }
-}
-
-impl ActionKindGet for SnarkPoolCommitmentCreateAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::SnarkPoolCommitmentCreate
-    }
-}
-
-impl ActionKindGet for SnarkPoolJobCommitmentAddAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::SnarkPoolJobCommitmentAdd
-    }
-}
-
-impl ActionKindGet for SnarkPoolWorkAddAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::SnarkPoolWorkAdd
-    }
-}
-
-impl ActionKindGet for SnarkPoolP2pSendAllAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::SnarkPoolP2pSendAll
-    }
-}
-
-impl ActionKindGet for SnarkPoolP2pSendAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::SnarkPoolP2pSend
-    }
-}
-
-impl ActionKindGet for SnarkPoolCheckTimeoutsAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::SnarkPoolCheckTimeouts
-    }
-}
-
-impl ActionKindGet for SnarkPoolJobCommitmentTimeoutAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::SnarkPoolJobCommitmentTimeout
-    }
-}
-
-impl ActionKindGet for ExternalSnarkWorkerStartAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::ExternalSnarkWorkerStart
-    }
-}
-
-impl ActionKindGet for ExternalSnarkWorkerStartedAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::ExternalSnarkWorkerStarted
-    }
-}
-
-impl ActionKindGet for ExternalSnarkWorkerStartTimeoutAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::ExternalSnarkWorkerStartTimeout
-    }
-}
-
-impl ActionKindGet for ExternalSnarkWorkerKillAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::ExternalSnarkWorkerKill
-    }
-}
-
-impl ActionKindGet for ExternalSnarkWorkerKilledAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::ExternalSnarkWorkerKilled
-    }
-}
-
-impl ActionKindGet for ExternalSnarkWorkerSubmitWorkAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::ExternalSnarkWorkerSubmitWork
-    }
-}
-
-impl ActionKindGet for ExternalSnarkWorkerWorkResultAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::ExternalSnarkWorkerWorkResult
-    }
-}
-
-impl ActionKindGet for ExternalSnarkWorkerWorkErrorAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::ExternalSnarkWorkerWorkError
-    }
-}
-
-impl ActionKindGet for ExternalSnarkWorkerWorkTimeoutAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::ExternalSnarkWorkerWorkTimeout
-    }
-}
-
-impl ActionKindGet for ExternalSnarkWorkerCancelWorkAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::ExternalSnarkWorkerCancelWork
-    }
-}
-
-impl ActionKindGet for ExternalSnarkWorkerWorkCancelledAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::ExternalSnarkWorkerWorkCancelled
-    }
-}
-
-impl ActionKindGet for ExternalSnarkWorkerPruneWorkAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::ExternalSnarkWorkerPruneWork
-    }
-}
-
-impl ActionKindGet for ExternalSnarkWorkerErrorAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::ExternalSnarkWorkerError
     }
 }
 
@@ -1422,13 +1181,13 @@ impl ActionKindGet for P2pChannelsMessageReceivedAction {
 impl ActionKindGet for P2pChannelsBestTipAction {
     fn kind(&self) -> ActionKind {
         match self {
-            Self::Init(a) => a.kind(),
-            Self::Pending(a) => a.kind(),
-            Self::Ready(a) => a.kind(),
-            Self::RequestSend(a) => a.kind(),
-            Self::Received(a) => a.kind(),
-            Self::RequestReceived(a) => a.kind(),
-            Self::ResponseSend(a) => a.kind(),
+            Self::Init { .. } => ActionKind::P2pChannelsBestTipInit,
+            Self::Pending { .. } => ActionKind::P2pChannelsBestTipPending,
+            Self::Ready { .. } => ActionKind::P2pChannelsBestTipReady,
+            Self::RequestSend { .. } => ActionKind::P2pChannelsBestTipRequestSend,
+            Self::Received { .. } => ActionKind::P2pChannelsBestTipReceived,
+            Self::RequestReceived { .. } => ActionKind::P2pChannelsBestTipRequestReceived,
+            Self::ResponseSend { .. } => ActionKind::P2pChannelsBestTipResponseSend,
         }
     }
 }
@@ -1436,16 +1195,16 @@ impl ActionKindGet for P2pChannelsBestTipAction {
 impl ActionKindGet for P2pChannelsSnarkAction {
     fn kind(&self) -> ActionKind {
         match self {
-            Self::Init(a) => a.kind(),
-            Self::Pending(a) => a.kind(),
-            Self::Ready(a) => a.kind(),
-            Self::RequestSend(a) => a.kind(),
-            Self::PromiseReceived(a) => a.kind(),
-            Self::Received(a) => a.kind(),
-            Self::RequestReceived(a) => a.kind(),
-            Self::ResponseSend(a) => a.kind(),
-            Self::Libp2pReceived(a) => a.kind(),
-            Self::Libp2pBroadcast(a) => a.kind(),
+            Self::Init { .. } => ActionKind::P2pChannelsSnarkInit,
+            Self::Pending { .. } => ActionKind::P2pChannelsSnarkPending,
+            Self::Ready { .. } => ActionKind::P2pChannelsSnarkReady,
+            Self::RequestSend { .. } => ActionKind::P2pChannelsSnarkRequestSend,
+            Self::PromiseReceived { .. } => ActionKind::P2pChannelsSnarkPromiseReceived,
+            Self::Received { .. } => ActionKind::P2pChannelsSnarkReceived,
+            Self::RequestReceived { .. } => ActionKind::P2pChannelsSnarkRequestReceived,
+            Self::ResponseSend { .. } => ActionKind::P2pChannelsSnarkResponseSend,
+            Self::Libp2pReceived { .. } => ActionKind::P2pChannelsSnarkLibp2pReceived,
+            Self::Libp2pBroadcast { .. } => ActionKind::P2pChannelsSnarkLibp2pBroadcast,
         }
     }
 }
@@ -1453,14 +1212,18 @@ impl ActionKindGet for P2pChannelsSnarkAction {
 impl ActionKindGet for P2pChannelsSnarkJobCommitmentAction {
     fn kind(&self) -> ActionKind {
         match self {
-            Self::Init(a) => a.kind(),
-            Self::Pending(a) => a.kind(),
-            Self::Ready(a) => a.kind(),
-            Self::RequestSend(a) => a.kind(),
-            Self::PromiseReceived(a) => a.kind(),
-            Self::Received(a) => a.kind(),
-            Self::RequestReceived(a) => a.kind(),
-            Self::ResponseSend(a) => a.kind(),
+            Self::Init { .. } => ActionKind::P2pChannelsSnarkJobCommitmentInit,
+            Self::Pending { .. } => ActionKind::P2pChannelsSnarkJobCommitmentPending,
+            Self::Ready { .. } => ActionKind::P2pChannelsSnarkJobCommitmentReady,
+            Self::RequestSend { .. } => ActionKind::P2pChannelsSnarkJobCommitmentRequestSend,
+            Self::PromiseReceived { .. } => {
+                ActionKind::P2pChannelsSnarkJobCommitmentPromiseReceived
+            }
+            Self::Received { .. } => ActionKind::P2pChannelsSnarkJobCommitmentReceived,
+            Self::RequestReceived { .. } => {
+                ActionKind::P2pChannelsSnarkJobCommitmentRequestReceived
+            }
+            Self::ResponseSend { .. } => ActionKind::P2pChannelsSnarkJobCommitmentResponseSend,
         }
     }
 }
@@ -1468,14 +1231,14 @@ impl ActionKindGet for P2pChannelsSnarkJobCommitmentAction {
 impl ActionKindGet for P2pChannelsRpcAction {
     fn kind(&self) -> ActionKind {
         match self {
-            Self::Init(a) => a.kind(),
-            Self::Pending(a) => a.kind(),
-            Self::Ready(a) => a.kind(),
-            Self::RequestSend(a) => a.kind(),
-            Self::Timeout(a) => a.kind(),
-            Self::ResponseReceived(a) => a.kind(),
-            Self::RequestReceived(a) => a.kind(),
-            Self::ResponseSend(a) => a.kind(),
+            Self::Init { .. } => ActionKind::P2pChannelsRpcInit,
+            Self::Pending { .. } => ActionKind::P2pChannelsRpcPending,
+            Self::Ready { .. } => ActionKind::P2pChannelsRpcReady,
+            Self::RequestSend { .. } => ActionKind::P2pChannelsRpcRequestSend,
+            Self::Timeout { .. } => ActionKind::P2pChannelsRpcTimeout,
+            Self::ResponseReceived { .. } => ActionKind::P2pChannelsRpcResponseReceived,
+            Self::RequestReceived { .. } => ActionKind::P2pChannelsRpcRequestReceived,
+            Self::ResponseSend { .. } => ActionKind::P2pChannelsRpcResponseSend,
         }
     }
 }
@@ -1489,66 +1252,6 @@ impl ActionKindGet for P2pPeerReadyAction {
 impl ActionKindGet for P2pPeerBestTipUpdateAction {
     fn kind(&self) -> ActionKind {
         ActionKind::P2pPeerBestTipUpdate
-    }
-}
-
-impl ActionKindGet for SnarkBlockVerifyInitAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::SnarkBlockVerifyInit
-    }
-}
-
-impl ActionKindGet for SnarkBlockVerifyPendingAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::SnarkBlockVerifyPending
-    }
-}
-
-impl ActionKindGet for SnarkBlockVerifyErrorAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::SnarkBlockVerifyError
-    }
-}
-
-impl ActionKindGet for SnarkBlockVerifySuccessAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::SnarkBlockVerifySuccess
-    }
-}
-
-impl ActionKindGet for SnarkBlockVerifyFinishAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::SnarkBlockVerifyFinish
-    }
-}
-
-impl ActionKindGet for SnarkWorkVerifyInitAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::SnarkWorkVerifyInit
-    }
-}
-
-impl ActionKindGet for SnarkWorkVerifyPendingAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::SnarkWorkVerifyPending
-    }
-}
-
-impl ActionKindGet for SnarkWorkVerifyErrorAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::SnarkWorkVerifyError
-    }
-}
-
-impl ActionKindGet for SnarkWorkVerifySuccessAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::SnarkWorkVerifySuccess
-    }
-}
-
-impl ActionKindGet for SnarkWorkVerifyFinishAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::SnarkWorkVerifyFinish
     }
 }
 
@@ -1680,66 +1383,6 @@ impl ActionKindGet for TransitionFrontierSyncLedgerAction {
             Self::Staged(a) => a.kind(),
             Self::Success(a) => a.kind(),
         }
-    }
-}
-
-impl ActionKindGet for SnarkPoolCandidateInfoReceivedAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::SnarkPoolCandidateInfoReceived
-    }
-}
-
-impl ActionKindGet for SnarkPoolCandidateWorkFetchAllAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::SnarkPoolCandidateWorkFetchAll
-    }
-}
-
-impl ActionKindGet for SnarkPoolCandidateWorkFetchInitAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::SnarkPoolCandidateWorkFetchInit
-    }
-}
-
-impl ActionKindGet for SnarkPoolCandidateWorkFetchPendingAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::SnarkPoolCandidateWorkFetchPending
-    }
-}
-
-impl ActionKindGet for SnarkPoolCandidateWorkReceivedAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::SnarkPoolCandidateWorkReceived
-    }
-}
-
-impl ActionKindGet for SnarkPoolCandidateWorkVerifyNextAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::SnarkPoolCandidateWorkVerifyNext
-    }
-}
-
-impl ActionKindGet for SnarkPoolCandidateWorkVerifyPendingAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::SnarkPoolCandidateWorkVerifyPending
-    }
-}
-
-impl ActionKindGet for SnarkPoolCandidateWorkVerifyErrorAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::SnarkPoolCandidateWorkVerifyError
-    }
-}
-
-impl ActionKindGet for SnarkPoolCandidateWorkVerifySuccessAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::SnarkPoolCandidateWorkVerifySuccess
-    }
-}
-
-impl ActionKindGet for SnarkPoolCandidatePeerPruneAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::SnarkPoolCandidatePeerPrune
     }
 }
 
@@ -1950,204 +1593,6 @@ impl ActionKindGet for P2pConnectionIncomingSuccessAction {
 impl ActionKindGet for P2pConnectionIncomingLibp2pReceivedAction {
     fn kind(&self) -> ActionKind {
         ActionKind::P2pConnectionIncomingLibp2pReceived
-    }
-}
-
-impl ActionKindGet for P2pChannelsBestTipInitAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::P2pChannelsBestTipInit
-    }
-}
-
-impl ActionKindGet for P2pChannelsBestTipPendingAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::P2pChannelsBestTipPending
-    }
-}
-
-impl ActionKindGet for P2pChannelsBestTipReadyAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::P2pChannelsBestTipReady
-    }
-}
-
-impl ActionKindGet for P2pChannelsBestTipRequestSendAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::P2pChannelsBestTipRequestSend
-    }
-}
-
-impl ActionKindGet for P2pChannelsBestTipReceivedAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::P2pChannelsBestTipReceived
-    }
-}
-
-impl ActionKindGet for P2pChannelsBestTipRequestReceivedAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::P2pChannelsBestTipRequestReceived
-    }
-}
-
-impl ActionKindGet for P2pChannelsBestTipResponseSendAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::P2pChannelsBestTipResponseSend
-    }
-}
-
-impl ActionKindGet for P2pChannelsSnarkInitAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::P2pChannelsSnarkInit
-    }
-}
-
-impl ActionKindGet for P2pChannelsSnarkPendingAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::P2pChannelsSnarkPending
-    }
-}
-
-impl ActionKindGet for P2pChannelsSnarkReadyAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::P2pChannelsSnarkReady
-    }
-}
-
-impl ActionKindGet for P2pChannelsSnarkRequestSendAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::P2pChannelsSnarkRequestSend
-    }
-}
-
-impl ActionKindGet for P2pChannelsSnarkPromiseReceivedAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::P2pChannelsSnarkPromiseReceived
-    }
-}
-
-impl ActionKindGet for P2pChannelsSnarkReceivedAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::P2pChannelsSnarkReceived
-    }
-}
-
-impl ActionKindGet for P2pChannelsSnarkRequestReceivedAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::P2pChannelsSnarkRequestReceived
-    }
-}
-
-impl ActionKindGet for P2pChannelsSnarkResponseSendAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::P2pChannelsSnarkResponseSend
-    }
-}
-
-impl ActionKindGet for P2pChannelsSnarkLibp2pReceivedAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::P2pChannelsSnarkLibp2pReceived
-    }
-}
-
-impl ActionKindGet for P2pChannelsSnarkLibp2pBroadcastAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::P2pChannelsSnarkLibp2pBroadcast
-    }
-}
-
-impl ActionKindGet for P2pChannelsSnarkJobCommitmentInitAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::P2pChannelsSnarkJobCommitmentInit
-    }
-}
-
-impl ActionKindGet for P2pChannelsSnarkJobCommitmentPendingAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::P2pChannelsSnarkJobCommitmentPending
-    }
-}
-
-impl ActionKindGet for P2pChannelsSnarkJobCommitmentReadyAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::P2pChannelsSnarkJobCommitmentReady
-    }
-}
-
-impl ActionKindGet for P2pChannelsSnarkJobCommitmentRequestSendAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::P2pChannelsSnarkJobCommitmentRequestSend
-    }
-}
-
-impl ActionKindGet for P2pChannelsSnarkJobCommitmentPromiseReceivedAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::P2pChannelsSnarkJobCommitmentPromiseReceived
-    }
-}
-
-impl ActionKindGet for P2pChannelsSnarkJobCommitmentReceivedAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::P2pChannelsSnarkJobCommitmentReceived
-    }
-}
-
-impl ActionKindGet for P2pChannelsSnarkJobCommitmentRequestReceivedAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::P2pChannelsSnarkJobCommitmentRequestReceived
-    }
-}
-
-impl ActionKindGet for P2pChannelsSnarkJobCommitmentResponseSendAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::P2pChannelsSnarkJobCommitmentResponseSend
-    }
-}
-
-impl ActionKindGet for P2pChannelsRpcInitAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::P2pChannelsRpcInit
-    }
-}
-
-impl ActionKindGet for P2pChannelsRpcPendingAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::P2pChannelsRpcPending
-    }
-}
-
-impl ActionKindGet for P2pChannelsRpcReadyAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::P2pChannelsRpcReady
-    }
-}
-
-impl ActionKindGet for P2pChannelsRpcRequestSendAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::P2pChannelsRpcRequestSend
-    }
-}
-
-impl ActionKindGet for P2pChannelsRpcTimeoutAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::P2pChannelsRpcTimeout
-    }
-}
-
-impl ActionKindGet for P2pChannelsRpcResponseReceivedAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::P2pChannelsRpcResponseReceived
-    }
-}
-
-impl ActionKindGet for P2pChannelsRpcRequestReceivedAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::P2pChannelsRpcRequestReceived
-    }
-}
-
-impl ActionKindGet for P2pChannelsRpcResponseSendAction {
-    fn kind(&self) -> ActionKind {
-        ActionKind::P2pChannelsRpcResponseSend
     }
 }
 

--- a/node/src/consensus/consensus_actions.rs
+++ b/node/src/consensus/consensus_actions.rs
@@ -10,188 +10,121 @@ use crate::snark::block_verify::SnarkBlockVerifyId;
 pub type ConsensusActionWithMeta = redux::ActionWithMeta<ConsensusAction>;
 pub type ConsensusActionWithMetaRef<'a> = redux::ActionWithMeta<&'a ConsensusAction>;
 
-#[derive(derive_more::From, Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum ConsensusAction {
-    BlockReceived(ConsensusBlockReceivedAction),
-    BlockChainProofUpdate(ConsensusBlockChainProofUpdateAction),
-    BlockSnarkVerifyPending(ConsensusBlockSnarkVerifyPendingAction),
-    BlockSnarkVerifySuccess(ConsensusBlockSnarkVerifySuccessAction),
-    DetectForkRange(ConsensusDetectForkRangeAction),
-    ShortRangeForkResolve(ConsensusShortRangeForkResolveAction),
-    LongRangeForkResolve(ConsensusLongRangeForkResolveAction),
-    BestTipUpdate(ConsensusBestTipUpdateAction),
-    Prune(ConsensusPruneAction),
+    BlockReceived {
+        hash: StateHash,
+        block: Arc<MinaBlockBlockStableV2>,
+        chain_proof: Option<(Vec<StateHash>, ArcBlockWithHash)>,
+    },
+    BlockChainProofUpdate {
+        hash: StateHash,
+        chain_proof: (Vec<StateHash>, ArcBlockWithHash),
+    },
+    BlockSnarkVerifyPending {
+        req_id: SnarkBlockVerifyId,
+        hash: StateHash,
+    },
+    BlockSnarkVerifySuccess {
+        hash: StateHash,
+    },
+    DetectForkRange {
+        hash: StateHash,
+    },
+    ShortRangeForkResolve {
+        hash: StateHash,
+    },
+    LongRangeForkResolve {
+        hash: StateHash,
+    },
+    BestTipUpdate {
+        hash: StateHash,
+    },
+    Prune,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ConsensusBlockReceivedAction {
-    pub hash: StateHash,
-    pub block: Arc<MinaBlockBlockStableV2>,
-    pub chain_proof: Option<(Vec<StateHash>, ArcBlockWithHash)>,
-}
-
-impl redux::EnablingCondition<crate::State> for ConsensusBlockReceivedAction {
+impl redux::EnablingCondition<crate::State> for ConsensusAction {
     fn is_enabled(&self, state: &crate::State) -> bool {
-        !state.consensus.blocks.contains_key(&self.hash)
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ConsensusBlockChainProofUpdateAction {
-    pub hash: StateHash,
-    pub chain_proof: (Vec<StateHash>, ArcBlockWithHash),
-}
-
-impl redux::EnablingCondition<crate::State> for ConsensusBlockChainProofUpdateAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        (state.consensus.best_tip.as_ref() == Some(&self.hash)
-            && state.consensus.best_tip_chain_proof.is_none())
-            || state
-                .consensus
-                .blocks
-                .get(&self.hash)
-                .map_or(false, |b| b.status.is_pending() && b.chain_proof.is_none())
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ConsensusBlockSnarkVerifyPendingAction {
-    pub req_id: SnarkBlockVerifyId,
-    pub hash: StateHash,
-}
-
-impl redux::EnablingCondition<crate::State> for ConsensusBlockSnarkVerifyPendingAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state
-            .consensus
-            .blocks
-            .get(&self.hash)
-            .map_or(false, |block| block.status.is_received())
-            && state.snark.block_verify.jobs.contains(self.req_id)
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ConsensusBlockSnarkVerifySuccessAction {
-    pub hash: StateHash,
-}
-
-impl redux::EnablingCondition<crate::State> for ConsensusBlockSnarkVerifySuccessAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state
-            .consensus
-            .blocks
-            .get(&self.hash)
-            .map_or(false, |block| block.status.is_snark_verify_pending())
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ConsensusDetectForkRangeAction {
-    pub hash: StateHash,
-}
-
-impl redux::EnablingCondition<crate::State> for ConsensusDetectForkRangeAction {
-    fn is_enabled(&self, #[allow(unused_variables)] state: &crate::State) -> bool {
-        state
-            .consensus
-            .blocks
-            .get(&self.hash)
-            .map_or(false, |block| {
-                matches!(
-                    block.status,
-                    ConsensusBlockStatus::SnarkVerifySuccess { .. }
-                )
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ConsensusShortRangeForkResolveAction {
-    pub hash: StateHash,
-}
-
-impl redux::EnablingCondition<crate::State> for ConsensusShortRangeForkResolveAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state
-            .consensus
-            .blocks
-            .get(&self.hash)
-            .map_or(false, |block| match state.consensus.best_tip() {
-                Some(tip) => {
-                    matches!(
-                        &block.status,
-                        ConsensusBlockStatus::ForkRangeDetected { compared_with, short_fork, .. }
-                            if compared_with.as_ref() == Some(tip.hash) && *short_fork
-                    )
-                }
-                None => true,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ConsensusLongRangeForkResolveAction {
-    pub hash: StateHash,
-}
-
-impl redux::EnablingCondition<crate::State> for ConsensusLongRangeForkResolveAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state
-            .consensus
-            .blocks
-            .get(&self.hash)
-            .map_or(false, |block| match state.consensus.best_tip() {
-                Some(tip) => {
-                    matches!(
-                        &block.status,
-                        ConsensusBlockStatus::ForkRangeDetected { compared_with, short_fork, .. }
-                             if compared_with.as_ref() == Some(tip.hash) && !*short_fork
-                    )
-                }
-                None => false,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ConsensusBestTipUpdateAction {
-    pub hash: StateHash,
-}
-
-impl redux::EnablingCondition<crate::State> for ConsensusBestTipUpdateAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state
-            .consensus
-            .is_candidate_decided_to_use_as_tip(&self.hash)
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ConsensusPruneAction {}
-
-impl redux::EnablingCondition<crate::State> for ConsensusPruneAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state.consensus.best_tip().is_some()
-    }
-}
-
-macro_rules! impl_into_global_action {
-    ($a:ty) => {
-        impl From<$a> for crate::Action {
-            fn from(value: $a) -> Self {
-                Self::Consensus(value.into())
-            }
+        match self {
+            ConsensusAction::BlockReceived { hash, .. } => {
+                !state.consensus.blocks.contains_key(hash)
+            },
+            ConsensusAction::BlockChainProofUpdate { hash, .. } => {
+                (state.consensus.best_tip.as_ref() == Some(hash)
+                    && state.consensus.best_tip_chain_proof.is_none())
+                    || state
+                        .consensus
+                        .blocks
+                        .get(hash)
+                        .map_or(false, |b| b.status.is_pending() && b.chain_proof.is_none())
+            },
+            ConsensusAction::BlockSnarkVerifyPending { req_id, hash } => {
+                state
+                    .consensus
+                    .blocks
+                    .get(hash)
+                    .map_or(false, |block| block.status.is_received())
+                    && state.snark.block_verify.jobs.contains(*req_id)
+            },
+            ConsensusAction::BlockSnarkVerifySuccess { hash } => {
+                state
+                    .consensus
+                    .blocks
+                    .get(hash)
+                    .map_or(false, |block| block.status.is_snark_verify_pending())
+            },
+            ConsensusAction::DetectForkRange { hash } => {
+                state
+                    .consensus
+                    .blocks
+                    .get(hash)
+                    .map_or(false, |block| {
+                        matches!(
+                            block.status,
+                            ConsensusBlockStatus::SnarkVerifySuccess { .. }
+                        )
+                    })
+            },
+            ConsensusAction::ShortRangeForkResolve { hash } => {
+                state
+                    .consensus
+                    .blocks
+                    .get(hash)
+                    .map_or(false, |block| match state.consensus.best_tip() {
+                        Some(tip) => {
+                            matches!(
+                                &block.status,
+                                ConsensusBlockStatus::ForkRangeDetected { compared_with, short_fork, .. }
+                                    if compared_with.as_ref() == Some(tip.hash) && *short_fork
+                            )
+                        }
+                        None => true,
+                    })
+            },
+            ConsensusAction::LongRangeForkResolve { hash } => {
+                state
+                    .consensus
+                    .blocks
+                    .get(hash)
+                    .map_or(false, |block| match state.consensus.best_tip() {
+                        Some(tip) => {
+                            matches!(
+                                &block.status,
+                                ConsensusBlockStatus::ForkRangeDetected { compared_with, short_fork, .. }
+                                     if compared_with.as_ref() == Some(tip.hash) && !*short_fork
+                            )
+                        }
+                        None => false,
+                    })
+            },
+            ConsensusAction::BestTipUpdate { hash } => {
+                state
+                    .consensus
+                    .is_candidate_decided_to_use_as_tip(hash)
+            },
+            ConsensusAction::Prune => {
+                state.consensus.best_tip().is_some()
+            },
         }
-    };
+    }
 }
-
-impl_into_global_action!(ConsensusBlockReceivedAction);
-impl_into_global_action!(ConsensusBlockChainProofUpdateAction);
-impl_into_global_action!(ConsensusBlockSnarkVerifyPendingAction);
-impl_into_global_action!(ConsensusBlockSnarkVerifySuccessAction);
-impl_into_global_action!(ConsensusDetectForkRangeAction);
-impl_into_global_action!(ConsensusShortRangeForkResolveAction);
-impl_into_global_action!(ConsensusLongRangeForkResolveAction);
-impl_into_global_action!(ConsensusBestTipUpdateAction);
-impl_into_global_action!(ConsensusPruneAction);

--- a/node/src/consensus/consensus_effects.rs
+++ b/node/src/consensus/consensus_effects.rs
@@ -8,49 +8,40 @@ use crate::{
     watched_accounts::WatchedAccountsBlockTransactionsIncludedAction,
 };
 
-use super::{
-    ConsensusAction, ConsensusActionWithMeta, ConsensusBestTipUpdateAction,
-    ConsensusBlockSnarkVerifyPendingAction, ConsensusDetectForkRangeAction,
-    ConsensusLongRangeForkResolveAction, ConsensusShortRangeForkResolveAction,
-};
+use super::{ConsensusAction, ConsensusActionWithMeta};
 
 pub fn consensus_effects<S: crate::Service>(store: &mut Store<S>, action: ConsensusActionWithMeta) {
     let (action, _) = action.split();
 
     match action {
-        ConsensusAction::BlockReceived(action) => {
+        ConsensusAction::BlockReceived { hash, block, .. } => {
             let req_id = store.state().snark.block_verify.next_req_id();
             store.dispatch(SnarkBlockVerifyInitAction {
                 req_id,
-                block: (action.hash.clone(), action.block).into(),
+                block: (hash.clone(), block).into(),
             });
-            store.dispatch(ConsensusBlockSnarkVerifyPendingAction {
-                req_id,
-                hash: action.hash,
-            });
+            store.dispatch(ConsensusAction::BlockSnarkVerifyPending { req_id, hash });
         }
-        ConsensusAction::BlockChainProofUpdate(a) => {
-            if store.state().consensus.best_tip.as_ref() == Some(&a.hash) {
+        ConsensusAction::BlockChainProofUpdate { hash, .. } => {
+            if store.state().consensus.best_tip.as_ref() == Some(&hash) {
                 transition_frontier_new_best_tip(store);
             }
         }
-        ConsensusAction::BlockSnarkVerifyPending(_) => {}
-        ConsensusAction::BlockSnarkVerifySuccess(a) => {
-            store.dispatch(ConsensusDetectForkRangeAction { hash: a.hash });
+        ConsensusAction::BlockSnarkVerifyPending { .. } => {}
+        ConsensusAction::BlockSnarkVerifySuccess { hash } => {
+            store.dispatch(ConsensusAction::DetectForkRange { hash });
         }
-        ConsensusAction::DetectForkRange(a) => {
-            store.dispatch(ConsensusShortRangeForkResolveAction {
-                hash: a.hash.clone(),
-            });
-            store.dispatch(ConsensusLongRangeForkResolveAction { hash: a.hash });
+        ConsensusAction::DetectForkRange { hash } => {
+            store.dispatch(ConsensusAction::ShortRangeForkResolve { hash: hash.clone() });
+            store.dispatch(ConsensusAction::LongRangeForkResolve { hash });
         }
-        ConsensusAction::ShortRangeForkResolve(a) => {
-            store.dispatch(ConsensusBestTipUpdateAction { hash: a.hash });
+        ConsensusAction::ShortRangeForkResolve { hash } => {
+            store.dispatch(ConsensusAction::BestTipUpdate { hash });
         }
-        ConsensusAction::LongRangeForkResolve(a) => {
-            store.dispatch(ConsensusBestTipUpdateAction { hash: a.hash });
+        ConsensusAction::LongRangeForkResolve { hash } => {
+            store.dispatch(ConsensusAction::BestTipUpdate { hash });
         }
-        ConsensusAction::BestTipUpdate(_) => {
+        ConsensusAction::BestTipUpdate { .. } => {
             let Some(block) = store.state.get().consensus.best_tip_block_with_hash() else {
                 return;
             };
@@ -66,7 +57,7 @@ pub fn consensus_effects<S: crate::Service>(store: &mut Store<S>, action: Consen
 
             transition_frontier_new_best_tip(store);
         }
-        ConsensusAction::Prune(_) => {}
+        ConsensusAction::Prune => {}
     }
 }
 

--- a/node/src/consensus/consensus_effects.rs
+++ b/node/src/consensus/consensus_effects.rs
@@ -4,7 +4,7 @@ use crate::transition_frontier::sync::{
 use crate::watched_accounts::WatchedAccountsLedgerInitialStateGetInitAction;
 use crate::Store;
 use crate::{
-    snark::block_verify::SnarkBlockVerifyInitAction,
+    snark::block_verify::SnarkBlockVerifyAction,
     watched_accounts::WatchedAccountsBlockTransactionsIncludedAction,
 };
 
@@ -16,7 +16,7 @@ pub fn consensus_effects<S: crate::Service>(store: &mut Store<S>, action: Consen
     match action {
         ConsensusAction::BlockReceived { hash, block, .. } => {
             let req_id = store.state().snark.block_verify.next_req_id();
-            store.dispatch(SnarkBlockVerifyInitAction {
+            store.dispatch(SnarkBlockVerifyAction::Init {
                 req_id,
                 block: (hash.clone(), block).into(),
             });

--- a/node/src/effects.rs
+++ b/node/src/effects.rs
@@ -21,9 +21,7 @@ use crate::p2p::discovery::{P2pDiscoveryKademliaBootstrapAction, P2pDiscoveryKad
 use crate::p2p::p2p_effects;
 use crate::rpc::rpc_effects;
 use crate::snark::snark_effects;
-use crate::snark_pool::candidate::{
-    SnarkPoolCandidateWorkFetchAllAction, SnarkPoolCandidateWorkVerifyNextAction,
-};
+use crate::snark_pool::candidate::SnarkPoolCandidateAction;
 use crate::snark_pool::{
     snark_pool_effects, SnarkPoolCheckTimeoutsAction, SnarkPoolP2pSendAllAction,
 };
@@ -62,8 +60,8 @@ pub fn effects<S: Service>(store: &mut Store<S>, action: ActionWithMeta) {
 
             p2p_request_best_tip_if_needed(store);
 
-            store.dispatch(SnarkPoolCandidateWorkFetchAllAction {});
-            store.dispatch(SnarkPoolCandidateWorkVerifyNextAction {});
+            store.dispatch(SnarkPoolCandidateAction::WorkFetchAll {});
+            store.dispatch(SnarkPoolCandidateAction::WorkVerifyNext {});
 
             p2p_request_snarks_if_needed(store);
 

--- a/node/src/effects.rs
+++ b/node/src/effects.rs
@@ -48,13 +48,13 @@ pub fn effects<S: Service>(store: &mut Store<S>, action: ActionWithMeta) {
 
             p2p_try_reconnect_disconnected_peers(store);
 
-            store.dispatch(SnarkPoolAction::CheckTimeouts {});
-            store.dispatch(SnarkPoolAction::P2pSendAll {});
+            store.dispatch(SnarkPoolAction::CheckTimeouts);
+            store.dispatch(SnarkPoolAction::P2pSendAll);
 
             p2p_request_best_tip_if_needed(store);
 
-            store.dispatch(SnarkPoolCandidateAction::WorkFetchAll {});
-            store.dispatch(SnarkPoolCandidateAction::WorkVerifyNext {});
+            store.dispatch(SnarkPoolCandidateAction::WorkFetchAll);
+            store.dispatch(SnarkPoolCandidateAction::WorkVerifyNext);
 
             p2p_request_snarks_if_needed(store);
 

--- a/node/src/effects.rs
+++ b/node/src/effects.rs
@@ -1,3 +1,4 @@
+use p2p::channels::snark::P2pChannelsSnarkAction;
 use redux::ActionMeta;
 
 use crate::block_producer::{block_producer_effects, BlockProducerWonSlotProduceInitAction};
@@ -8,7 +9,6 @@ use crate::logger::logger_effects;
 use crate::p2p::channels::rpc::{
     P2pChannelsRpcRequestSendAction, P2pChannelsRpcTimeoutAction, P2pRpcKind, P2pRpcRequest,
 };
-use crate::p2p::channels::snark::P2pChannelsSnarkRequestSendAction;
 use crate::p2p::connection::incoming::P2pConnectionIncomingTimeoutAction;
 use crate::p2p::connection::outgoing::{
     P2pConnectionOutgoingRandomInitAction, P2pConnectionOutgoingReconnectAction,
@@ -210,7 +210,7 @@ fn p2p_request_snarks_if_needed<S: Service>(store: &mut Store<S>) {
         .collect::<Vec<_>>();
 
     for (peer_id, limit) in snark_reqs {
-        store.dispatch(P2pChannelsSnarkRequestSendAction { peer_id, limit });
+        store.dispatch(P2pChannelsSnarkAction::RequestSend { peer_id, limit });
     }
 }
 

--- a/node/src/effects.rs
+++ b/node/src/effects.rs
@@ -17,9 +17,7 @@ use crate::p2p::p2p_effects;
 use crate::rpc::rpc_effects;
 use crate::snark::snark_effects;
 use crate::snark_pool::candidate::SnarkPoolCandidateAction;
-use crate::snark_pool::{
-    snark_pool_effects, SnarkPoolCheckTimeoutsAction, SnarkPoolP2pSendAllAction,
-};
+use crate::snark_pool::{snark_pool_effects, SnarkPoolAction};
 use crate::transition_frontier::sync::TransitionFrontierSyncBlocksNextApplyInitAction;
 use crate::transition_frontier::transition_frontier_effects;
 use crate::watched_accounts::watched_accounts_effects;
@@ -50,8 +48,8 @@ pub fn effects<S: Service>(store: &mut Store<S>, action: ActionWithMeta) {
 
             p2p_try_reconnect_disconnected_peers(store);
 
-            store.dispatch(SnarkPoolCheckTimeoutsAction {});
-            store.dispatch(SnarkPoolP2pSendAllAction {});
+            store.dispatch(SnarkPoolAction::CheckTimeouts {});
+            store.dispatch(SnarkPoolAction::P2pSendAll {});
 
             p2p_request_best_tip_if_needed(store);
 

--- a/node/src/event_source/event_source_effects.rs
+++ b/node/src/event_source/event_source_effects.rs
@@ -5,11 +5,7 @@ use p2p::P2pListenEvent;
 
 use crate::action::CheckTimeoutsAction;
 use crate::block_producer::vrf_evaluator::BlockProducerVrfEvaluatorEvaluationSuccessAction;
-use crate::external_snark_worker::{
-    ExternalSnarkWorkerErrorAction, ExternalSnarkWorkerEvent, ExternalSnarkWorkerKilledAction,
-    ExternalSnarkWorkerStartedAction, ExternalSnarkWorkerWorkCancelledAction,
-    ExternalSnarkWorkerWorkErrorAction, ExternalSnarkWorkerWorkResultAction,
-};
+use crate::external_snark_worker::ExternalSnarkWorkerEvent;
 use crate::p2p::channels::best_tip::P2pChannelsBestTipReadyAction;
 use crate::p2p::channels::rpc::P2pChannelsRpcReadyAction;
 use crate::p2p::channels::snark::{
@@ -48,7 +44,7 @@ use crate::rpc::{
 use crate::snark::block_verify::SnarkBlockVerifyAction;
 use crate::snark::work_verify::SnarkWorkVerifyAction;
 use crate::snark::SnarkEvent;
-use crate::{Service, Store};
+use crate::{ExternalSnarkWorkerAction, Service, Store};
 
 use super::{
     Event, EventSourceAction, EventSourceActionWithMeta, EventSourceNewEventAction,
@@ -304,22 +300,22 @@ pub fn event_source_effects<S: Service>(store: &mut Store<S>, action: EventSourc
             },
             Event::ExternalSnarkWorker(e) => match e {
                 ExternalSnarkWorkerEvent::Started => {
-                    store.dispatch(ExternalSnarkWorkerStartedAction {});
+                    store.dispatch(ExternalSnarkWorkerAction::Started);
                 }
                 ExternalSnarkWorkerEvent::Killed => {
-                    store.dispatch(ExternalSnarkWorkerKilledAction {});
+                    store.dispatch(ExternalSnarkWorkerAction::Killed);
                 }
                 ExternalSnarkWorkerEvent::WorkResult(result) => {
-                    store.dispatch(ExternalSnarkWorkerWorkResultAction { result });
+                    store.dispatch(ExternalSnarkWorkerAction::WorkResult { result });
                 }
                 ExternalSnarkWorkerEvent::WorkError(error) => {
-                    store.dispatch(ExternalSnarkWorkerWorkErrorAction { error });
+                    store.dispatch(ExternalSnarkWorkerAction::WorkError { error });
                 }
                 ExternalSnarkWorkerEvent::WorkCancelled => {
-                    store.dispatch(ExternalSnarkWorkerWorkCancelledAction {});
+                    store.dispatch(ExternalSnarkWorkerAction::WorkCancelled);
                 }
                 ExternalSnarkWorkerEvent::Error(error) => {
-                    store.dispatch(ExternalSnarkWorkerErrorAction {
+                    store.dispatch(ExternalSnarkWorkerAction::Error {
                         error,
                         permanent: false,
                     });

--- a/node/src/event_source/event_source_effects.rs
+++ b/node/src/event_source/event_source_effects.rs
@@ -8,7 +8,7 @@ use crate::action::CheckTimeoutsAction;
 use crate::block_producer::vrf_evaluator::BlockProducerVrfEvaluatorEvaluationSuccessAction;
 use crate::external_snark_worker::ExternalSnarkWorkerEvent;
 use crate::p2p::channels::best_tip::P2pChannelsBestTipAction;
-use crate::p2p::channels::rpc::P2pChannelsRpcReadyAction;
+use crate::p2p::channels::rpc::P2pChannelsRpcAction;
 use crate::p2p::channels::snark_job_commitment::P2pChannelsSnarkJobCommitmentAction;
 use crate::p2p::channels::{ChannelId, P2pChannelsMessageReceivedAction};
 use crate::p2p::connection::incoming::{
@@ -185,7 +185,7 @@ pub fn event_source_effects<S: Service>(store: &mut Store<S>, action: EventSourc
                             }
                             ChannelId::Rpc => {
                                 // TODO(binier): maybe dispatch success and then ready.
-                                store.dispatch(P2pChannelsRpcReadyAction { peer_id });
+                                store.dispatch(P2pChannelsRpcAction::Ready { peer_id });
                             }
                         },
                     },

--- a/node/src/event_source/event_source_effects.rs
+++ b/node/src/event_source/event_source_effects.rs
@@ -11,7 +11,7 @@ use crate::p2p::channels::rpc::P2pChannelsRpcReadyAction;
 use crate::p2p::channels::snark::{
     P2pChannelsSnarkLibp2pReceivedAction, P2pChannelsSnarkReadyAction,
 };
-use crate::p2p::channels::snark_job_commitment::P2pChannelsSnarkJobCommitmentReadyAction;
+use crate::p2p::channels::snark_job_commitment::P2pChannelsSnarkJobCommitmentAction;
 use crate::p2p::channels::{ChannelId, P2pChannelsMessageReceivedAction};
 use crate::p2p::connection::incoming::{
     P2pConnectionIncomingAnswerSdpCreateErrorAction,
@@ -181,8 +181,9 @@ pub fn event_source_effects<S: Service>(store: &mut Store<S>, action: EventSourc
                             }
                             ChannelId::SnarkJobCommitmentPropagation => {
                                 // TODO(binier): maybe dispatch success and then ready.
-                                store
-                                    .dispatch(P2pChannelsSnarkJobCommitmentReadyAction { peer_id });
+                                store.dispatch(P2pChannelsSnarkJobCommitmentAction::Ready {
+                                    peer_id,
+                                });
                             }
                             ChannelId::Rpc => {
                                 // TODO(binier): maybe dispatch success and then ready.

--- a/node/src/event_source/event_source_effects.rs
+++ b/node/src/event_source/event_source_effects.rs
@@ -46,7 +46,7 @@ use crate::rpc::{
     RpcSyncStatsGetAction,
 };
 use crate::snark::block_verify::SnarkBlockVerifyAction;
-use crate::snark::work_verify::{SnarkWorkVerifyErrorAction, SnarkWorkVerifySuccessAction};
+use crate::snark::work_verify::SnarkWorkVerifyAction;
 use crate::snark::SnarkEvent;
 use crate::{Service, Store};
 
@@ -245,10 +245,10 @@ pub fn event_source_effects<S: Service>(store: &mut Store<S>, action: EventSourc
                 },
                 SnarkEvent::WorkVerify(req_id, result) => match result {
                     Err(error) => {
-                        store.dispatch(SnarkWorkVerifyErrorAction { req_id, error });
+                        store.dispatch(SnarkWorkVerifyAction::Error { req_id, error });
                     }
                     Ok(()) => {
-                        store.dispatch(SnarkWorkVerifySuccessAction { req_id });
+                        store.dispatch(SnarkWorkVerifyAction::Success { req_id });
                     }
                 },
             },

--- a/node/src/event_source/event_source_effects.rs
+++ b/node/src/event_source/event_source_effects.rs
@@ -1,3 +1,4 @@
+use p2p::channels::snark::P2pChannelsSnarkAction;
 use p2p::listen::{
     P2pListenClosedAction, P2pListenErrorAction, P2pListenExpiredAction, P2pListenNewAction,
 };
@@ -8,9 +9,6 @@ use crate::block_producer::vrf_evaluator::BlockProducerVrfEvaluatorEvaluationSuc
 use crate::external_snark_worker::ExternalSnarkWorkerEvent;
 use crate::p2p::channels::best_tip::P2pChannelsBestTipAction;
 use crate::p2p::channels::rpc::P2pChannelsRpcReadyAction;
-use crate::p2p::channels::snark::{
-    P2pChannelsSnarkLibp2pReceivedAction, P2pChannelsSnarkReadyAction,
-};
 use crate::p2p::channels::snark_job_commitment::P2pChannelsSnarkJobCommitmentAction;
 use crate::p2p::channels::{ChannelId, P2pChannelsMessageReceivedAction};
 use crate::p2p::connection::incoming::{
@@ -177,7 +175,7 @@ pub fn event_source_effects<S: Service>(store: &mut Store<S>, action: EventSourc
                             }
                             ChannelId::SnarkPropagation => {
                                 // TODO(binier): maybe dispatch success and then ready.
-                                store.dispatch(P2pChannelsSnarkReadyAction { peer_id });
+                                store.dispatch(P2pChannelsSnarkAction::Ready { peer_id });
                             }
                             ChannelId::SnarkJobCommitmentPropagation => {
                                 // TODO(binier): maybe dispatch success and then ready.
@@ -207,7 +205,7 @@ pub fn event_source_effects<S: Service>(store: &mut Store<S>, action: EventSourc
                         }
                     },
                     P2pChannelEvent::Libp2pSnarkReceived(peer_id, snark, nonce) => {
-                        store.dispatch(P2pChannelsSnarkLibp2pReceivedAction {
+                        store.dispatch(P2pChannelsSnarkAction::Libp2pReceived {
                             peer_id,
                             snark,
                             nonce,

--- a/node/src/event_source/event_source_effects.rs
+++ b/node/src/event_source/event_source_effects.rs
@@ -45,7 +45,7 @@ use crate::rpc::{
     RpcSnarkerJobCommitAction, RpcSnarkerJobSpecAction, RpcSnarkersWorkersGetAction,
     RpcSyncStatsGetAction,
 };
-use crate::snark::block_verify::{SnarkBlockVerifyErrorAction, SnarkBlockVerifySuccessAction};
+use crate::snark::block_verify::SnarkBlockVerifyAction;
 use crate::snark::work_verify::{SnarkWorkVerifyErrorAction, SnarkWorkVerifySuccessAction};
 use crate::snark::SnarkEvent;
 use crate::{Service, Store};
@@ -237,10 +237,10 @@ pub fn event_source_effects<S: Service>(store: &mut Store<S>, action: EventSourc
             Event::Snark(event) => match event {
                 SnarkEvent::BlockVerify(req_id, result) => match result {
                     Err(error) => {
-                        store.dispatch(SnarkBlockVerifyErrorAction { req_id, error });
+                        store.dispatch(SnarkBlockVerifyAction::Error { req_id, error });
                     }
                     Ok(()) => {
-                        store.dispatch(SnarkBlockVerifySuccessAction { req_id });
+                        store.dispatch(SnarkBlockVerifyAction::Success { req_id });
                     }
                 },
                 SnarkEvent::WorkVerify(req_id, result) => match result {

--- a/node/src/event_source/event_source_effects.rs
+++ b/node/src/event_source/event_source_effects.rs
@@ -6,7 +6,7 @@ use p2p::P2pListenEvent;
 use crate::action::CheckTimeoutsAction;
 use crate::block_producer::vrf_evaluator::BlockProducerVrfEvaluatorEvaluationSuccessAction;
 use crate::external_snark_worker::ExternalSnarkWorkerEvent;
-use crate::p2p::channels::best_tip::P2pChannelsBestTipReadyAction;
+use crate::p2p::channels::best_tip::P2pChannelsBestTipAction;
 use crate::p2p::channels::rpc::P2pChannelsRpcReadyAction;
 use crate::p2p::channels::snark::{
     P2pChannelsSnarkLibp2pReceivedAction, P2pChannelsSnarkReadyAction,
@@ -173,7 +173,7 @@ pub fn event_source_effects<S: Service>(store: &mut Store<S>, action: EventSourc
                         Ok(_) => match chan_id {
                             ChannelId::BestTipPropagation => {
                                 // TODO(binier): maybe dispatch success and then ready.
-                                store.dispatch(P2pChannelsBestTipReadyAction { peer_id });
+                                store.dispatch(P2pChannelsBestTipAction::Ready { peer_id });
                             }
                             ChannelId::SnarkPropagation => {
                                 // TODO(binier): maybe dispatch success and then ready.

--- a/node/src/external_snark_worker/external_snark_worker_actions.rs
+++ b/node/src/external_snark_worker/external_snark_worker_actions.rs
@@ -4,235 +4,133 @@ use openmina_core::snark::SnarkJobId;
 use redux::{EnablingCondition, Timestamp};
 use serde::{Deserialize, Serialize};
 
-use crate::{external_snark_worker::ExternalSnarkWorker, snark_pool::JobSummary, State};
+use crate::{snark_pool::JobSummary, State};
 
-use super::{ExternalSnarkWorkerError, ExternalSnarkWorkerState, ExternalSnarkWorkerWorkError};
+use super::{
+    ExternalSnarkWorkerError, ExternalSnarkWorkerState, ExternalSnarkWorkerWorkError,
+    SnarkWorkResult,
+};
 
-#[derive(Debug, Clone, Serialize, Deserialize, derive_more::From)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ExternalSnarkWorkerAction {
-    Start(ExternalSnarkWorkerStartAction),
-    Started(ExternalSnarkWorkerStartedAction),
-    StartTimeout(ExternalSnarkWorkerStartTimeoutAction),
-    Kill(ExternalSnarkWorkerKillAction),
-    Killed(ExternalSnarkWorkerKilledAction),
+    Start,
+    Started,
+    StartTimeout {
+        now: Timestamp,
+    },
+    Kill,
+    Killed,
 
-    SubmitWork(ExternalSnarkWorkerSubmitWorkAction),
-    WorkResult(ExternalSnarkWorkerWorkResultAction),
-    WorkError(ExternalSnarkWorkerWorkErrorAction),
-    WorkTimeout(ExternalSnarkWorkerWorkTimeoutAction),
+    SubmitWork {
+        job_id: SnarkJobId,
+        summary: JobSummary,
+    },
+    WorkResult {
+        result: SnarkWorkResult,
+    },
+    WorkError {
+        error: ExternalSnarkWorkerWorkError,
+    },
+    WorkTimeout {
+        now: Timestamp,
+    },
 
-    CancelWork(ExternalSnarkWorkerCancelWorkAction),
-    WorkCancelled(ExternalSnarkWorkerWorkCancelledAction),
+    CancelWork,
+    WorkCancelled,
 
-    PruneWork(ExternalSnarkWorkerPruneWorkAction),
+    PruneWork,
 
-    Error(ExternalSnarkWorkerErrorAction),
+    Error {
+        error: ExternalSnarkWorkerError,
+        permanent: bool,
+    },
 }
 
 pub type ExternalSnarkWorkerActionWithMeta = redux::ActionWithMeta<ExternalSnarkWorkerAction>;
 pub type ExternalSnarkWorkerActionWithMetaRef<'a> =
     redux::ActionWithMeta<&'a ExternalSnarkWorkerAction>;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ExternalSnarkWorkerStartAction {}
-
-impl EnablingCondition<State> for ExternalSnarkWorkerStartAction {
-    fn is_enabled(&self, #[allow(unused_variables)] state: &State) -> bool {
-        state.config.snarker.is_some()
-            && matches!(
+impl EnablingCondition<State> for ExternalSnarkWorkerAction {
+    fn is_enabled(&self, state: &State) -> bool {
+        match self {
+            ExternalSnarkWorkerAction::Start => {
+                state.config.snarker.is_some()
+                    && matches!(
+                        state.external_snark_worker.0.state,
+                        ExternalSnarkWorkerState::None
+                    )
+            }
+            ExternalSnarkWorkerAction::Started => {
+                matches!(
+                    state.external_snark_worker.0.state,
+                    ExternalSnarkWorkerState::Starting
+                )
+            }
+            ExternalSnarkWorkerAction::StartTimeout { now } => {
+                const TIMEOUT: Duration = Duration::from_secs(120);
+                matches!(
+                    state.external_snark_worker.0.state,
+                    ExternalSnarkWorkerState::Starting
+                ) && now
+                    .checked_sub(state.external_snark_worker.0.timestamp)
+                    .map_or(false, |d| d > TIMEOUT)
+            }
+            ExternalSnarkWorkerAction::Kill => !matches!(
                 state.external_snark_worker.0.state,
-                ExternalSnarkWorkerState::None
-            )
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ExternalSnarkWorkerStartedAction {}
-
-impl EnablingCondition<State> for ExternalSnarkWorkerStartedAction {
-    fn is_enabled(&self, #[allow(unused_variables)] state: &State) -> bool {
-        matches!(
-            state.external_snark_worker.0.state,
-            ExternalSnarkWorkerState::Starting
-        )
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ExternalSnarkWorkerStartTimeoutAction {
-    pub now: Timestamp,
-}
-
-impl EnablingCondition<State> for ExternalSnarkWorkerStartTimeoutAction {
-    fn is_enabled(&self, #[allow(unused_variables)] state: &State) -> bool {
-        const TIMEOUT: Duration = Duration::from_secs(120);
-        let ExternalSnarkWorker { state, timestamp } = &state.external_snark_worker.0;
-        matches!(state, ExternalSnarkWorkerState::Starting)
-            && self
-                .now
-                .checked_sub(*timestamp)
-                .map_or(false, |d| d > TIMEOUT)
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ExternalSnarkWorkerKillAction {}
-
-impl EnablingCondition<State> for ExternalSnarkWorkerKillAction {
-    fn is_enabled(&self, #[allow(unused_variables)] state: &State) -> bool {
-        match &state.external_snark_worker.0.state {
-            ExternalSnarkWorkerState::Error(_, false)
-            | ExternalSnarkWorkerState::None
-            | ExternalSnarkWorkerState::Killing => false,
-            _ => true,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ExternalSnarkWorkerKilledAction {}
-
-impl EnablingCondition<State> for ExternalSnarkWorkerKilledAction {
-    fn is_enabled(&self, #[allow(unused_variables)] state: &State) -> bool {
-        matches!(
-            state.external_snark_worker.0.state,
-            ExternalSnarkWorkerState::Killing
-        )
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ExternalSnarkWorkerErrorAction {
-    pub error: ExternalSnarkWorkerError,
-    pub permanent: bool,
-}
-
-impl EnablingCondition<State> for ExternalSnarkWorkerErrorAction {
-    fn is_enabled(&self, #[allow(unused_variables)] state: &State) -> bool {
-        true
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ExternalSnarkWorkerSubmitWorkAction {
-    pub job_id: SnarkJobId,
-    pub summary: JobSummary,
-}
-
-impl EnablingCondition<State> for ExternalSnarkWorkerSubmitWorkAction {
-    fn is_enabled(&self, #[allow(unused_variables)] state: &State) -> bool {
-        state.external_snark_worker.is_idle()
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ExternalSnarkWorkerCancelWorkAction {}
-
-impl EnablingCondition<State> for ExternalSnarkWorkerCancelWorkAction {
-    fn is_enabled(&self, #[allow(unused_variables)] state: &State) -> bool {
-        matches!(
-            state.external_snark_worker.0.state,
-            ExternalSnarkWorkerState::Working(..)
-        )
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ExternalSnarkWorkerWorkCancelledAction {}
-
-impl EnablingCondition<State> for ExternalSnarkWorkerWorkCancelledAction {
-    fn is_enabled(&self, #[allow(unused_variables)] state: &State) -> bool {
-        matches!(
-            state.external_snark_worker.0.state,
-            ExternalSnarkWorkerState::Cancelling(_)
-        )
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ExternalSnarkWorkerWorkResultAction {
-    pub result: super::SnarkWorkResult,
-}
-
-impl EnablingCondition<State> for ExternalSnarkWorkerWorkResultAction {
-    fn is_enabled(&self, #[allow(unused_variables)] state: &State) -> bool {
-        matches!(
-            state.external_snark_worker.0.state,
-            ExternalSnarkWorkerState::Working(..)
-        )
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ExternalSnarkWorkerWorkErrorAction {
-    pub error: ExternalSnarkWorkerWorkError,
-}
-
-impl EnablingCondition<State> for ExternalSnarkWorkerWorkErrorAction {
-    fn is_enabled(&self, #[allow(unused_variables)] state: &State) -> bool {
-        matches!(
-            state.external_snark_worker.0.state,
-            ExternalSnarkWorkerState::Working(..)
-        )
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ExternalSnarkWorkerWorkTimeoutAction {
-    pub now: Timestamp,
-}
-
-impl EnablingCondition<State> for ExternalSnarkWorkerWorkTimeoutAction {
-    fn is_enabled(&self, #[allow(unused_variables)] state: &State) -> bool {
-        if let ExternalSnarkWorkerState::Working(_, summary) = &state.external_snark_worker.0.state
-        {
-            self.now
-                .checked_sub(state.external_snark_worker.0.timestamp)
-                .map_or(false, |d| d > summary.estimated_duration())
-        } else {
-            false
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ExternalSnarkWorkerPruneWorkAction {}
-
-impl EnablingCondition<State> for ExternalSnarkWorkerPruneWorkAction {
-    fn is_enabled(&self, #[allow(unused_variables)] state: &State) -> bool {
-        matches!(
-            state.external_snark_worker.0.state,
-            ExternalSnarkWorkerState::WorkReady(..)
-                | ExternalSnarkWorkerState::WorkError(..)
-                | ExternalSnarkWorkerState::Cancelled(..)
-        )
-    }
-}
-
-macro_rules! impl_into_global_action {
-    ($($a:ty),* $(,)?) => {
-        $(
-            impl From<$a> for crate::Action {
-                fn from(value: $a) -> Self {
-                    Self::ExternalSnarkWorker(value.into())
+                ExternalSnarkWorkerState::Error(_, false)
+                    | ExternalSnarkWorkerState::None
+                    | ExternalSnarkWorkerState::Killing
+            ),
+            ExternalSnarkWorkerAction::Killed => {
+                matches!(
+                    state.external_snark_worker.0.state,
+                    ExternalSnarkWorkerState::Killing
+                )
+            }
+            ExternalSnarkWorkerAction::SubmitWork { .. } => state.external_snark_worker.is_idle(),
+            ExternalSnarkWorkerAction::WorkResult { .. } => {
+                matches!(
+                    state.external_snark_worker.0.state,
+                    ExternalSnarkWorkerState::Working(..)
+                )
+            }
+            ExternalSnarkWorkerAction::WorkError { .. } => {
+                matches!(
+                    state.external_snark_worker.0.state,
+                    ExternalSnarkWorkerState::Working(..)
+                )
+            }
+            ExternalSnarkWorkerAction::WorkTimeout { now } => {
+                if let ExternalSnarkWorkerState::Working(_, summary) =
+                    &state.external_snark_worker.0.state
+                {
+                    now.checked_sub(state.external_snark_worker.0.timestamp)
+                        .map_or(false, |d| d > summary.estimated_duration())
+                } else {
+                    false
                 }
             }
-        )*
-    };
+            ExternalSnarkWorkerAction::CancelWork => {
+                matches!(
+                    state.external_snark_worker.0.state,
+                    ExternalSnarkWorkerState::Working(..)
+                )
+            }
+            ExternalSnarkWorkerAction::WorkCancelled => {
+                matches!(
+                    state.external_snark_worker.0.state,
+                    ExternalSnarkWorkerState::Cancelling(_)
+                )
+            }
+            ExternalSnarkWorkerAction::PruneWork => {
+                matches!(
+                    state.external_snark_worker.0.state,
+                    ExternalSnarkWorkerState::WorkReady(..)
+                        | ExternalSnarkWorkerState::WorkError(..)
+                        | ExternalSnarkWorkerState::Cancelled(..)
+                )
+            }
+            ExternalSnarkWorkerAction::Error { .. } => true,
+        }
+    }
 }
-
-impl_into_global_action!(
-    ExternalSnarkWorkerStartAction,
-    ExternalSnarkWorkerStartedAction,
-    ExternalSnarkWorkerStartTimeoutAction,
-    ExternalSnarkWorkerKillAction,
-    ExternalSnarkWorkerKilledAction,
-    ExternalSnarkWorkerErrorAction,
-    ExternalSnarkWorkerSubmitWorkAction,
-    ExternalSnarkWorkerWorkResultAction,
-    ExternalSnarkWorkerWorkTimeoutAction,
-    ExternalSnarkWorkerCancelWorkAction,
-    ExternalSnarkWorkerWorkCancelledAction,
-    ExternalSnarkWorkerPruneWorkAction,
-    ExternalSnarkWorkerWorkErrorAction,
-);

--- a/node/src/external_snark_worker/external_snark_worker_effects.rs
+++ b/node/src/external_snark_worker/external_snark_worker_effects.rs
@@ -1,6 +1,6 @@
 use openmina_core::snark::Snark;
 
-use crate::snark_pool::{SnarkPoolAutoCreateCommitmentAction, SnarkPoolWorkAddAction};
+use crate::snark_pool::SnarkPoolAction;
 
 use super::{
     available_job_to_snark_worker_spec, ExternalSnarkWorkerAction,
@@ -27,7 +27,7 @@ pub fn external_snark_worker_effects<S: crate::Service>(
             }
         }
         ExternalSnarkWorkerAction::Started => {
-            store.dispatch(SnarkPoolAutoCreateCommitmentAction {});
+            store.dispatch(SnarkPoolAction::AutoCreateCommitment {});
         }
         ExternalSnarkWorkerAction::StartTimeout { .. } => {
             store.dispatch(ExternalSnarkWorkerAction::Error {
@@ -78,7 +78,7 @@ pub fn external_snark_worker_effects<S: crate::Service>(
                 proofs: result.clone(),
             };
             let sender = store.state().p2p.my_id();
-            store.dispatch(SnarkPoolWorkAddAction { snark, sender });
+            store.dispatch(SnarkPoolAction::WorkAdd { snark, sender });
             store.dispatch(ExternalSnarkWorkerAction::PruneWork);
         }
         ExternalSnarkWorkerAction::WorkError { .. } => {
@@ -100,7 +100,7 @@ pub fn external_snark_worker_effects<S: crate::Service>(
             store.dispatch(ExternalSnarkWorkerAction::PruneWork);
         }
         ExternalSnarkWorkerAction::PruneWork => {
-            store.dispatch(SnarkPoolAutoCreateCommitmentAction {});
+            store.dispatch(SnarkPoolAction::AutoCreateCommitment {});
         }
     }
 }

--- a/node/src/external_snark_worker/external_snark_worker_effects.rs
+++ b/node/src/external_snark_worker/external_snark_worker_effects.rs
@@ -27,7 +27,7 @@ pub fn external_snark_worker_effects<S: crate::Service>(
             }
         }
         ExternalSnarkWorkerAction::Started => {
-            store.dispatch(SnarkPoolAction::AutoCreateCommitment {});
+            store.dispatch(SnarkPoolAction::AutoCreateCommitment);
         }
         ExternalSnarkWorkerAction::StartTimeout { .. } => {
             store.dispatch(ExternalSnarkWorkerAction::Error {
@@ -78,6 +78,7 @@ pub fn external_snark_worker_effects<S: crate::Service>(
                 proofs: result.clone(),
             };
             let sender = store.state().p2p.my_id();
+            // Directly add snark to the snark pool as it's produced by us.
             store.dispatch(SnarkPoolAction::WorkAdd { snark, sender });
             store.dispatch(ExternalSnarkWorkerAction::PruneWork);
         }
@@ -100,7 +101,7 @@ pub fn external_snark_worker_effects<S: crate::Service>(
             store.dispatch(ExternalSnarkWorkerAction::PruneWork);
         }
         ExternalSnarkWorkerAction::PruneWork => {
-            store.dispatch(SnarkPoolAction::AutoCreateCommitment {});
+            store.dispatch(SnarkPoolAction::AutoCreateCommitment);
         }
     }
 }

--- a/node/src/external_snark_worker/external_snark_worker_reducer.rs
+++ b/node/src/external_snark_worker/external_snark_worker_reducer.rs
@@ -13,60 +13,60 @@ impl ExternalSnarkWorker {
     pub fn reducer(&mut self, action: ExternalSnarkWorkerActionWithMetaRef<'_>) {
         let (action, meta) = action.split();
         match action {
-            ExternalSnarkWorkerAction::Start(_) => {
+            ExternalSnarkWorkerAction::Start => {
                 self.state = ExternalSnarkWorkerState::Starting;
             }
-            ExternalSnarkWorkerAction::Started(_) => {
+            ExternalSnarkWorkerAction::Started => {
                 self.state = ExternalSnarkWorkerState::Idle;
             }
-            ExternalSnarkWorkerAction::StartTimeout(_) => {
+            ExternalSnarkWorkerAction::StartTimeout { .. } => {
                 return;
             }
-            ExternalSnarkWorkerAction::Kill(_) => {
+            ExternalSnarkWorkerAction::Kill => {
                 self.state = ExternalSnarkWorkerState::Killing;
             }
-            ExternalSnarkWorkerAction::Killed(_) => {
+            ExternalSnarkWorkerAction::Killed => {
                 self.state = ExternalSnarkWorkerState::None;
             }
-            ExternalSnarkWorkerAction::Error(a) => {
-                self.state = ExternalSnarkWorkerState::Error(a.error.clone(), a.permanent);
+            ExternalSnarkWorkerAction::Error { error, permanent } => {
+                self.state = ExternalSnarkWorkerState::Error(error.clone(), *permanent);
             }
-            ExternalSnarkWorkerAction::SubmitWork(action) => {
+            ExternalSnarkWorkerAction::SubmitWork { job_id, summary } => {
                 self.state = ExternalSnarkWorkerState::Working(
-                    action.job_id.clone(),
-                    action.summary.clone(),
+                    job_id.clone(),
+                    summary.clone(),
                 );
             }
-            ExternalSnarkWorkerAction::WorkResult(action) => {
+            ExternalSnarkWorkerAction::WorkResult { result } => {
                 let ExternalSnarkWorkerState::Working(job_id, _) = &self.state else {
                     return;
                 };
                 self.state =
-                    ExternalSnarkWorkerState::WorkReady(job_id.clone(), action.result.clone());
+                    ExternalSnarkWorkerState::WorkReady(job_id.clone(), result.clone());
             }
-            ExternalSnarkWorkerAction::WorkError(action) => {
+            ExternalSnarkWorkerAction::WorkError { error } => {
                 let ExternalSnarkWorkerState::Working(job_id, _) = &self.state else {
                     return;
                 };
                 self.state =
-                    ExternalSnarkWorkerState::WorkError(job_id.clone(), action.error.clone());
+                    ExternalSnarkWorkerState::WorkError(job_id.clone(), error.clone());
             }
-            ExternalSnarkWorkerAction::WorkTimeout(_) => {
+            ExternalSnarkWorkerAction::WorkTimeout { .. } => {
                 return;
             }
-            ExternalSnarkWorkerAction::CancelWork(_) => {
+            ExternalSnarkWorkerAction::CancelWork => {
                 let ExternalSnarkWorkerState::Working(job_id, _) = &self.state else {
                     return;
                 };
                 self.state = ExternalSnarkWorkerState::Cancelling(job_id.clone());
             }
-            ExternalSnarkWorkerAction::WorkCancelled(_) => {
+            ExternalSnarkWorkerAction::WorkCancelled => {
                 let ExternalSnarkWorkerState::Cancelling(job_id) = &self.state else {
                     return;
                 };
                 self.state = ExternalSnarkWorkerState::Cancelled(job_id.clone());
             }
-            ExternalSnarkWorkerAction::PruneWork(_) => {
+            ExternalSnarkWorkerAction::PruneWork => {
                 self.state = ExternalSnarkWorkerState::Idle;
             }
         }

--- a/node/src/logger/logger_effects.rs
+++ b/node/src/logger/logger_effects.rs
@@ -420,40 +420,48 @@ pub fn logger_effects<S: Service>(store: &Store<S>, action: ActionWithMetaRef<'_
                     _ => {}
                 },
                 P2pChannelsAction::Rpc(action) => match action {
-                    P2pChannelsRpcAction::Init(action) => {
+                    P2pChannelsRpcAction::Init { peer_id } => {
                         openmina_core::log::debug!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {}", action.peer_id),
-                            peer_id = action.peer_id.to_string()
+                            summary = format!("peer_id: {peer_id}", ),
+                            peer_id = peer_id.to_string()
                         );
                     }
-                    P2pChannelsRpcAction::Ready(action) => {
+                    P2pChannelsRpcAction::Ready { peer_id } => {
                         openmina_core::log::debug!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {}", action.peer_id),
-                            peer_id = action.peer_id.to_string()
+                            summary = format!("peer_id: {peer_id}", ),
+                            peer_id = peer_id.to_string()
                         );
                     }
-                    P2pChannelsRpcAction::RequestSend(action) => {
+                    P2pChannelsRpcAction::RequestSend {
+                        peer_id,
+                        id,
+                        request,
+                    } => {
                         openmina_core::log::debug!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {}, rpc_id: {}, kind: {:?}", action.peer_id, action.id, action.request.kind()),
-                            peer_id = action.peer_id.to_string(),
-                            rpc_id = action.id.to_string(),
-                            trace_request = serde_json::to_string(&action.request).ok()
+                            summary = format!("peer_id: {peer_id}, rpc_id: {id}, kind: {:?}", request.kind()),
+                            peer_id = peer_id.to_string(),
+                            rpc_id = id.to_string(),
+                            trace_request = serde_json::to_string(request).ok()
                         );
                     }
-                    P2pChannelsRpcAction::ResponseReceived(action) => {
+                    P2pChannelsRpcAction::ResponseReceived {
+                        peer_id,
+                        id,
+                        response,
+                    } => {
                         openmina_core::log::debug!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {}, rpc_id: {}", action.peer_id, action.id),
-                            peer_id = action.peer_id.to_string(),
-                            rpc_id = action.id.to_string(),
-                            trace_response = serde_json::to_string(&action.response).ok()
+                            summary = format!("peer_id: {peer_id}, rpc_id: {id}"),
+                            peer_id = peer_id.to_string(),
+                            rpc_id = id.to_string(),
+                            trace_response = serde_json::to_string(response).ok()
                         );
                     }
                     _ => {}

--- a/node/src/logger/logger_effects.rs
+++ b/node/src/logger/logger_effects.rs
@@ -363,20 +363,20 @@ pub fn logger_effects<S: Service>(store: &Store<S>, action: ActionWithMetaRef<'_
             P2pAction::Channels(action) => match action {
                 P2pChannelsAction::MessageReceived(_) => {}
                 P2pChannelsAction::BestTip(action) => match action {
-                    P2pChannelsBestTipAction::Init(action) => {
+                    P2pChannelsBestTipAction::Init { peer_id } => {
                         openmina_core::log::debug!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {}", action.peer_id),
-                            peer_id = action.peer_id.to_string()
+                            summary = format!("peer_id: {peer_id}"),
+                            peer_id = peer_id.to_string()
                         );
                     }
-                    P2pChannelsBestTipAction::Ready(action) => {
+                    P2pChannelsBestTipAction::Ready { peer_id } => {
                         openmina_core::log::debug!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {}", action.peer_id),
-                            peer_id = action.peer_id.to_string()
+                            summary = format!("peer_id: {peer_id}"),
+                            peer_id = peer_id.to_string()
                         );
                     }
                     _ => {}

--- a/node/src/logger/logger_effects.rs
+++ b/node/src/logger/logger_effects.rs
@@ -525,39 +525,43 @@ pub fn logger_effects<S: Service>(store: &Store<S>, action: ActionWithMetaRef<'_
         }
         Action::Snark(a) => match a {
             SnarkAction::WorkVerify(a) => match a {
-                SnarkWorkVerifyAction::Init(a) => {
+                SnarkWorkVerifyAction::Init {
+                    req_id,
+                    batch,
+                    sender,
+                } => {
                     openmina_core::log::info!(
                         meta.time();
                         kind = kind.to_string(),
-                        summary = format!("id: {}, batch size: {}", a.req_id, a.batch.len()),
-                        peer_id = a.sender,
-                        rpc_id = a.req_id.to_string(),
-                        trace_batch = serde_json::to_string(&a.batch.iter().map(|v| v.job_id()).collect::<Vec<_>>()).ok()
+                        summary = format!("id: {}, batch size: {}", req_id, batch.len()),
+                        peer_id = sender,
+                        rpc_id = req_id.to_string(),
+                        trace_batch = serde_json::to_string(&batch.iter().map(|v| v.job_id()).collect::<Vec<_>>()).ok()
                     );
                 }
-                SnarkWorkVerifyAction::Error(a) => {
-                    let Some(req) = store.state().snark.work_verify.jobs.get(a.req_id) else {
+                SnarkWorkVerifyAction::Error { req_id, .. } => {
+                    let Some(req) = store.state().snark.work_verify.jobs.get(*req_id) else {
                         return;
                     };
                     openmina_core::log::warn!(
                         meta.time();
                         kind = kind.to_string(),
-                        summary = format!("id: {}, batch size: {}", a.req_id, req.batch().len()),
+                        summary = format!("id: {}, batch size: {}", req_id, req.batch().len()),
                         peer_id = req.sender(),
-                        rpc_id = a.req_id.to_string(),
+                        rpc_id = req_id.to_string(),
                         trace_batch = serde_json::to_string(&req.batch().iter().map(|v| v.job_id()).collect::<Vec<_>>()).ok()
                     );
                 }
-                SnarkWorkVerifyAction::Success(a) => {
-                    let Some(req) = store.state().snark.work_verify.jobs.get(a.req_id) else {
+                SnarkWorkVerifyAction::Success { req_id } => {
+                    let Some(req) = store.state().snark.work_verify.jobs.get(*req_id) else {
                         return;
                     };
                     openmina_core::log::info!(
                         meta.time();
                         kind = kind.to_string(),
-                        summary = format!("id: {}, batch size: {}", a.req_id, req.batch().len()),
+                        summary = format!("id: {}, batch size: {}", req_id, req.batch().len()),
                         peer_id = req.sender(),
-                        rpc_id = a.req_id.to_string(),
+                        rpc_id = req_id.to_string(),
                         trace_batch = serde_json::to_string(&req.batch().iter().map(|v| v.job_id()).collect::<Vec<_>>()).ok()
                     );
                 }

--- a/node/src/logger/logger_effects.rs
+++ b/node/src/logger/logger_effects.rs
@@ -401,20 +401,20 @@ pub fn logger_effects<S: Service>(store: &Store<S>, action: ActionWithMetaRef<'_
                     _ => {}
                 },
                 P2pChannelsAction::SnarkJobCommitment(action) => match action {
-                    P2pChannelsSnarkJobCommitmentAction::Init(action) => {
+                    P2pChannelsSnarkJobCommitmentAction::Init { peer_id } => {
                         openmina_core::log::debug!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {}", action.peer_id),
-                            peer_id = action.peer_id.to_string()
+                            summary = format!("peer_id: {}", peer_id),
+                            peer_id = peer_id.to_string()
                         );
                     }
-                    P2pChannelsSnarkJobCommitmentAction::Ready(action) => {
+                    P2pChannelsSnarkJobCommitmentAction::Ready { peer_id } => {
                         openmina_core::log::debug!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {}", action.peer_id),
-                            peer_id = action.peer_id.to_string()
+                            summary = format!("peer_id: {}", peer_id),
+                            peer_id = peer_id.to_string()
                         );
                     }
                     _ => {}

--- a/node/src/logger/logger_effects.rs
+++ b/node/src/logger/logger_effects.rs
@@ -382,20 +382,20 @@ pub fn logger_effects<S: Service>(store: &Store<S>, action: ActionWithMetaRef<'_
                     _ => {}
                 },
                 P2pChannelsAction::Snark(action) => match action {
-                    P2pChannelsSnarkAction::Init(action) => {
+                    P2pChannelsSnarkAction::Init { peer_id } => {
                         openmina_core::log::debug!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {}", action.peer_id),
-                            peer_id = action.peer_id.to_string()
+                            summary = format!("peer_id: {peer_id}", ),
+                            peer_id = peer_id.to_string()
                         );
                     }
-                    P2pChannelsSnarkAction::Ready(action) => {
+                    P2pChannelsSnarkAction::Ready { peer_id } => {
                         openmina_core::log::debug!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {}", action.peer_id),
-                            peer_id = action.peer_id.to_string()
+                            summary = format!("peer_id: {peer_id}", ),
+                            peer_id = peer_id.to_string()
                         );
                     }
                     _ => {}

--- a/node/src/logger/logger_effects.rs
+++ b/node/src/logger/logger_effects.rs
@@ -464,58 +464,58 @@ pub fn logger_effects<S: Service>(store: &Store<S>, action: ActionWithMetaRef<'_
         Action::ExternalSnarkWorker(a) => {
             use crate::external_snark_worker::ExternalSnarkWorkerAction;
             match a {
-                ExternalSnarkWorkerAction::Start(_)
-                | ExternalSnarkWorkerAction::Started(_)
-                | ExternalSnarkWorkerAction::Kill(_)
-                | ExternalSnarkWorkerAction::Killed(_)
-                | ExternalSnarkWorkerAction::WorkCancelled(_)
-                | ExternalSnarkWorkerAction::PruneWork(_) => {
+                ExternalSnarkWorkerAction::Start
+                | ExternalSnarkWorkerAction::Started
+                | ExternalSnarkWorkerAction::Kill
+                | ExternalSnarkWorkerAction::Killed
+                | ExternalSnarkWorkerAction::WorkCancelled
+                | ExternalSnarkWorkerAction::PruneWork => {
                     openmina_core::log::debug!(
                         meta.time();
                         kind = kind.to_string(),
                         trace_action = serde_json::to_string(&a).ok()
                     )
                 }
-                ExternalSnarkWorkerAction::SubmitWork(a) => {
+                ExternalSnarkWorkerAction::SubmitWork { job_id, .. } => {
                     openmina_core::log::info!(
                         meta.time();
                         kind = kind.to_string(),
-                        work_id = a.job_id.to_string(),
+                        work_id = job_id.to_string(),
                     )
                 }
-                ExternalSnarkWorkerAction::WorkResult(_) => {
-                    openmina_core::log::info!(
-                        meta.time();
-                        kind = kind.to_string(),
-                    )
-                }
-                ExternalSnarkWorkerAction::CancelWork(_) => {
+                ExternalSnarkWorkerAction::WorkResult { .. } => {
                     openmina_core::log::info!(
                         meta.time();
                         kind = kind.to_string(),
                     )
                 }
-                ExternalSnarkWorkerAction::WorkError(a) => {
+                ExternalSnarkWorkerAction::CancelWork => {
+                    openmina_core::log::info!(
+                        meta.time();
+                        kind = kind.to_string(),
+                    )
+                }
+                ExternalSnarkWorkerAction::WorkError { error, .. } => {
                     openmina_core::log::warn!(
                         meta.time();
                         kind = kind.to_string(),
-                        error = a.error.to_string(),
+                        error = error.to_string(),
                     )
                 }
-                ExternalSnarkWorkerAction::Error(a) => {
+                ExternalSnarkWorkerAction::Error { error, .. } => {
                     openmina_core::log::info!(
                         meta.time();
                         kind = kind.to_string(),
-                        error = a.error.to_string(),
+                        error = error.to_string(),
                     )
                 }
-                ExternalSnarkWorkerAction::StartTimeout(_) => {
+                ExternalSnarkWorkerAction::StartTimeout { .. } => {
                     openmina_core::log::warn!(
                         meta.time();
                         kind = kind.to_string(),
                     )
                 }
-                ExternalSnarkWorkerAction::WorkTimeout(_) => {
+                ExternalSnarkWorkerAction::WorkTimeout { .. } => {
                     openmina_core::log::warn!(
                         meta.time();
                         kind = kind.to_string(),

--- a/node/src/p2p/channels/best_tip/p2p_channels_best_tip_actions.rs
+++ b/node/src/p2p/channels/best_tip/p2p_channels_best_tip_actions.rs
@@ -1,42 +1,6 @@
 use super::*;
 
-impl redux::EnablingCondition<crate::State> for P2pChannelsBestTipInitAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pChannelsBestTipPendingAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pChannelsBestTipReadyAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pChannelsBestTipRequestSendAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pChannelsBestTipReceivedAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pChannelsBestTipRequestReceivedAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pChannelsBestTipResponseSendAction {
+impl redux::EnablingCondition<crate::State> for P2pChannelsBestTipAction {
     fn is_enabled(&self, state: &crate::State) -> bool {
         self.is_enabled(&state.p2p)
     }

--- a/node/src/p2p/channels/rpc/p2p_channels_rpc_actions.rs
+++ b/node/src/p2p/channels/rpc/p2p_channels_rpc_actions.rs
@@ -1,52 +1,13 @@
 use super::*;
 
-impl redux::EnablingCondition<crate::State> for P2pChannelsRpcInitAction {
+impl redux::EnablingCondition<crate::State> for P2pChannelsRpcAction {
     fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pChannelsRpcPendingAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pChannelsRpcReadyAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pChannelsRpcRequestSendAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pChannelsRpcTimeoutAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-            && state
-                .p2p
-                .is_peer_rpc_timed_out(&self.peer_id, self.id, state.time())
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pChannelsRpcResponseReceivedAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pChannelsRpcRequestReceivedAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pChannelsRpcResponseSendAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+        match self {
+            Self::Timeout { peer_id, id } => {
+                self.is_enabled(&state.p2p)
+                    && state.p2p.is_peer_rpc_timed_out(peer_id, *id, state.time())
+            }
+            _ => self.is_enabled(&state.p2p),
+        }
     }
 }

--- a/node/src/p2p/channels/snark/p2p_channels_snark_actions.rs
+++ b/node/src/p2p/channels/snark/p2p_channels_snark_actions.rs
@@ -1,60 +1,6 @@
 use super::*;
 
-impl redux::EnablingCondition<crate::State> for P2pChannelsSnarkInitAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pChannelsSnarkPendingAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pChannelsSnarkReadyAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pChannelsSnarkRequestSendAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pChannelsSnarkPromiseReceivedAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pChannelsSnarkReceivedAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pChannelsSnarkRequestReceivedAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pChannelsSnarkResponseSendAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pChannelsSnarkLibp2pReceivedAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pChannelsSnarkLibp2pBroadcastAction {
+impl redux::EnablingCondition<crate::State> for P2pChannelsSnarkAction {
     fn is_enabled(&self, state: &crate::State) -> bool {
         self.is_enabled(&state.p2p)
     }

--- a/node/src/p2p/channels/snark_job_commitment/p2p_channels_snark_job_commitment_actions.rs
+++ b/node/src/p2p/channels/snark_job_commitment/p2p_channels_snark_job_commitment_actions.rs
@@ -1,48 +1,6 @@
 use super::*;
 
-impl redux::EnablingCondition<crate::State> for P2pChannelsSnarkJobCommitmentInitAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pChannelsSnarkJobCommitmentPendingAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pChannelsSnarkJobCommitmentReadyAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pChannelsSnarkJobCommitmentRequestSendAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pChannelsSnarkJobCommitmentPromiseReceivedAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pChannelsSnarkJobCommitmentReceivedAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pChannelsSnarkJobCommitmentRequestReceivedAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pChannelsSnarkJobCommitmentResponseSendAction {
+impl redux::EnablingCondition<crate::State> for P2pChannelsSnarkJobCommitmentAction {
     fn is_enabled(&self, state: &crate::State) -> bool {
         self.is_enabled(&state.p2p)
     }

--- a/node/src/p2p/mod.rs
+++ b/node/src/p2p/mod.rs
@@ -97,13 +97,7 @@ impl_into_global_action!(discovery::P2pDiscoveryKademliaAddRouteAction);
 
 impl_into_global_action!(channels::P2pChannelsMessageReceivedAction);
 
-impl_into_global_action!(channels::best_tip::P2pChannelsBestTipInitAction);
-impl_into_global_action!(channels::best_tip::P2pChannelsBestTipPendingAction);
-impl_into_global_action!(channels::best_tip::P2pChannelsBestTipReadyAction);
-impl_into_global_action!(channels::best_tip::P2pChannelsBestTipRequestSendAction);
-impl_into_global_action!(channels::best_tip::P2pChannelsBestTipReceivedAction);
-impl_into_global_action!(channels::best_tip::P2pChannelsBestTipRequestReceivedAction);
-impl_into_global_action!(channels::best_tip::P2pChannelsBestTipResponseSendAction);
+impl_into_global_action!(channels::best_tip::P2pChannelsBestTipAction);
 
 impl_into_global_action!(channels::snark::P2pChannelsSnarkInitAction);
 impl_into_global_action!(channels::snark::P2pChannelsSnarkPendingAction);

--- a/node/src/p2p/mod.rs
+++ b/node/src/p2p/mod.rs
@@ -103,11 +103,4 @@ impl_into_global_action!(channels::snark::P2pChannelsSnarkAction);
 
 impl_into_global_action!(channels::snark_job_commitment::P2pChannelsSnarkJobCommitmentAction);
 
-impl_into_global_action!(channels::rpc::P2pChannelsRpcInitAction);
-impl_into_global_action!(channels::rpc::P2pChannelsRpcPendingAction);
-impl_into_global_action!(channels::rpc::P2pChannelsRpcReadyAction);
-impl_into_global_action!(channels::rpc::P2pChannelsRpcRequestSendAction);
-impl_into_global_action!(channels::rpc::P2pChannelsRpcTimeoutAction);
-impl_into_global_action!(channels::rpc::P2pChannelsRpcResponseReceivedAction);
-impl_into_global_action!(channels::rpc::P2pChannelsRpcRequestReceivedAction);
-impl_into_global_action!(channels::rpc::P2pChannelsRpcResponseSendAction);
+impl_into_global_action!(channels::rpc::P2pChannelsRpcAction);

--- a/node/src/p2p/mod.rs
+++ b/node/src/p2p/mod.rs
@@ -99,16 +99,7 @@ impl_into_global_action!(channels::P2pChannelsMessageReceivedAction);
 
 impl_into_global_action!(channels::best_tip::P2pChannelsBestTipAction);
 
-impl_into_global_action!(channels::snark::P2pChannelsSnarkInitAction);
-impl_into_global_action!(channels::snark::P2pChannelsSnarkPendingAction);
-impl_into_global_action!(channels::snark::P2pChannelsSnarkReadyAction);
-impl_into_global_action!(channels::snark::P2pChannelsSnarkRequestSendAction);
-impl_into_global_action!(channels::snark::P2pChannelsSnarkPromiseReceivedAction);
-impl_into_global_action!(channels::snark::P2pChannelsSnarkReceivedAction);
-impl_into_global_action!(channels::snark::P2pChannelsSnarkRequestReceivedAction);
-impl_into_global_action!(channels::snark::P2pChannelsSnarkResponseSendAction);
-impl_into_global_action!(channels::snark::P2pChannelsSnarkLibp2pReceivedAction);
-impl_into_global_action!(channels::snark::P2pChannelsSnarkLibp2pBroadcastAction);
+impl_into_global_action!(channels::snark::P2pChannelsSnarkAction);
 
 impl_into_global_action!(channels::snark_job_commitment::P2pChannelsSnarkJobCommitmentAction);
 

--- a/node/src/p2p/mod.rs
+++ b/node/src/p2p/mod.rs
@@ -110,26 +110,7 @@ impl_into_global_action!(channels::snark::P2pChannelsSnarkResponseSendAction);
 impl_into_global_action!(channels::snark::P2pChannelsSnarkLibp2pReceivedAction);
 impl_into_global_action!(channels::snark::P2pChannelsSnarkLibp2pBroadcastAction);
 
-impl_into_global_action!(channels::snark_job_commitment::P2pChannelsSnarkJobCommitmentInitAction);
-impl_into_global_action!(
-    channels::snark_job_commitment::P2pChannelsSnarkJobCommitmentPendingAction
-);
-impl_into_global_action!(channels::snark_job_commitment::P2pChannelsSnarkJobCommitmentReadyAction);
-impl_into_global_action!(
-    channels::snark_job_commitment::P2pChannelsSnarkJobCommitmentRequestSendAction
-);
-impl_into_global_action!(
-    channels::snark_job_commitment::P2pChannelsSnarkJobCommitmentPromiseReceivedAction
-);
-impl_into_global_action!(
-    channels::snark_job_commitment::P2pChannelsSnarkJobCommitmentReceivedAction
-);
-impl_into_global_action!(
-    channels::snark_job_commitment::P2pChannelsSnarkJobCommitmentRequestReceivedAction
-);
-impl_into_global_action!(
-    channels::snark_job_commitment::P2pChannelsSnarkJobCommitmentResponseSendAction
-);
+impl_into_global_action!(channels::snark_job_commitment::P2pChannelsSnarkJobCommitmentAction);
 
 impl_into_global_action!(channels::rpc::P2pChannelsRpcInitAction);
 impl_into_global_action!(channels::rpc::P2pChannelsRpcPendingAction);

--- a/node/src/p2p/p2p_effects.rs
+++ b/node/src/p2p/p2p_effects.rs
@@ -1,7 +1,7 @@
 use mina_p2p_messages::v2::{MinaLedgerSyncLedgerAnswerStableV2, StateHash};
 use openmina_core::block::BlockWithHash;
 
-use crate::consensus::{ConsensusBlockChainProofUpdateAction, ConsensusBlockReceivedAction};
+use crate::consensus::ConsensusAction;
 use crate::rpc::{
     RpcP2pConnectionIncomingErrorAction, RpcP2pConnectionIncomingRespondAction,
     RpcP2pConnectionIncomingSuccessAction, RpcP2pConnectionOutgoingErrorAction,
@@ -489,7 +489,7 @@ pub fn p2p_effects<S: Service>(store: &mut Store<S>, action: P2pActionWithMeta) 
                                     return;
                                 }
                             }
-                            store.dispatch(ConsensusBlockChainProofUpdateAction {
+                            store.dispatch(ConsensusAction::BlockChainProofUpdate {
                                 hash: best_tip.hash,
                                 chain_proof: (hashes, root_block),
                             });
@@ -685,7 +685,7 @@ pub fn p2p_effects<S: Service>(store: &mut Store<S>, action: P2pActionWithMeta) 
                 action.effects(&meta, store);
             }
             P2pPeerAction::BestTipUpdate(action) => {
-                store.dispatch(ConsensusBlockReceivedAction {
+                store.dispatch(ConsensusAction::BlockReceived {
                     hash: action.best_tip.hash,
                     block: action.best_tip.block,
                     chain_proof: None,

--- a/node/src/p2p/p2p_effects.rs
+++ b/node/src/p2p/p2p_effects.rs
@@ -8,7 +8,7 @@ use crate::rpc::{
     RpcP2pConnectionOutgoingSuccessAction,
 };
 use crate::snark_pool::candidate::SnarkPoolCandidateAction;
-use crate::snark_pool::SnarkPoolJobCommitmentAddAction;
+use crate::snark_pool::SnarkPoolAction;
 use crate::transition_frontier::sync::ledger::snarked::{
     PeerLedgerQueryError, PeerLedgerQueryResponse,
     TransitionFrontierSyncLedgerSnarkedPeerQueryErrorAction,
@@ -348,7 +348,7 @@ pub fn p2p_effects<S: Service>(store: &mut Store<S>, action: P2pActionWithMeta) 
                     commitment,
                 } = action
                 {
-                    store.dispatch(SnarkPoolJobCommitmentAddAction {
+                    store.dispatch(SnarkPoolAction::CommitmentAdd {
                         commitment,
                         sender: peer_id,
                     });

--- a/node/src/p2p/p2p_effects.rs
+++ b/node/src/p2p/p2p_effects.rs
@@ -357,30 +357,20 @@ pub fn p2p_effects<S: Service>(store: &mut Store<S>, action: P2pActionWithMeta) 
                     action.effects(&meta, store);
                 }
             },
-            P2pChannelsAction::SnarkJobCommitment(action) => match action {
-                P2pChannelsSnarkJobCommitmentAction::Init(action) => {
-                    action.effects(&meta, store);
-                }
-                P2pChannelsSnarkJobCommitmentAction::Pending(_) => {}
-                P2pChannelsSnarkJobCommitmentAction::Ready(action) => {
-                    action.effects(&meta, store);
-                }
-                P2pChannelsSnarkJobCommitmentAction::RequestSend(action) => {
-                    action.effects(&meta, store);
-                }
-                P2pChannelsSnarkJobCommitmentAction::PromiseReceived(_) => {}
-                P2pChannelsSnarkJobCommitmentAction::Received(action) => {
-                    action.effects(&meta, store);
+            P2pChannelsAction::SnarkJobCommitment(action) => {
+                // TODO: does the order matter here? if not this clone can be removed
+                action.clone().effects(&meta, store);
+                if let P2pChannelsSnarkJobCommitmentAction::Received {
+                    peer_id,
+                    commitment,
+                } = action
+                {
                     store.dispatch(SnarkPoolJobCommitmentAddAction {
-                        commitment: action.commitment,
-                        sender: action.peer_id,
+                        commitment,
+                        sender: peer_id,
                     });
                 }
-                P2pChannelsSnarkJobCommitmentAction::RequestReceived(_) => {}
-                P2pChannelsSnarkJobCommitmentAction::ResponseSend(action) => {
-                    action.effects(&meta, store);
-                }
-            },
+            }
             P2pChannelsAction::Rpc(action) => match action {
                 P2pChannelsRpcAction::Init(action) => {
                     action.effects(&meta, store);

--- a/node/src/p2p/p2p_effects.rs
+++ b/node/src/p2p/p2p_effects.rs
@@ -7,10 +7,7 @@ use crate::rpc::{
     RpcP2pConnectionIncomingSuccessAction, RpcP2pConnectionOutgoingErrorAction,
     RpcP2pConnectionOutgoingSuccessAction,
 };
-use crate::snark_pool::candidate::{
-    SnarkPoolCandidateInfoReceivedAction, SnarkPoolCandidatePeerPruneAction,
-    SnarkPoolCandidateWorkReceivedAction,
-};
+use crate::snark_pool::candidate::SnarkPoolCandidateAction;
 use crate::snark_pool::SnarkPoolJobCommitmentAddAction;
 use crate::transition_frontier::sync::ledger::snarked::{
     PeerLedgerQueryError, PeerLedgerQueryResponse,
@@ -262,7 +259,7 @@ pub fn p2p_effects<S: Service>(store: &mut Store<S>, action: P2pActionWithMeta) 
                     store.dispatch(action);
                 }
 
-                store.dispatch(SnarkPoolCandidatePeerPruneAction {
+                store.dispatch(SnarkPoolCandidateAction::PeerPrune {
                     peer_id: action.peer_id,
                 });
             }
@@ -356,7 +353,7 @@ pub fn p2p_effects<S: Service>(store: &mut Store<S>, action: P2pActionWithMeta) 
                 P2pChannelsSnarkAction::PromiseReceived(_) => {}
                 P2pChannelsSnarkAction::Received(action) => {
                     action.effects(&meta, store);
-                    store.dispatch(SnarkPoolCandidateInfoReceivedAction {
+                    store.dispatch(SnarkPoolCandidateAction::InfoReceived {
                         peer_id: action.peer_id,
                         info: action.snark,
                     });
@@ -366,7 +363,7 @@ pub fn p2p_effects<S: Service>(store: &mut Store<S>, action: P2pActionWithMeta) 
                     action.effects(&meta, store);
                 }
                 P2pChannelsSnarkAction::Libp2pReceived(action) => {
-                    store.dispatch(SnarkPoolCandidateWorkReceivedAction {
+                    store.dispatch(SnarkPoolCandidateAction::WorkReceived {
                         peer_id: action.peer_id,
                         work: action.snark,
                     });
@@ -541,7 +538,7 @@ pub fn p2p_effects<S: Service>(store: &mut Store<S>, action: P2pActionWithMeta) 
                             });
                         }
                         Some(P2pRpcResponse::Snark(snark)) => {
-                            store.dispatch(SnarkPoolCandidateWorkReceivedAction {
+                            store.dispatch(SnarkPoolCandidateAction::WorkReceived {
                                 peer_id: action.peer_id,
                                 work: snark.clone(),
                             });

--- a/node/src/rpc/rpc_effects.rs
+++ b/node/src/rpc/rpc_effects.rs
@@ -7,7 +7,7 @@ use crate::p2p::connection::incoming::P2pConnectionIncomingInitAction;
 use crate::p2p::connection::outgoing::P2pConnectionOutgoingInitAction;
 use crate::p2p::connection::P2pConnectionResponse;
 use crate::rpc::{PeerConnectionStatus, RpcPeerInfo};
-use crate::snark_pool::SnarkPoolCommitmentCreateAction;
+use crate::snark_pool::SnarkPoolAction;
 use crate::{Service, Store};
 
 use super::{
@@ -369,7 +369,7 @@ pub fn rpc_effects<S: Service>(store: &mut Store<S>, action: RpcActionWithMeta) 
             {
                 return;
             }
-            store.dispatch(SnarkPoolCommitmentCreateAction { job_id });
+            store.dispatch(SnarkPoolAction::CommitmentCreate { job_id });
         }
         RpcAction::SnarkerJobSpec(action) => {
             let job_id = action.job_id;

--- a/node/src/snark/block_verify/snark_block_verify_actions.rs
+++ b/node/src/snark/block_verify/snark_block_verify_actions.rs
@@ -1,49 +1,13 @@
 use super::*;
 
-impl redux::EnablingCondition<crate::State> for SnarkBlockVerifyInitAction {
+impl redux::EnablingCondition<crate::State> for SnarkBlockVerifyAction {
     fn is_enabled(&self, state: &crate::State) -> bool {
         self.is_enabled(&state.snark)
     }
 }
 
-impl redux::EnablingCondition<crate::State> for SnarkBlockVerifyPendingAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.snark)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for SnarkBlockVerifyErrorAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.snark)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for SnarkBlockVerifySuccessAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.snark)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for SnarkBlockVerifyFinishAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.snark)
-    }
-}
-
-impl From<SnarkBlockVerifyInitAction> for crate::Action {
-    fn from(a: SnarkBlockVerifyInitAction) -> Self {
-        Self::Snark(a.into())
-    }
-}
-
-impl From<SnarkBlockVerifyErrorAction> for crate::Action {
-    fn from(a: SnarkBlockVerifyErrorAction) -> Self {
-        Self::Snark(a.into())
-    }
-}
-
-impl From<SnarkBlockVerifySuccessAction> for crate::Action {
-    fn from(a: SnarkBlockVerifySuccessAction) -> Self {
-        Self::Snark(a.into())
+impl From<SnarkBlockVerifyAction> for crate::Action {
+    fn from(value: SnarkBlockVerifyAction) -> Self {
+        Self::Snark(value.into())
     }
 }

--- a/node/src/snark/snark_effects.rs
+++ b/node/src/snark/snark_effects.rs
@@ -1,7 +1,5 @@
 use crate::consensus::ConsensusBlockSnarkVerifySuccessAction;
-use crate::snark_pool::candidate::{
-    SnarkPoolCandidateWorkVerifyErrorAction, SnarkPoolCandidateWorkVerifySuccessAction,
-};
+use crate::snark_pool::candidate::SnarkPoolCandidateAction;
 use crate::snark_pool::SnarkPoolWorkAddAction;
 use crate::{Service, Store};
 
@@ -41,7 +39,7 @@ pub fn snark_effects<S: Service>(store: &mut Store<S>, action: SnarkActionWithMe
                 let Some(req) = req else { return };
                 let sender = req.sender().parse().unwrap();
 
-                store.dispatch(SnarkPoolCandidateWorkVerifyErrorAction {
+                store.dispatch(SnarkPoolCandidateAction::WorkVerifyError {
                     peer_id: sender,
                     verify_id: a.req_id,
                 });
@@ -53,7 +51,7 @@ pub fn snark_effects<S: Service>(store: &mut Store<S>, action: SnarkActionWithMe
                 let sender = req.sender().parse().unwrap();
                 let batch = req.batch().to_vec();
 
-                store.dispatch(SnarkPoolCandidateWorkVerifySuccessAction {
+                store.dispatch(SnarkPoolCandidateAction::WorkVerifySuccess {
                     peer_id: sender,
                     verify_id: a.req_id,
                 });

--- a/node/src/snark/snark_effects.rs
+++ b/node/src/snark/snark_effects.rs
@@ -11,24 +11,16 @@ pub fn snark_effects<S: Service>(store: &mut Store<S>, action: SnarkActionWithMe
     let (action, meta) = action.split();
 
     match action {
-        SnarkAction::BlockVerify(a) => match a {
-            SnarkBlockVerifyAction::Init(a) => {
-                a.effects(&meta, store);
-            }
-            SnarkBlockVerifyAction::Pending(_) => {}
-            SnarkBlockVerifyAction::Error(a) => {
-                a.effects(&meta, store);
-            }
-            SnarkBlockVerifyAction::Success(a) => {
-                let req = store.state().snark.block_verify.jobs.get(a.req_id);
+        SnarkAction::BlockVerify(a) => {
+            if let SnarkBlockVerifyAction::Success { req_id } = a {
+                let req = store.state().snark.block_verify.jobs.get(req_id);
                 let Some(req) = req else { return };
                 store.dispatch(ConsensusAction::BlockSnarkVerifySuccess {
                     hash: req.block().hash_ref().clone(),
                 });
-                a.effects(&meta, store);
             }
-            SnarkBlockVerifyAction::Finish(_) => {}
-        },
+            a.effects(&meta, store);
+        }
         SnarkAction::WorkVerify(a) => match a {
             SnarkWorkVerifyAction::Init(a) => {
                 a.effects(&meta, store);

--- a/node/src/snark/snark_effects.rs
+++ b/node/src/snark/snark_effects.rs
@@ -1,4 +1,4 @@
-use crate::consensus::ConsensusBlockSnarkVerifySuccessAction;
+use crate::consensus::ConsensusAction;
 use crate::snark_pool::candidate::SnarkPoolCandidateAction;
 use crate::snark_pool::SnarkPoolWorkAddAction;
 use crate::{Service, Store};
@@ -22,7 +22,7 @@ pub fn snark_effects<S: Service>(store: &mut Store<S>, action: SnarkActionWithMe
             SnarkBlockVerifyAction::Success(a) => {
                 let req = store.state().snark.block_verify.jobs.get(a.req_id);
                 let Some(req) = req else { return };
-                store.dispatch(ConsensusBlockSnarkVerifySuccessAction {
+                store.dispatch(ConsensusAction::BlockSnarkVerifySuccess {
                     hash: req.block().hash_ref().clone(),
                 });
                 a.effects(&meta, store);

--- a/node/src/snark/snark_effects.rs
+++ b/node/src/snark/snark_effects.rs
@@ -1,6 +1,6 @@
 use crate::consensus::ConsensusAction;
 use crate::snark_pool::candidate::SnarkPoolCandidateAction;
-use crate::snark_pool::SnarkPoolWorkAddAction;
+use crate::snark_pool::SnarkPoolAction;
 use crate::{Service, Store};
 
 use super::block_verify::SnarkBlockVerifyAction;
@@ -50,7 +50,7 @@ pub fn snark_effects<S: Service>(store: &mut Store<S>, action: SnarkActionWithMe
                         verify_id: req_id,
                     });
                     for snark in batch {
-                        store.dispatch(SnarkPoolWorkAddAction { snark, sender });
+                        store.dispatch(SnarkPoolAction::WorkAdd { snark, sender });
                     }
                 }
                 SnarkWorkVerifyAction::Init { .. } => {}

--- a/node/src/snark/work_verify/snark_work_verify_actions.rs
+++ b/node/src/snark/work_verify/snark_work_verify_actions.rs
@@ -1,49 +1,13 @@
 use super::*;
 
-impl redux::EnablingCondition<crate::State> for SnarkWorkVerifyInitAction {
+impl redux::EnablingCondition<crate::State> for SnarkWorkVerifyAction {
     fn is_enabled(&self, state: &crate::State) -> bool {
         self.is_enabled(&state.snark)
     }
 }
 
-impl redux::EnablingCondition<crate::State> for SnarkWorkVerifyPendingAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.snark)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for SnarkWorkVerifyErrorAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.snark)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for SnarkWorkVerifySuccessAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.snark)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for SnarkWorkVerifyFinishAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.snark)
-    }
-}
-
-impl From<SnarkWorkVerifyInitAction> for crate::Action {
-    fn from(a: SnarkWorkVerifyInitAction) -> Self {
-        Self::Snark(a.into())
-    }
-}
-
-impl From<SnarkWorkVerifyErrorAction> for crate::Action {
-    fn from(a: SnarkWorkVerifyErrorAction) -> Self {
-        Self::Snark(a.into())
-    }
-}
-
-impl From<SnarkWorkVerifySuccessAction> for crate::Action {
-    fn from(a: SnarkWorkVerifySuccessAction) -> Self {
-        Self::Snark(a.into())
+impl From<SnarkWorkVerifyAction> for crate::Action {
+    fn from(value: SnarkWorkVerifyAction) -> Self {
+        Self::Snark(value.into())
     }
 }

--- a/node/src/snark_pool/candidate/snark_pool_candidate_actions.rs
+++ b/node/src/snark_pool/candidate/snark_pool_candidate_actions.rs
@@ -116,9 +116,11 @@ impl redux::EnablingCondition<crate::State> for SnarkPoolCandidateAction {
                         })
             }
             SnarkPoolCandidateAction::WorkVerifyError { .. } => {
+                // TODO(binier)
                 true
             }
             SnarkPoolCandidateAction::WorkVerifySuccess { .. } => {
+                // TODO(binier)
                 true
             }
             SnarkPoolCandidateAction::PeerPrune { peer_id } => {

--- a/node/src/snark_pool/candidate/snark_pool_candidate_effects.rs
+++ b/node/src/snark_pool/candidate/snark_pool_candidate_effects.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use snark::work_verify::SnarkWorkVerifyInitAction;
+use snark::work_verify::SnarkWorkVerifyAction;
 
 use crate::p2p::channels::rpc::{P2pChannelsRpcRequestSendAction, P2pRpcRequest};
 use crate::p2p::disconnection::{P2pDisconnectionInitAction, P2pDisconnectionReason};
@@ -71,7 +71,7 @@ pub fn snark_pool_candidate_effects<S: redux::Service>(
             let req_id = state.snark.work_verify.next_req_id();
             let job_ids = batch.iter().map(|v| v.job_id()).collect::<Vec<_>>();
             let sender = peer_id.to_string();
-            store.dispatch(SnarkWorkVerifyInitAction {
+            store.dispatch(SnarkWorkVerifyAction::Init {
                 req_id,
                 batch,
                 sender,

--- a/node/src/snark_pool/candidate/snark_pool_candidate_effects.rs
+++ b/node/src/snark_pool/candidate/snark_pool_candidate_effects.rs
@@ -1,132 +1,102 @@
 use std::collections::BTreeMap;
 
-use redux::ActionMeta;
 use snark::work_verify::SnarkWorkVerifyInitAction;
 
 use crate::p2p::channels::rpc::{P2pChannelsRpcRequestSendAction, P2pRpcRequest};
 use crate::p2p::disconnection::{P2pDisconnectionInitAction, P2pDisconnectionReason};
 use crate::Store;
 
-use super::{
-    SnarkPoolCandidateAction, SnarkPoolCandidateActionWithMeta,
-    SnarkPoolCandidateWorkFetchAllAction, SnarkPoolCandidateWorkFetchInitAction,
-    SnarkPoolCandidateWorkFetchPendingAction, SnarkPoolCandidateWorkVerifyErrorAction,
-    SnarkPoolCandidateWorkVerifyNextAction, SnarkPoolCandidateWorkVerifyPendingAction,
-};
-
-impl SnarkPoolCandidateWorkFetchAllAction {
-    pub fn effects<S: redux::Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        let state = store.state();
-        let peers = state.p2p.ready_peers_iter().map(|(id, _)| *id);
-        let get_order = |job_id: &_| {
-            state
-                .snark_pool
-                .get(job_id)
-                .map(|job| job.order)
-                .unwrap_or(usize::MAX)
-        };
-        let list = state
-            .snark_pool
-            .candidates
-            .peers_next_work_to_fetch(peers, get_order);
-
-        for (peer_id, job_id) in list {
-            store.dispatch(SnarkPoolCandidateWorkFetchInitAction { peer_id, job_id });
-        }
-    }
-}
-
-impl SnarkPoolCandidateWorkFetchInitAction {
-    pub fn effects<S: redux::Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        let Some(peer) = store.state().p2p.get_ready_peer(&self.peer_id) else {
-            return;
-        };
-        let rpc_id = peer.channels.rpc.next_local_rpc_id();
-        store.dispatch(P2pChannelsRpcRequestSendAction {
-            peer_id: self.peer_id,
-            id: rpc_id,
-            request: P2pRpcRequest::Snark(self.job_id.clone()),
-        });
-        store.dispatch(SnarkPoolCandidateWorkFetchPendingAction {
-            peer_id: self.peer_id,
-            job_id: self.job_id,
-            rpc_id,
-        });
-    }
-}
-
-impl SnarkPoolCandidateWorkVerifyNextAction {
-    pub fn effects<S: redux::Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        let state = store.state();
-        let job_id_orders = state
-            .snark_pool
-            .range(..)
-            .map(|(_, v)| (v.order, &v.id))
-            .collect::<BTreeMap<_, _>>();
-        let job_ids_ordered_iter = job_id_orders.into_iter().map(|(_, id)| id);
-        let batch = state
-            .snark_pool
-            .candidates
-            .get_batch_to_verify(job_ids_ordered_iter);
-        let Some((peer_id, batch)) = batch else {
-            return;
-        };
-
-        let req_id = state.snark.work_verify.next_req_id();
-        let job_ids = batch.iter().map(|v| v.job_id()).collect::<Vec<_>>();
-        let sender = peer_id.to_string();
-        store.dispatch(SnarkWorkVerifyInitAction {
-            req_id,
-            batch,
-            sender,
-        });
-        store.dispatch(SnarkPoolCandidateWorkVerifyPendingAction {
-            peer_id,
-            job_ids,
-            verify_id: req_id,
-        });
-    }
-}
-
-impl SnarkPoolCandidateWorkVerifyErrorAction {
-    pub fn effects<S: redux::Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        // TODO(binier): blacklist peer
-        store.dispatch(P2pDisconnectionInitAction {
-            peer_id: self.peer_id,
-            reason: P2pDisconnectionReason::SnarkPoolVerifyError,
-        });
-    }
-}
+use super::{SnarkPoolCandidateAction, SnarkPoolCandidateActionWithMeta};
 
 pub fn snark_pool_candidate_effects<S: redux::Service>(
     store: &mut Store<S>,
     action: SnarkPoolCandidateActionWithMeta,
 ) {
-    let (action, meta) = action.split();
+    let (action, _) = action.split();
     match action {
-        SnarkPoolCandidateAction::InfoReceived(_) => {}
-        SnarkPoolCandidateAction::WorkFetchAll(a) => {
-            a.effects(&meta, store);
+        SnarkPoolCandidateAction::InfoReceived { .. } => {}
+        SnarkPoolCandidateAction::WorkFetchAll => {
+            let state = store.state();
+            let peers = state.p2p.ready_peers_iter().map(|(id, _)| *id);
+            let get_order = |job_id: &_| {
+                state
+                    .snark_pool
+                    .get(job_id)
+                    .map(|job| job.order)
+                    .unwrap_or(usize::MAX)
+            };
+            let list = state
+                .snark_pool
+                .candidates
+                .peers_next_work_to_fetch(peers, get_order);
+
+            for (peer_id, job_id) in list {
+                store.dispatch(SnarkPoolCandidateAction::WorkFetchInit { peer_id, job_id });
+            }
         }
-        SnarkPoolCandidateAction::WorkFetchInit(a) => {
-            a.effects(&meta, store);
+        SnarkPoolCandidateAction::WorkFetchInit { peer_id, job_id } => {
+            let Some(peer) = store.state().p2p.get_ready_peer(&peer_id) else {
+                return;
+            };
+            let rpc_id = peer.channels.rpc.next_local_rpc_id();
+            store.dispatch(P2pChannelsRpcRequestSendAction {
+                peer_id,
+                id: rpc_id,
+                request: P2pRpcRequest::Snark(job_id.clone()),
+            });
+            store.dispatch(SnarkPoolCandidateAction::WorkFetchPending {
+                peer_id,
+                job_id: job_id.clone(),
+                rpc_id,
+            });
         }
-        SnarkPoolCandidateAction::WorkFetchPending(_) => {}
-        SnarkPoolCandidateAction::WorkReceived(_) => {}
-        SnarkPoolCandidateAction::WorkVerifyNext(a) => {
-            a.effects(&meta, store);
+        SnarkPoolCandidateAction::WorkFetchPending { .. } => {}
+        SnarkPoolCandidateAction::WorkReceived { .. } => {}
+        SnarkPoolCandidateAction::WorkVerifyNext => {
+            let state = store.state();
+            let job_id_orders = state
+                .snark_pool
+                .range(..)
+                .map(|(_, v)| (v.order, &v.id))
+                .collect::<BTreeMap<_, _>>();
+            let job_ids_ordered_iter = job_id_orders.into_iter().map(|(_, id)| id);
+            let batch = state
+                .snark_pool
+                .candidates
+                .get_batch_to_verify(job_ids_ordered_iter);
+            let Some((peer_id, batch)) = batch else {
+                return;
+            };
+
+            let req_id = state.snark.work_verify.next_req_id();
+            let job_ids = batch.iter().map(|v| v.job_id()).collect::<Vec<_>>();
+            let sender = peer_id.to_string();
+            store.dispatch(SnarkWorkVerifyInitAction {
+                req_id,
+                batch,
+                sender,
+            });
+            store.dispatch(SnarkPoolCandidateAction::WorkVerifyPending {
+                peer_id,
+                job_ids,
+                verify_id: req_id,
+            });
         }
-        SnarkPoolCandidateAction::WorkVerifyPending(_) => {}
-        SnarkPoolCandidateAction::WorkVerifyError(a) => {
-            a.effects(&meta, store);
+        SnarkPoolCandidateAction::WorkVerifyPending { .. } => {}
+        SnarkPoolCandidateAction::WorkVerifyError { peer_id, .. } => {
+            // TODO(binier): blacklist peer
+            store.dispatch(P2pDisconnectionInitAction {
+                peer_id,
+                reason: P2pDisconnectionReason::SnarkPoolVerifyError,
+            });
         }
-        SnarkPoolCandidateAction::WorkVerifySuccess(_) => {
+        SnarkPoolCandidateAction::WorkVerifySuccess { .. } => {
             // action for adding verified snarks to snark pool is called
             // in snark/work_verify effects. That is by design as we might
             // remove work pending verification if we receive better snark
             // from same peer. But since we have already started verification,
             // we might as well use it's result.
         }
-        SnarkPoolCandidateAction::PeerPrune(_) => {}
+        SnarkPoolCandidateAction::PeerPrune { .. } => {}
     }
 }

--- a/node/src/snark_pool/candidate/snark_pool_candidate_effects.rs
+++ b/node/src/snark_pool/candidate/snark_pool_candidate_effects.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use snark::work_verify::SnarkWorkVerifyAction;
 
-use crate::p2p::channels::rpc::{P2pChannelsRpcRequestSendAction, P2pRpcRequest};
+use crate::p2p::channels::rpc::{P2pChannelsRpcAction, P2pRpcRequest};
 use crate::p2p::disconnection::{P2pDisconnectionInitAction, P2pDisconnectionReason};
 use crate::Store;
 
@@ -39,7 +39,7 @@ pub fn snark_pool_candidate_effects<S: redux::Service>(
                 return;
             };
             let rpc_id = peer.channels.rpc.next_local_rpc_id();
-            store.dispatch(P2pChannelsRpcRequestSendAction {
+            store.dispatch(P2pChannelsRpcAction::RequestSend {
                 peer_id,
                 id: rpc_id,
                 request: P2pRpcRequest::Snark(job_id.clone()),

--- a/node/src/snark_pool/candidate/snark_pool_candidate_reducer.rs
+++ b/node/src/snark_pool/candidate/snark_pool_candidate_reducer.rs
@@ -6,29 +6,37 @@ impl SnarkPoolCandidatesState {
     pub fn reducer(&mut self, action: SnarkPoolCandidateActionWithMetaRef<'_>) {
         let (action, meta) = action.split();
         match action {
-            SnarkPoolCandidateAction::InfoReceived(a) => {
-                self.info_received(meta.time(), a.peer_id, a.info.clone());
+            SnarkPoolCandidateAction::InfoReceived { peer_id, info } => {
+                self.info_received(meta.time(), *peer_id, info.clone());
             }
-            SnarkPoolCandidateAction::WorkFetchAll(_) => {}
-            SnarkPoolCandidateAction::WorkFetchInit(_) => {}
-            SnarkPoolCandidateAction::WorkFetchPending(a) => {
-                self.work_fetch_pending(meta.time(), &a.peer_id, &a.job_id, a.rpc_id);
+            SnarkPoolCandidateAction::WorkFetchAll => {}
+            SnarkPoolCandidateAction::WorkFetchInit { .. } => {}
+            SnarkPoolCandidateAction::WorkFetchPending {
+                peer_id,
+                job_id,
+                rpc_id,
+            } => {
+                self.work_fetch_pending(meta.time(), peer_id, job_id, *rpc_id);
             }
-            SnarkPoolCandidateAction::WorkReceived(a) => {
-                self.work_received(meta.time(), a.peer_id, a.work.clone());
+            SnarkPoolCandidateAction::WorkReceived { peer_id, work } => {
+                self.work_received(meta.time(), *peer_id, work.clone());
             }
-            SnarkPoolCandidateAction::WorkVerifyNext(_) => {}
-            SnarkPoolCandidateAction::WorkVerifyPending(a) => {
-                self.verify_pending(meta.time(), &a.peer_id, a.verify_id, &a.job_ids);
+            SnarkPoolCandidateAction::WorkVerifyNext => {}
+            SnarkPoolCandidateAction::WorkVerifyPending {
+                peer_id,
+                job_ids,
+                verify_id,
+            } => {
+                self.verify_pending(meta.time(), peer_id, *verify_id, job_ids);
             }
-            SnarkPoolCandidateAction::WorkVerifyError(a) => {
-                self.verify_result(meta.time(), &a.peer_id, a.verify_id, Err(()));
+            SnarkPoolCandidateAction::WorkVerifyError { peer_id, verify_id } => {
+                self.verify_result(meta.time(), peer_id, *verify_id, Err(()));
             }
-            SnarkPoolCandidateAction::WorkVerifySuccess(a) => {
-                self.verify_result(meta.time(), &a.peer_id, a.verify_id, Ok(()));
+            SnarkPoolCandidateAction::WorkVerifySuccess { peer_id, verify_id } => {
+                self.verify_result(meta.time(), peer_id, *verify_id, Ok(()));
             }
-            SnarkPoolCandidateAction::PeerPrune(a) => {
-                self.peer_remove(a.peer_id);
+            SnarkPoolCandidateAction::PeerPrune { peer_id } => {
+                self.peer_remove(*peer_id);
             }
         }
     }

--- a/node/src/snark_pool/candidate/snark_pool_candidate_state.rs
+++ b/node/src/snark_pool/candidate/snark_pool_candidate_state.rs
@@ -274,7 +274,7 @@ impl SnarkPoolCandidatesState {
         }
     }
 
-    pub fn remove_inferrior_snarks(&mut self, snark: &Snark) {
+    pub fn remove_inferior_snarks(&mut self, snark: &Snark) {
         let job_id = snark.job_id();
         let by_peer = &mut self.by_peer;
         if let Some(peers) = self.by_job_id.get_mut(&job_id) {

--- a/node/src/snark_pool/snark_pool_effects.rs
+++ b/node/src/snark_pool/snark_pool_effects.rs
@@ -160,7 +160,7 @@ pub fn snark_pool_effects<S: Service>(store: &mut Store<S>, action: SnarkPoolAct
             }
         }
         SnarkPoolAction::JobCommitmentTimeout { .. } => {
-            store.dispatch(SnarkPoolAction::AutoCreateCommitment {});
+            store.dispatch(SnarkPoolAction::AutoCreateCommitment);
         }
     }
 }

--- a/node/src/snark_pool/snark_pool_effects.rs
+++ b/node/src/snark_pool/snark_pool_effects.rs
@@ -3,7 +3,7 @@ use openmina_core::snark::SnarkJobCommitment;
 use crate::p2p::channels::snark::{
     P2pChannelsSnarkLibp2pBroadcastAction, P2pChannelsSnarkResponseSendAction,
 };
-use crate::p2p::channels::snark_job_commitment::P2pChannelsSnarkJobCommitmentResponseSendAction;
+use crate::p2p::channels::snark_job_commitment::P2pChannelsSnarkJobCommitmentAction;
 use crate::{ExternalSnarkWorkerAction, Service, SnarkerStrategy, State, Store};
 
 use super::candidate::snark_pool_candidate_effects;
@@ -138,7 +138,7 @@ pub fn snark_pool_effects<S: Service>(store: &mut Store<S>, action: SnarkPoolAct
             let (commitments, first_index, last_index) =
                 data_to_send(state, index_and_limit, |job| job.commitment_msg().cloned());
 
-            let send_commitments = P2pChannelsSnarkJobCommitmentResponseSendAction {
+            let send_commitments = P2pChannelsSnarkJobCommitmentAction::ResponseSend {
                 peer_id: a.peer_id,
                 commitments,
                 first_index,

--- a/node/src/snark_pool/snark_pool_effects.rs
+++ b/node/src/snark_pool/snark_pool_effects.rs
@@ -1,8 +1,6 @@
 use openmina_core::snark::SnarkJobCommitment;
+use p2p::channels::snark::P2pChannelsSnarkAction;
 
-use crate::p2p::channels::snark::{
-    P2pChannelsSnarkLibp2pBroadcastAction, P2pChannelsSnarkResponseSendAction,
-};
 use crate::p2p::channels::snark_job_commitment::P2pChannelsSnarkJobCommitmentAction;
 use crate::{ExternalSnarkWorkerAction, Service, SnarkerStrategy, State, Store};
 
@@ -114,7 +112,7 @@ pub fn snark_pool_effects<S: Service>(store: &mut Store<S>, action: SnarkPoolAct
                 }
             }
 
-            store.dispatch(P2pChannelsSnarkLibp2pBroadcastAction {
+            store.dispatch(P2pChannelsSnarkAction::Libp2pBroadcast {
                 snark: a.snark,
                 nonce: 0,
             });
@@ -151,7 +149,7 @@ pub fn snark_pool_effects<S: Service>(store: &mut Store<S>, action: SnarkPoolAct
                 data_to_send(state, index_and_limit, |job| job.snark_msg());
 
             store.dispatch(send_commitments);
-            store.dispatch(P2pChannelsSnarkResponseSendAction {
+            store.dispatch(P2pChannelsSnarkAction::ResponseSend {
                 peer_id: a.peer_id,
                 snarks,
                 first_index,

--- a/node/src/snark_pool/snark_pool_reducer.rs
+++ b/node/src/snark_pool/snark_pool_reducer.rs
@@ -75,7 +75,7 @@ impl SnarkPoolState {
                     sender: a.sender,
                 });
                 self.insert(job);
-                self.candidates.remove_inferrior_snarks(&a.snark);
+                self.candidates.remove_inferior_snarks(&a.snark);
             }
             SnarkPoolAction::P2pSendAll(_) => {}
             SnarkPoolAction::P2pSend(_) => {}

--- a/node/src/transition_frontier/sync/ledger/snarked/transition_frontier_sync_ledger_snarked_effects.rs
+++ b/node/src/transition_frontier/sync/ledger/snarked/transition_frontier_sync_ledger_snarked_effects.rs
@@ -1,5 +1,5 @@
 use mina_p2p_messages::v2::MinaLedgerSyncLedgerQueryStableV1;
-use p2p::channels::rpc::{P2pChannelsRpcRequestSendAction, P2pRpcRequest};
+use p2p::channels::rpc::{P2pChannelsRpcAction, P2pRpcRequest};
 use p2p::PeerId;
 use redux::ActionMeta;
 
@@ -43,7 +43,7 @@ fn query_peer_init<S: redux::Service>(
         MinaLedgerSyncLedgerQueryStableV1::WhatChildHashes(address.clone().into())
     };
 
-    if store.dispatch(P2pChannelsRpcRequestSendAction {
+    if store.dispatch(P2pChannelsRpcAction::RequestSend {
         peer_id,
         id: rpc_id,
         request: P2pRpcRequest::LedgerQuery(ledger_hash, query),

--- a/node/src/transition_frontier/sync/ledger/staged/transition_frontier_sync_ledger_staged_effects.rs
+++ b/node/src/transition_frontier/sync/ledger/staged/transition_frontier_sync_ledger_staged_effects.rs
@@ -1,6 +1,6 @@
 use redux::ActionMeta;
 
-use crate::p2p::channels::rpc::{P2pChannelsRpcRequestSendAction, P2pRpcRequest};
+use crate::p2p::channels::rpc::{P2pChannelsRpcAction, P2pRpcRequest};
 use crate::Store;
 
 use super::{
@@ -42,7 +42,7 @@ impl TransitionFrontierSyncLedgerStagedPartsPeerFetchInitAction {
 
         for (peer_id, rpc_id) in ready_peers {
             // TODO(binier): maybe
-            if store.dispatch(P2pChannelsRpcRequestSendAction {
+            if store.dispatch(P2pChannelsRpcAction::RequestSend {
                 peer_id,
                 id: rpc_id,
                 request: P2pRpcRequest::StagedLedgerAuxAndPendingCoinbasesAtBlock(

--- a/node/src/transition_frontier/sync/transition_frontier_sync_actions.rs
+++ b/node/src/transition_frontier/sync/transition_frontier_sync_actions.rs
@@ -107,7 +107,7 @@ impl redux::EnablingCondition<crate::State> for TransitionFrontierSyncBestTipUpd
             //
             // Otherwise other block producers might spam the network
             // with blocks that are better than current best tip, yet
-            // inferrior to the block that we are producing and we can't
+            // inferior to the block that we are producing and we can't
             // let that get in the way of us producing a block.
             && state.block_producer.producing_won_slot()
                 .filter(|_| !state.block_producer.is_me(self.best_tip.producer()))

--- a/node/src/transition_frontier/sync/transition_frontier_sync_effects.rs
+++ b/node/src/transition_frontier/sync/transition_frontier_sync_effects.rs
@@ -1,4 +1,4 @@
-use p2p::channels::rpc::P2pChannelsRpcRequestSendAction;
+use p2p::channels::rpc::P2pChannelsRpcAction;
 use redux::ActionMeta;
 
 use crate::p2p::channels::rpc::P2pRpcRequest;
@@ -152,7 +152,7 @@ impl TransitionFrontierSyncBlocksPeerQueryInitAction {
             return;
         };
 
-        if store.dispatch(P2pChannelsRpcRequestSendAction {
+        if store.dispatch(P2pChannelsRpcAction::RequestSend {
             peer_id: self.peer_id,
             id: rpc_id,
             request: P2pRpcRequest::Block(self.hash.clone()),
@@ -177,7 +177,7 @@ impl TransitionFrontierSyncBlocksPeerQueryRetryAction {
             return;
         };
 
-        if store.dispatch(P2pChannelsRpcRequestSendAction {
+        if store.dispatch(P2pChannelsRpcAction::RequestSend {
             peer_id: self.peer_id,
             id: rpc_id,
             request: P2pRpcRequest::Block(self.hash.clone()),

--- a/node/src/transition_frontier/transition_frontier_effects.rs
+++ b/node/src/transition_frontier/transition_frontier_effects.rs
@@ -4,7 +4,7 @@ use crate::block_producer::BlockProducerBestTipUpdateAction;
 use crate::consensus::ConsensusAction;
 use crate::ledger::LEDGER_DEPTH;
 use crate::p2p::channels::best_tip::P2pChannelsBestTipAction;
-use crate::snark_pool::{SnarkPoolJobsUpdateAction, SnarkWork};
+use crate::snark_pool::{SnarkPoolAction, SnarkWork};
 use crate::stats::sync::SyncingLedger;
 use crate::Store;
 
@@ -301,7 +301,7 @@ pub fn transition_frontier_effects<S: crate::Service>(
                 store.dispatch(TransitionFrontierSyncedAction {
                     needed_protocol_states,
                 });
-                store.dispatch(SnarkPoolJobsUpdateAction {
+                store.dispatch(SnarkPoolAction::JobsUpdate {
                     jobs,
                     orphaned_snarks,
                 });

--- a/node/src/transition_frontier/transition_frontier_effects.rs
+++ b/node/src/transition_frontier/transition_frontier_effects.rs
@@ -1,7 +1,7 @@
 use redux::Timestamp;
 
 use crate::block_producer::BlockProducerBestTipUpdateAction;
-use crate::consensus::ConsensusPruneAction;
+use crate::consensus::ConsensusAction;
 use crate::ledger::LEDGER_DEPTH;
 use crate::p2p::channels::best_tip::P2pChannelsBestTipResponseSendAction;
 use crate::snark_pool::{SnarkPoolJobsUpdateAction, SnarkWork};
@@ -327,7 +327,7 @@ pub fn transition_frontier_effects<S: crate::Service>(
                 });
             }
 
-            store.dispatch(ConsensusPruneAction {});
+            store.dispatch(ConsensusAction::Prune);
             store.dispatch(BlockProducerBestTipUpdateAction { best_tip });
         }
     }

--- a/node/src/transition_frontier/transition_frontier_effects.rs
+++ b/node/src/transition_frontier/transition_frontier_effects.rs
@@ -3,7 +3,7 @@ use redux::Timestamp;
 use crate::block_producer::BlockProducerBestTipUpdateAction;
 use crate::consensus::ConsensusAction;
 use crate::ledger::LEDGER_DEPTH;
-use crate::p2p::channels::best_tip::P2pChannelsBestTipResponseSendAction;
+use crate::p2p::channels::best_tip::P2pChannelsBestTipAction;
 use crate::snark_pool::{SnarkPoolJobsUpdateAction, SnarkWork};
 use crate::stats::sync::SyncingLedger;
 use crate::Store;
@@ -321,7 +321,7 @@ pub fn transition_frontier_effects<S: crate::Service>(
             // publish new best tip.
             let best_tip = best_tip.clone();
             for peer_id in store.state().p2p.ready_peers() {
-                store.dispatch(P2pChannelsBestTipResponseSendAction {
+                store.dispatch(P2pChannelsBestTipAction::ResponseSend {
                     peer_id,
                     best_tip: best_tip.clone(),
                 });

--- a/p2p/src/channels/best_tip/p2p_channels_best_tip_actions.rs
+++ b/p2p/src/channels/best_tip/p2p_channels_best_tip_actions.rs
@@ -1,212 +1,132 @@
 use openmina_core::block::ArcBlockWithHash;
 use serde::{Deserialize, Serialize};
 
-use crate::{P2pState, PeerId};
+use crate::{
+    channels::{best_tip::P2pChannelsBestTipState, P2pChannelsAction},
+    P2pState, PeerId,
+};
+
+use super::BestTipPropagationState;
 
 pub type P2pChannelsBestTipActionWithMetaRef<'a> =
     redux::ActionWithMeta<&'a P2pChannelsBestTipAction>;
 
-#[derive(derive_more::From, Serialize, Deserialize, Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum P2pChannelsBestTipAction {
-    Init(P2pChannelsBestTipInitAction),
-    Pending(P2pChannelsBestTipPendingAction),
-    Ready(P2pChannelsBestTipReadyAction),
-
-    RequestSend(P2pChannelsBestTipRequestSendAction),
-    Received(P2pChannelsBestTipReceivedAction),
-
-    RequestReceived(P2pChannelsBestTipRequestReceivedAction),
-    ResponseSend(P2pChannelsBestTipResponseSendAction),
+    Init {
+        peer_id: PeerId,
+    },
+    Pending {
+        peer_id: PeerId,
+    },
+    Ready {
+        peer_id: PeerId,
+    },
+    RequestSend {
+        peer_id: PeerId,
+    },
+    Received {
+        peer_id: PeerId,
+        best_tip: ArcBlockWithHash,
+    },
+    RequestReceived {
+        peer_id: PeerId,
+    },
+    ResponseSend {
+        peer_id: PeerId,
+        best_tip: ArcBlockWithHash,
+    },
 }
 
 impl P2pChannelsBestTipAction {
     pub fn peer_id(&self) -> &PeerId {
         match self {
-            Self::Init(v) => &v.peer_id,
-            Self::Pending(v) => &v.peer_id,
-            Self::Ready(v) => &v.peer_id,
-            Self::RequestSend(v) => &v.peer_id,
-            Self::Received(v) => &v.peer_id,
-            Self::RequestReceived(v) => &v.peer_id,
-            Self::ResponseSend(v) => &v.peer_id,
+            Self::Init { peer_id }
+            | Self::Pending { peer_id }
+            | Self::Ready { peer_id }
+            | Self::RequestSend { peer_id }
+            | Self::Received { peer_id, .. }
+            | Self::RequestReceived { peer_id }
+            | Self::ResponseSend { peer_id, .. } => peer_id,
         }
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pChannelsBestTipInitAction {
-    pub peer_id: PeerId,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pChannelsBestTipInitAction {
+impl redux::EnablingCondition<P2pState> for P2pChannelsBestTipAction {
     fn is_enabled(&self, state: &P2pState) -> bool {
-        state.get_ready_peer(&self.peer_id).map_or(false, |p| {
-            matches!(&p.channels.best_tip, P2pChannelsBestTipState::Enabled)
-        })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pChannelsBestTipPendingAction {
-    pub peer_id: PeerId,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pChannelsBestTipPendingAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state.get_ready_peer(&self.peer_id).map_or(false, |p| {
-            matches!(&p.channels.best_tip, P2pChannelsBestTipState::Init { .. })
-        })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pChannelsBestTipReadyAction {
-    pub peer_id: PeerId,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pChannelsBestTipReadyAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state.get_ready_peer(&self.peer_id).map_or(false, |p| {
-            matches!(
-                &p.channels.best_tip,
-                P2pChannelsBestTipState::Pending { .. }
-            )
-        })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pChannelsBestTipRequestSendAction {
-    pub peer_id: PeerId,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pChannelsBestTipRequestSendAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .get_ready_peer(&self.peer_id)
-            .map_or(false, |p| match &p.channels.best_tip {
-                P2pChannelsBestTipState::Ready { local, .. } => match local {
-                    BestTipPropagationState::WaitingForRequest { .. } => true,
-                    BestTipPropagationState::Responded { .. } => true,
+        match self {
+            P2pChannelsBestTipAction::Init { peer_id } => {
+                state.get_ready_peer(peer_id).map_or(false, |p| {
+                    matches!(&p.channels.best_tip, P2pChannelsBestTipState::Enabled)
+                })
+            }
+            P2pChannelsBestTipAction::Pending { peer_id } => {
+                state.get_ready_peer(peer_id).map_or(false, |p| {
+                    matches!(&p.channels.best_tip, P2pChannelsBestTipState::Init { .. })
+                })
+            }
+            P2pChannelsBestTipAction::Ready { peer_id } => {
+                state.get_ready_peer(peer_id).map_or(false, |p| {
+                    matches!(
+                        &p.channels.best_tip,
+                        P2pChannelsBestTipState::Pending { .. }
+                    )
+                })
+            }
+            P2pChannelsBestTipAction::RequestSend { peer_id } => state
+                .get_ready_peer(peer_id)
+                .map_or(false, |p| match &p.channels.best_tip {
+                    P2pChannelsBestTipState::Ready { local, .. } => match local {
+                        BestTipPropagationState::WaitingForRequest { .. } => true,
+                        BestTipPropagationState::Responded { .. } => true,
+                        _ => false,
+                    },
                     _ => false,
-                },
-                _ => false,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pChannelsBestTipReceivedAction {
-    pub peer_id: PeerId,
-    pub best_tip: ArcBlockWithHash,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pChannelsBestTipReceivedAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        // TODO(binier): use consensus to enforce that peer doesn't send
-        // us inferrior block than it has in the past.
-        state
-            .get_ready_peer(&self.peer_id)
-            .map_or(false, |p| match &p.channels.best_tip {
-                P2pChannelsBestTipState::Ready { local, .. } => match local {
-                    BestTipPropagationState::Requested { .. } => true,
+                }),
+            P2pChannelsBestTipAction::Received { peer_id, .. } => {
+                // TODO(binier): use consensus to enforce that peer doesn't send
+                // us inferior block than it has in the past.
+                state
+                    .get_ready_peer(peer_id)
+                    .map_or(false, |p| match &p.channels.best_tip {
+                        P2pChannelsBestTipState::Ready { local, .. } => match local {
+                            BestTipPropagationState::Requested { .. } => true,
+                            _ => false,
+                        },
+                        _ => false,
+                    })
+            }
+            P2pChannelsBestTipAction::RequestReceived { peer_id } => state
+                .get_ready_peer(peer_id)
+                .map_or(false, |p| match &p.channels.best_tip {
+                    P2pChannelsBestTipState::Ready { remote, .. } => match remote {
+                        BestTipPropagationState::WaitingForRequest { .. } => true,
+                        BestTipPropagationState::Responded { .. } => true,
+                        _ => false,
+                    },
                     _ => false,
-                },
-                _ => false,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pChannelsBestTipRequestReceivedAction {
-    pub peer_id: PeerId,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pChannelsBestTipRequestReceivedAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .get_ready_peer(&self.peer_id)
-            .map_or(false, |p| match &p.channels.best_tip {
-                P2pChannelsBestTipState::Ready { remote, .. } => match remote {
-                    BestTipPropagationState::WaitingForRequest { .. } => true,
-                    BestTipPropagationState::Responded { .. } => true,
-                    _ => false,
-                },
-                _ => false,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pChannelsBestTipResponseSendAction {
-    pub peer_id: PeerId,
-    pub best_tip: ArcBlockWithHash,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pChannelsBestTipResponseSendAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .get_ready_peer(&self.peer_id)
-            .map_or(false, |p| match &p.channels.best_tip {
-                P2pChannelsBestTipState::Ready {
-                    remote, last_sent, ..
-                } => {
-                    if !matches!(remote, BestTipPropagationState::Requested { .. }) {
-                        return false;
+                }),
+            P2pChannelsBestTipAction::ResponseSend { peer_id, best_tip } => state
+                .get_ready_peer(peer_id)
+                .map_or(false, |p| match &p.channels.best_tip {
+                    P2pChannelsBestTipState::Ready {
+                        remote, last_sent, ..
+                    } => {
+                        if !matches!(remote, BestTipPropagationState::Requested { .. }) {
+                            return false;
+                        }
+                        last_sent
+                            .as_ref()
+                            .map_or(true, |sent| sent.hash != best_tip.hash)
                     }
-                    last_sent
-                        .as_ref()
-                        .map_or(true, |sent| sent.hash != self.best_tip.hash)
-                }
-                _ => false,
-            })
+                    _ => false,
+                }),
+        }
     }
 }
 
-// --- From<LeafAction> for Action impls.
-
-use crate::channels::P2pChannelsAction;
-
-use super::{BestTipPropagationState, P2pChannelsBestTipState};
-
-impl From<P2pChannelsBestTipInitAction> for crate::P2pAction {
-    fn from(a: P2pChannelsBestTipInitAction) -> Self {
-        Self::Channels(P2pChannelsAction::BestTip(a.into()))
-    }
-}
-
-impl From<P2pChannelsBestTipPendingAction> for crate::P2pAction {
-    fn from(a: P2pChannelsBestTipPendingAction) -> Self {
-        Self::Channels(P2pChannelsAction::BestTip(a.into()))
-    }
-}
-
-impl From<P2pChannelsBestTipReadyAction> for crate::P2pAction {
-    fn from(a: P2pChannelsBestTipReadyAction) -> Self {
-        Self::Channels(P2pChannelsAction::BestTip(a.into()))
-    }
-}
-
-impl From<P2pChannelsBestTipRequestSendAction> for crate::P2pAction {
-    fn from(a: P2pChannelsBestTipRequestSendAction) -> Self {
-        Self::Channels(P2pChannelsAction::BestTip(a.into()))
-    }
-}
-
-impl From<P2pChannelsBestTipReceivedAction> for crate::P2pAction {
-    fn from(a: P2pChannelsBestTipReceivedAction) -> Self {
-        Self::Channels(P2pChannelsAction::BestTip(a.into()))
-    }
-}
-
-impl From<P2pChannelsBestTipRequestReceivedAction> for crate::P2pAction {
-    fn from(a: P2pChannelsBestTipRequestReceivedAction) -> Self {
-        Self::Channels(P2pChannelsAction::BestTip(a.into()))
-    }
-}
-
-impl From<P2pChannelsBestTipResponseSendAction> for crate::P2pAction {
-    fn from(a: P2pChannelsBestTipResponseSendAction) -> Self {
-        Self::Channels(P2pChannelsAction::BestTip(a.into()))
+impl From<P2pChannelsBestTipAction> for crate::P2pAction {
+    fn from(action: P2pChannelsBestTipAction) -> Self {
+        Self::Channels(P2pChannelsAction::BestTip(action))
     }
 }

--- a/p2p/src/channels/best_tip/p2p_channels_best_tip_effects.rs
+++ b/p2p/src/channels/best_tip/p2p_channels_best_tip_effects.rs
@@ -5,87 +5,53 @@ use crate::{
     peer::P2pPeerBestTipUpdateAction,
 };
 
-use super::{
-    BestTipPropagationChannelMsg, P2pChannelsBestTipInitAction, P2pChannelsBestTipPendingAction,
-    P2pChannelsBestTipReadyAction, P2pChannelsBestTipReceivedAction,
-    P2pChannelsBestTipRequestReceivedAction, P2pChannelsBestTipRequestSendAction,
-    P2pChannelsBestTipResponseSendAction,
-};
+use super::{BestTipPropagationChannelMsg, P2pChannelsBestTipAction};
 
-impl P2pChannelsBestTipInitAction {
+impl P2pChannelsBestTipAction {
     pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
     where
         Store: crate::P2pStore<S>,
         Store::Service: P2pChannelsService,
-        P2pChannelsBestTipPendingAction: redux::EnablingCondition<S>,
-    {
-        let peer_id = self.peer_id;
-        store
-            .service()
-            .channel_open(peer_id, ChannelId::BestTipPropagation);
-        store.dispatch(P2pChannelsBestTipPendingAction { peer_id });
-    }
-}
-
-impl P2pChannelsBestTipReadyAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-        Store::Service: P2pChannelsService,
-        P2pChannelsBestTipRequestSendAction: redux::EnablingCondition<S>,
-        P2pChannelsBestTipRequestReceivedAction: redux::EnablingCondition<S>,
-    {
-        let peer_id = self.peer_id;
-        store.dispatch(P2pChannelsBestTipRequestSendAction { peer_id });
-        if store.state().is_libp2p_peer(&peer_id) {
-            store.dispatch(P2pChannelsBestTipRequestReceivedAction { peer_id });
-        }
-    }
-}
-
-impl P2pChannelsBestTipRequestSendAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-        Store::Service: P2pChannelsService,
-    {
-        let msg = BestTipPropagationChannelMsg::GetNext;
-        store
-            .service()
-            .channel_send(self.peer_id, MsgId::first(), msg.into());
-    }
-}
-
-impl P2pChannelsBestTipReceivedAction {
-    pub fn effects<Store, S>(&self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-        Store::Service: P2pChannelsService,
+        P2pChannelsBestTipAction: redux::EnablingCondition<S>,
         P2pPeerBestTipUpdateAction: redux::EnablingCondition<S>,
-        P2pChannelsBestTipRequestSendAction: redux::EnablingCondition<S>,
-        P2pChannelsBestTipRequestReceivedAction: redux::EnablingCondition<S>,
     {
-        let peer_id = self.peer_id;
-        store.dispatch(P2pPeerBestTipUpdateAction {
-            peer_id,
-            best_tip: self.best_tip.clone(),
-        });
-        store.dispatch(P2pChannelsBestTipRequestSendAction { peer_id });
-        if store.state().is_libp2p_peer(&peer_id) {
-            store.dispatch(P2pChannelsBestTipRequestReceivedAction { peer_id });
+        match self {
+            P2pChannelsBestTipAction::Init { peer_id } => {
+                store
+                    .service()
+                    .channel_open(peer_id, ChannelId::BestTipPropagation);
+                store.dispatch(P2pChannelsBestTipAction::Pending { peer_id });
+            }
+            P2pChannelsBestTipAction::Ready { peer_id } => {
+                store.dispatch(P2pChannelsBestTipAction::RequestSend { peer_id });
+                if store.state().is_libp2p_peer(&peer_id) {
+                    store.dispatch(P2pChannelsBestTipAction::RequestReceived { peer_id });
+                }
+            }
+            P2pChannelsBestTipAction::RequestSend { peer_id } => {
+                let msg = BestTipPropagationChannelMsg::GetNext;
+                store
+                    .service()
+                    .channel_send(peer_id, MsgId::first(), msg.into());
+            }
+            P2pChannelsBestTipAction::Received { peer_id, best_tip } => {
+                store.dispatch(P2pPeerBestTipUpdateAction {
+                    peer_id,
+                    best_tip: best_tip.clone(),
+                });
+                store.dispatch(P2pChannelsBestTipAction::RequestSend { peer_id });
+                if store.state().is_libp2p_peer(&peer_id) {
+                    store.dispatch(P2pChannelsBestTipAction::RequestReceived { peer_id });
+                }
+            }
+            P2pChannelsBestTipAction::ResponseSend { peer_id, best_tip } => {
+                let msg = BestTipPropagationChannelMsg::BestTip(best_tip.block);
+                store
+                    .service()
+                    .channel_send(peer_id, MsgId::first(), msg.into());
+            }
+            P2pChannelsBestTipAction::Pending { .. } => {}
+            P2pChannelsBestTipAction::RequestReceived { .. } => {}
         }
-    }
-}
-
-impl P2pChannelsBestTipResponseSendAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-        Store::Service: P2pChannelsService,
-    {
-        let msg = BestTipPropagationChannelMsg::BestTip(self.best_tip.block);
-        store
-            .service()
-            .channel_send(self.peer_id, MsgId::first(), msg.into());
     }
 }

--- a/p2p/src/channels/best_tip/p2p_channels_best_tip_reducer.rs
+++ b/p2p/src/channels/best_tip/p2p_channels_best_tip_reducer.rs
@@ -7,13 +7,13 @@ impl P2pChannelsBestTipState {
     pub fn reducer(&mut self, action: P2pChannelsBestTipActionWithMetaRef<'_>) {
         let (action, meta) = action.split();
         match action {
-            P2pChannelsBestTipAction::Init(_) => {
+            P2pChannelsBestTipAction::Init { .. } => {
                 *self = Self::Init { time: meta.time() };
             }
-            P2pChannelsBestTipAction::Pending(_) => {
+            P2pChannelsBestTipAction::Pending { .. } => {
                 *self = Self::Pending { time: meta.time() };
             }
-            P2pChannelsBestTipAction::Ready(_) => {
+            P2pChannelsBestTipAction::Ready { .. } => {
                 *self = Self::Ready {
                     time: meta.time(),
                     local: BestTipPropagationState::WaitingForRequest { time: meta.time() },
@@ -22,13 +22,13 @@ impl P2pChannelsBestTipState {
                     last_received: None,
                 };
             }
-            P2pChannelsBestTipAction::RequestSend(_) => {
+            P2pChannelsBestTipAction::RequestSend { .. } => {
                 let Self::Ready { local, .. } = self else {
                     return;
                 };
                 *local = BestTipPropagationState::Requested { time: meta.time() };
             }
-            P2pChannelsBestTipAction::Received(action) => {
+            P2pChannelsBestTipAction::Received { best_tip, .. } => {
                 let Self::Ready {
                     local,
                     last_received,
@@ -39,16 +39,16 @@ impl P2pChannelsBestTipState {
                 };
 
                 *local = BestTipPropagationState::Responded { time: meta.time() };
-                *last_received = Some(action.best_tip.clone());
+                *last_received = Some(best_tip.clone());
             }
-            P2pChannelsBestTipAction::RequestReceived(_) => {
+            P2pChannelsBestTipAction::RequestReceived { .. } => {
                 let Self::Ready { remote, .. } = self else {
                     return;
                 };
 
                 *remote = BestTipPropagationState::Requested { time: meta.time() };
             }
-            P2pChannelsBestTipAction::ResponseSend(action) => {
+            P2pChannelsBestTipAction::ResponseSend { best_tip, .. } => {
                 let Self::Ready {
                     remote, last_sent, ..
                 } = self
@@ -57,7 +57,7 @@ impl P2pChannelsBestTipState {
                 };
 
                 *remote = BestTipPropagationState::Responded { time: meta.time() };
-                *last_sent = Some(action.best_tip.clone());
+                *last_sent = Some(best_tip.clone());
             }
         }
     }

--- a/p2p/src/channels/p2p_channels_effects.rs
+++ b/p2p/src/channels/p2p_channels_effects.rs
@@ -8,10 +8,7 @@ use super::{
     rpc::{
         P2pChannelsRpcRequestReceivedAction, P2pChannelsRpcResponseReceivedAction, RpcChannelMsg,
     },
-    snark::{
-        P2pChannelsSnarkPromiseReceivedAction, P2pChannelsSnarkReceivedAction,
-        P2pChannelsSnarkRequestReceivedAction, SnarkPropagationChannelMsg,
-    },
+    snark::{P2pChannelsSnarkAction, SnarkPropagationChannelMsg},
     snark_job_commitment::{
         P2pChannelsSnarkJobCommitmentAction, SnarkJobCommitmentPropagationChannelMsg,
     },
@@ -23,9 +20,7 @@ impl P2pChannelsMessageReceivedAction {
     where
         Store: crate::P2pStore<S>,
         P2pChannelsBestTipAction: redux::EnablingCondition<S>,
-        P2pChannelsSnarkRequestReceivedAction: redux::EnablingCondition<S>,
-        P2pChannelsSnarkPromiseReceivedAction: redux::EnablingCondition<S>,
-        P2pChannelsSnarkReceivedAction: redux::EnablingCondition<S>,
+        P2pChannelsSnarkAction: redux::EnablingCondition<S>,
         P2pChannelsSnarkJobCommitmentAction: redux::EnablingCondition<S>,
         P2pChannelsRpcRequestReceivedAction: redux::EnablingCondition<S>,
         P2pChannelsRpcResponseReceivedAction: redux::EnablingCondition<S>,
@@ -45,16 +40,16 @@ impl P2pChannelsMessageReceivedAction {
             },
             ChannelMsg::SnarkPropagation(msg) => match msg {
                 SnarkPropagationChannelMsg::GetNext { limit } => {
-                    store.dispatch(P2pChannelsSnarkRequestReceivedAction { peer_id, limit })
+                    store.dispatch(P2pChannelsSnarkAction::RequestReceived { peer_id, limit })
                 }
                 SnarkPropagationChannelMsg::WillSend { count } => {
-                    store.dispatch(P2pChannelsSnarkPromiseReceivedAction {
+                    store.dispatch(P2pChannelsSnarkAction::PromiseReceived {
                         peer_id,
                         promised_count: count,
                     })
                 }
                 SnarkPropagationChannelMsg::Snark(snark) => {
-                    store.dispatch(P2pChannelsSnarkReceivedAction { peer_id, snark })
+                    store.dispatch(P2pChannelsSnarkAction::Received { peer_id, snark })
                 }
             },
             ChannelMsg::SnarkJobCommitmentPropagation(msg) => match msg {

--- a/p2p/src/channels/p2p_channels_effects.rs
+++ b/p2p/src/channels/p2p_channels_effects.rs
@@ -13,10 +13,7 @@ use super::{
         P2pChannelsSnarkRequestReceivedAction, SnarkPropagationChannelMsg,
     },
     snark_job_commitment::{
-        P2pChannelsSnarkJobCommitmentPromiseReceivedAction,
-        P2pChannelsSnarkJobCommitmentReceivedAction,
-        P2pChannelsSnarkJobCommitmentRequestReceivedAction,
-        SnarkJobCommitmentPropagationChannelMsg,
+        P2pChannelsSnarkJobCommitmentAction, SnarkJobCommitmentPropagationChannelMsg,
     },
     ChannelMsg, P2pChannelsMessageReceivedAction,
 };
@@ -29,9 +26,7 @@ impl P2pChannelsMessageReceivedAction {
         P2pChannelsSnarkRequestReceivedAction: redux::EnablingCondition<S>,
         P2pChannelsSnarkPromiseReceivedAction: redux::EnablingCondition<S>,
         P2pChannelsSnarkReceivedAction: redux::EnablingCondition<S>,
-        P2pChannelsSnarkJobCommitmentRequestReceivedAction: redux::EnablingCondition<S>,
-        P2pChannelsSnarkJobCommitmentPromiseReceivedAction: redux::EnablingCondition<S>,
-        P2pChannelsSnarkJobCommitmentReceivedAction: redux::EnablingCondition<S>,
+        P2pChannelsSnarkJobCommitmentAction: redux::EnablingCondition<S>,
         P2pChannelsRpcRequestReceivedAction: redux::EnablingCondition<S>,
         P2pChannelsRpcResponseReceivedAction: redux::EnablingCondition<S>,
         P2pDisconnectionInitAction: redux::EnablingCondition<S>,
@@ -64,19 +59,19 @@ impl P2pChannelsMessageReceivedAction {
             },
             ChannelMsg::SnarkJobCommitmentPropagation(msg) => match msg {
                 SnarkJobCommitmentPropagationChannelMsg::GetNext { limit } => {
-                    store.dispatch(P2pChannelsSnarkJobCommitmentRequestReceivedAction {
+                    store.dispatch(P2pChannelsSnarkJobCommitmentAction::RequestReceived {
                         peer_id,
                         limit,
                     })
                 }
                 SnarkJobCommitmentPropagationChannelMsg::WillSend { count } => {
-                    store.dispatch(P2pChannelsSnarkJobCommitmentPromiseReceivedAction {
+                    store.dispatch(P2pChannelsSnarkJobCommitmentAction::PromiseReceived {
                         peer_id,
                         promised_count: count,
                     })
                 }
                 SnarkJobCommitmentPropagationChannelMsg::Commitment(commitment) => {
-                    store.dispatch(P2pChannelsSnarkJobCommitmentReceivedAction {
+                    store.dispatch(P2pChannelsSnarkJobCommitmentAction::Received {
                         peer_id,
                         commitment,
                     })

--- a/p2p/src/channels/p2p_channels_effects.rs
+++ b/p2p/src/channels/p2p_channels_effects.rs
@@ -4,10 +4,7 @@ use redux::ActionMeta;
 use crate::disconnection::{P2pDisconnectionInitAction, P2pDisconnectionReason};
 
 use super::{
-    best_tip::{
-        BestTipPropagationChannelMsg, P2pChannelsBestTipReceivedAction,
-        P2pChannelsBestTipRequestReceivedAction,
-    },
+    best_tip::{BestTipPropagationChannelMsg, P2pChannelsBestTipAction},
     rpc::{
         P2pChannelsRpcRequestReceivedAction, P2pChannelsRpcResponseReceivedAction, RpcChannelMsg,
     },
@@ -28,8 +25,7 @@ impl P2pChannelsMessageReceivedAction {
     pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
     where
         Store: crate::P2pStore<S>,
-        P2pChannelsBestTipRequestReceivedAction: redux::EnablingCondition<S>,
-        P2pChannelsBestTipReceivedAction: redux::EnablingCondition<S>,
+        P2pChannelsBestTipAction: redux::EnablingCondition<S>,
         P2pChannelsSnarkRequestReceivedAction: redux::EnablingCondition<S>,
         P2pChannelsSnarkPromiseReceivedAction: redux::EnablingCondition<S>,
         P2pChannelsSnarkReceivedAction: redux::EnablingCondition<S>,
@@ -45,11 +41,11 @@ impl P2pChannelsMessageReceivedAction {
         let was_expected = match self.message {
             ChannelMsg::BestTipPropagation(msg) => match msg {
                 BestTipPropagationChannelMsg::GetNext => {
-                    store.dispatch(P2pChannelsBestTipRequestReceivedAction { peer_id })
+                    store.dispatch(P2pChannelsBestTipAction::RequestReceived { peer_id })
                 }
                 BestTipPropagationChannelMsg::BestTip(best_tip) => {
                     let best_tip = BlockWithHash::new(best_tip);
-                    store.dispatch(P2pChannelsBestTipReceivedAction { peer_id, best_tip })
+                    store.dispatch(P2pChannelsBestTipAction::Received { peer_id, best_tip })
                 }
             },
             ChannelMsg::SnarkPropagation(msg) => match msg {

--- a/p2p/src/channels/p2p_channels_effects.rs
+++ b/p2p/src/channels/p2p_channels_effects.rs
@@ -5,9 +5,7 @@ use crate::disconnection::{P2pDisconnectionInitAction, P2pDisconnectionReason};
 
 use super::{
     best_tip::{BestTipPropagationChannelMsg, P2pChannelsBestTipAction},
-    rpc::{
-        P2pChannelsRpcRequestReceivedAction, P2pChannelsRpcResponseReceivedAction, RpcChannelMsg,
-    },
+    rpc::{P2pChannelsRpcAction, RpcChannelMsg},
     snark::{P2pChannelsSnarkAction, SnarkPropagationChannelMsg},
     snark_job_commitment::{
         P2pChannelsSnarkJobCommitmentAction, SnarkJobCommitmentPropagationChannelMsg,
@@ -22,8 +20,7 @@ impl P2pChannelsMessageReceivedAction {
         P2pChannelsBestTipAction: redux::EnablingCondition<S>,
         P2pChannelsSnarkAction: redux::EnablingCondition<S>,
         P2pChannelsSnarkJobCommitmentAction: redux::EnablingCondition<S>,
-        P2pChannelsRpcRequestReceivedAction: redux::EnablingCondition<S>,
-        P2pChannelsRpcResponseReceivedAction: redux::EnablingCondition<S>,
+        P2pChannelsRpcAction: redux::EnablingCondition<S>,
         P2pDisconnectionInitAction: redux::EnablingCondition<S>,
     {
         let peer_id = self.peer_id;
@@ -74,14 +71,14 @@ impl P2pChannelsMessageReceivedAction {
             },
             ChannelMsg::Rpc(msg) => match msg {
                 RpcChannelMsg::Request(id, request) => {
-                    store.dispatch(P2pChannelsRpcRequestReceivedAction {
+                    store.dispatch(P2pChannelsRpcAction::RequestReceived {
                         peer_id,
                         id,
                         request,
                     })
                 }
                 RpcChannelMsg::Response(id, response) => {
-                    store.dispatch(P2pChannelsRpcResponseReceivedAction {
+                    store.dispatch(P2pChannelsRpcAction::ResponseReceived {
                         peer_id,
                         id,
                         response,

--- a/p2p/src/channels/rpc/p2p_channels_rpc_actions.rs
+++ b/p2p/src/channels/rpc/p2p_channels_rpc_actions.rs
@@ -138,7 +138,7 @@ pub struct P2pChannelsRpcResponseReceivedAction {
 impl redux::EnablingCondition<P2pState> for P2pChannelsRpcResponseReceivedAction {
     fn is_enabled(&self, state: &P2pState) -> bool {
         // TODO(binier): use consensus to enforce that peer doesn't send
-        // us inferrior block than it has in the past.
+        // us inferior block than it has in the past.
         state
             .get_ready_peer(&self.peer_id)
             .map_or(false, |p| match &p.channels.rpc {

--- a/p2p/src/channels/rpc/p2p_channels_rpc_actions.rs
+++ b/p2p/src/channels/rpc/p2p_channels_rpc_actions.rs
@@ -8,244 +8,131 @@ pub type P2pChannelsRpcActionWithMetaRef<'a> = redux::ActionWithMeta<&'a P2pChan
 
 pub const MAX_P2P_RPC_REMOTE_CONCURRENT_REQUESTS: usize = 5;
 
-#[derive(derive_more::From, Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum P2pChannelsRpcAction {
-    Init(P2pChannelsRpcInitAction),
-    Pending(P2pChannelsRpcPendingAction),
-    Ready(P2pChannelsRpcReadyAction),
-
-    RequestSend(P2pChannelsRpcRequestSendAction),
-    Timeout(P2pChannelsRpcTimeoutAction),
-    ResponseReceived(P2pChannelsRpcResponseReceivedAction),
-
-    RequestReceived(P2pChannelsRpcRequestReceivedAction),
-    ResponseSend(P2pChannelsRpcResponseSendAction),
+    Init {
+        peer_id: PeerId,
+    },
+    Pending {
+        peer_id: PeerId,
+    },
+    Ready {
+        peer_id: PeerId,
+    },
+    RequestSend {
+        peer_id: PeerId,
+        id: P2pRpcId,
+        request: P2pRpcRequest,
+    },
+    Timeout {
+        peer_id: PeerId,
+        id: P2pRpcId,
+    },
+    ResponseReceived {
+        peer_id: PeerId,
+        id: P2pRpcId,
+        response: Option<P2pRpcResponse>,
+    },
+    RequestReceived {
+        peer_id: PeerId,
+        id: P2pRpcId,
+        request: P2pRpcRequest,
+    },
+    ResponseSend {
+        peer_id: PeerId,
+        id: P2pRpcId,
+        response: Option<P2pRpcResponse>,
+    },
 }
 
 impl P2pChannelsRpcAction {
     pub fn peer_id(&self) -> &PeerId {
         match self {
-            Self::Init(v) => &v.peer_id,
-            Self::Pending(v) => &v.peer_id,
-            Self::Ready(v) => &v.peer_id,
-            Self::RequestSend(v) => &v.peer_id,
-            Self::Timeout(v) => &v.peer_id,
-            Self::ResponseReceived(v) => &v.peer_id,
-            Self::RequestReceived(v) => &v.peer_id,
-            Self::ResponseSend(v) => &v.peer_id,
+            Self::Init { peer_id }
+            | Self::Pending { peer_id }
+            | Self::Ready { peer_id }
+            | Self::RequestSend { peer_id, .. }
+            | Self::Timeout { peer_id, .. }
+            | Self::ResponseReceived { peer_id, .. }
+            | Self::RequestReceived { peer_id, .. }
+            | Self::ResponseSend { peer_id, .. } => peer_id,
         }
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pChannelsRpcInitAction {
-    pub peer_id: PeerId,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pChannelsRpcInitAction {
+impl redux::EnablingCondition<P2pState> for P2pChannelsRpcAction {
     fn is_enabled(&self, state: &P2pState) -> bool {
-        state.get_ready_peer(&self.peer_id).map_or(false, |p| {
-            matches!(&p.channels.rpc, P2pChannelsRpcState::Enabled)
-        })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pChannelsRpcPendingAction {
-    pub peer_id: PeerId,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pChannelsRpcPendingAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state.get_ready_peer(&self.peer_id).map_or(false, |p| {
-            matches!(&p.channels.rpc, P2pChannelsRpcState::Init { .. })
-        })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pChannelsRpcReadyAction {
-    pub peer_id: PeerId,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pChannelsRpcReadyAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state.get_ready_peer(&self.peer_id).map_or(false, |p| {
-            matches!(&p.channels.rpc, P2pChannelsRpcState::Pending { .. })
-        })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pChannelsRpcRequestSendAction {
-    pub peer_id: PeerId,
-    pub id: P2pRpcId,
-    pub request: P2pRpcRequest,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pChannelsRpcRequestSendAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .peers
-            .get(&self.peer_id)
-            .filter(|p| !p.is_libp2p() || self.request.kind().supported_by_libp2p())
-            .and_then(|p| p.status.as_ready())
-            .map_or(false, |p| match &p.channels.rpc {
-                P2pChannelsRpcState::Ready {
-                    local,
-                    next_local_rpc_id,
-                    ..
-                } => {
-                    *next_local_rpc_id == self.id
-                        && matches!(
-                            local,
-                            P2pRpcLocalState::WaitingForRequest { .. }
-                                | P2pRpcLocalState::Responded { .. }
-                        )
-                }
-                _ => false,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pChannelsRpcTimeoutAction {
-    pub peer_id: PeerId,
-    pub id: P2pRpcId,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pChannelsRpcTimeoutAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .get_ready_peer(&self.peer_id)
-            .map_or(false, |p| match &p.channels.rpc {
-                P2pChannelsRpcState::Ready { local, .. } => match local {
-                    P2pRpcLocalState::Requested { id, .. } => *id == self.id,
+        match self {
+            P2pChannelsRpcAction::Init { peer_id } => {
+                state.get_ready_peer(peer_id).map_or(false, |p| {
+                    matches!(p.channels.rpc, P2pChannelsRpcState::Enabled)
+                })
+            },
+            P2pChannelsRpcAction::Pending { peer_id } => {
+                state.get_ready_peer(peer_id).map_or(false, |p| {
+                    matches!(p.channels.rpc, P2pChannelsRpcState::Init { .. })
+                })
+            },
+            P2pChannelsRpcAction::Ready { peer_id } => {
+                state.get_ready_peer(peer_id).map_or(false, |p| {
+                    matches!(p.channels.rpc, P2pChannelsRpcState::Pending { .. })
+                })
+            },
+            P2pChannelsRpcAction::RequestSend { peer_id, id, request } => {
+                state.peers.get(peer_id)
+                    .filter(|p| !p.is_libp2p() || request.kind().supported_by_libp2p())
+                    .and_then(|p| p.status.as_ready())
+                    .map_or(false, |p| match &p.channels.rpc {
+                        P2pChannelsRpcState::Ready { local, next_local_rpc_id, .. } => {
+                            next_local_rpc_id == id && matches!(
+                                local,
+                                P2pRpcLocalState::WaitingForRequest { .. } | P2pRpcLocalState::Responded { .. }
+                            )
+                        },
+                        _ => false,
+                    })
+            },
+            P2pChannelsRpcAction::Timeout { peer_id, id } => {
+                state.get_ready_peer(peer_id).map_or(false, |p| match &p.channels.rpc {
+                    P2pChannelsRpcState::Ready { local, .. } => {
+                        matches!(local, P2pRpcLocalState::Requested { id: rpc_id, .. } if rpc_id == id)
+                    },
                     _ => false,
-                },
-                _ => false,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pChannelsRpcResponseReceivedAction {
-    pub peer_id: PeerId,
-    pub id: P2pRpcId,
-    pub response: Option<P2pRpcResponse>,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pChannelsRpcResponseReceivedAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        // TODO(binier): use consensus to enforce that peer doesn't send
-        // us inferior block than it has in the past.
-        state
-            .get_ready_peer(&self.peer_id)
-            .map_or(false, |p| match &p.channels.rpc {
-                P2pChannelsRpcState::Ready { local, .. } => match local {
-                    // TODO(binier): validate that response corresponds to request.
-                    P2pRpcLocalState::Requested { id, .. } => *id == self.id,
+                })
+            },
+            P2pChannelsRpcAction::ResponseReceived { peer_id, id, .. } => {
+                state.get_ready_peer(peer_id).map_or(false, |p| match &p.channels.rpc {
+                    P2pChannelsRpcState::Ready { local, .. } => {
+                        matches!(local, P2pRpcLocalState::Requested { id: rpc_id, .. } if rpc_id == id)
+                    },
                     _ => false,
-                },
-                _ => false,
-            })
+                })
+            },
+            P2pChannelsRpcAction::RequestReceived { peer_id, id, .. } => {
+                state.get_ready_peer(peer_id).map_or(false, |p| match &p.channels.rpc {
+                    P2pChannelsRpcState::Ready { remote, .. } => {
+                        remote.pending_requests.len() < MAX_P2P_RPC_REMOTE_CONCURRENT_REQUESTS &&
+                        remote.pending_requests.iter().all(|v| v.id != *id)
+                    },
+                    _ => false,
+                })
+            },
+            P2pChannelsRpcAction::ResponseSend { peer_id, id, .. } => {
+                state.get_ready_peer(peer_id).map_or(false, |p| match &p.channels.rpc {
+                    P2pChannelsRpcState::Ready { remote, .. } => {
+                        remote.pending_requests.iter().any(|v| v.id == *id)
+                    },
+                    _ => false,
+                })
+            },
+        }
     }
 }
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pChannelsRpcRequestReceivedAction {
-    pub peer_id: PeerId,
-    pub id: P2pRpcId,
-    pub request: P2pRpcRequest,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pChannelsRpcRequestReceivedAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .get_ready_peer(&self.peer_id)
-            .map_or(false, |p| match &p.channels.rpc {
-                P2pChannelsRpcState::Ready { remote, .. } => {
-                    remote.pending_requests.len() < MAX_P2P_RPC_REMOTE_CONCURRENT_REQUESTS
-                        && remote.pending_requests.iter().all(|v| v.id != self.id)
-                }
-                _ => false,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pChannelsRpcResponseSendAction {
-    pub peer_id: PeerId,
-    pub id: P2pRpcId,
-    pub response: Option<P2pRpcResponse>,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pChannelsRpcResponseSendAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .get_ready_peer(&self.peer_id)
-            .map_or(false, |p| match &p.channels.rpc {
-                P2pChannelsRpcState::Ready { remote, .. } => {
-                    // TODO(binier): validate that response corresponds to request.
-                    remote
-                        .pending_requests
-                        .iter()
-                        .find(|v| v.id == self.id)
-                        .is_some()
-                }
-                _ => false,
-            })
-    }
-}
-
-// --- From<LeafAction> for Action impls.
 
 use crate::channels::P2pChannelsAction;
 
-impl From<P2pChannelsRpcInitAction> for crate::P2pAction {
-    fn from(a: P2pChannelsRpcInitAction) -> Self {
-        Self::Channels(P2pChannelsAction::Rpc(a.into()))
-    }
-}
-
-impl From<P2pChannelsRpcPendingAction> for crate::P2pAction {
-    fn from(a: P2pChannelsRpcPendingAction) -> Self {
-        Self::Channels(P2pChannelsAction::Rpc(a.into()))
-    }
-}
-
-impl From<P2pChannelsRpcReadyAction> for crate::P2pAction {
-    fn from(a: P2pChannelsRpcReadyAction) -> Self {
-        Self::Channels(P2pChannelsAction::Rpc(a.into()))
-    }
-}
-
-impl From<P2pChannelsRpcRequestSendAction> for crate::P2pAction {
-    fn from(a: P2pChannelsRpcRequestSendAction) -> Self {
-        Self::Channels(P2pChannelsAction::Rpc(a.into()))
-    }
-}
-
-impl From<P2pChannelsRpcTimeoutAction> for crate::P2pAction {
-    fn from(a: P2pChannelsRpcTimeoutAction) -> Self {
-        Self::Channels(P2pChannelsAction::Rpc(a.into()))
-    }
-}
-
-impl From<P2pChannelsRpcResponseReceivedAction> for crate::P2pAction {
-    fn from(a: P2pChannelsRpcResponseReceivedAction) -> Self {
-        Self::Channels(P2pChannelsAction::Rpc(a.into()))
-    }
-}
-
-impl From<P2pChannelsRpcRequestReceivedAction> for crate::P2pAction {
-    fn from(a: P2pChannelsRpcRequestReceivedAction) -> Self {
-        Self::Channels(P2pChannelsAction::Rpc(a.into()))
-    }
-}
-
-impl From<P2pChannelsRpcResponseSendAction> for crate::P2pAction {
-    fn from(a: P2pChannelsRpcResponseSendAction) -> Self {
-        Self::Channels(P2pChannelsAction::Rpc(a.into()))
+impl From<P2pChannelsRpcAction> for crate::P2pAction {
+    fn from(a: P2pChannelsRpcAction) -> Self {
+        Self::Channels(P2pChannelsAction::Rpc(a))
     }
 }

--- a/p2p/src/channels/rpc/p2p_channels_rpc_actions.rs
+++ b/p2p/src/channels/rpc/p2p_channels_rpc_actions.rs
@@ -101,8 +101,11 @@ impl redux::EnablingCondition<P2pState> for P2pChannelsRpcAction {
                 })
             },
             P2pChannelsRpcAction::ResponseReceived { peer_id, id, .. } => {
+                // TODO(binier): use consensus to enforce that peer doesn't send
+                // us inferior block than it has in the past.
                 state.get_ready_peer(peer_id).map_or(false, |p| match &p.channels.rpc {
                     P2pChannelsRpcState::Ready { local, .. } => {
+                        // TODO(binier): validate that response corresponds to request.
                         matches!(local, P2pRpcLocalState::Requested { id: rpc_id, .. } if rpc_id == id)
                     },
                     _ => false,
@@ -120,6 +123,7 @@ impl redux::EnablingCondition<P2pState> for P2pChannelsRpcAction {
             P2pChannelsRpcAction::ResponseSend { peer_id, id, .. } => {
                 state.get_ready_peer(peer_id).map_or(false, |p| match &p.channels.rpc {
                     P2pChannelsRpcState::Ready { remote, .. } => {
+                        // TODO(binier): validate that response corresponds to request.
                         remote.pending_requests.iter().any(|v| v.id == *id)
                     },
                     _ => false,

--- a/p2p/src/channels/rpc/p2p_channels_rpc_effects.rs
+++ b/p2p/src/channels/rpc/p2p_channels_rpc_effects.rs
@@ -6,65 +6,55 @@ use crate::{
     peer::P2pPeerBestTipUpdateAction,
 };
 
-use super::{
-    P2pChannelsRpcInitAction, P2pChannelsRpcPendingAction, P2pChannelsRpcRequestSendAction,
-    P2pChannelsRpcResponseReceivedAction, P2pChannelsRpcResponseSendAction, P2pRpcResponse,
-    RpcChannelMsg,
-};
+use super::{P2pChannelsRpcAction, P2pRpcResponse, RpcChannelMsg};
 
-impl P2pChannelsRpcInitAction {
+impl P2pChannelsRpcAction {
     pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
     where
         Store: crate::P2pStore<S>,
         Store::Service: P2pChannelsService,
-        P2pChannelsRpcPendingAction: redux::EnablingCondition<S>,
-    {
-        let peer_id = self.peer_id;
-        store.service().channel_open(peer_id, ChannelId::Rpc);
-        store.dispatch(P2pChannelsRpcPendingAction { peer_id });
-    }
-}
-
-impl P2pChannelsRpcRequestSendAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-        Store::Service: P2pChannelsService,
-    {
-        let msg = RpcChannelMsg::Request(self.id, self.request);
-        store
-            .service()
-            .channel_send(self.peer_id, MsgId::first(), msg.into());
-    }
-}
-
-impl P2pChannelsRpcResponseReceivedAction {
-    pub fn effects<Store, S>(&self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
         P2pPeerBestTipUpdateAction: redux::EnablingCondition<S>,
+        Self: redux::EnablingCondition<S>,
     {
-        match &self.response {
-            Some(P2pRpcResponse::BestTipWithProof(resp)) => {
-                store.dispatch(P2pPeerBestTipUpdateAction {
-                    peer_id: self.peer_id,
-                    best_tip: BlockWithHash::new(resp.best_tip.clone()),
-                });
+        match self {
+            P2pChannelsRpcAction::Init { peer_id } => {
+                store.service().channel_open(peer_id, ChannelId::Rpc);
+                store.dispatch(P2pChannelsRpcAction::Pending { peer_id });
             }
-            _ => {}
+            P2pChannelsRpcAction::RequestSend {
+                peer_id,
+                id,
+                request,
+            } => {
+                let msg = RpcChannelMsg::Request(id, request);
+                store
+                    .service()
+                    .channel_send(peer_id, MsgId::first(), msg.into());
+            }
+            P2pChannelsRpcAction::ResponseReceived {
+                peer_id, response, ..
+            } => {
+                if let Some(P2pRpcResponse::BestTipWithProof(resp)) = response {
+                    store.dispatch(P2pPeerBestTipUpdateAction {
+                        peer_id,
+                        best_tip: BlockWithHash::new(resp.best_tip.clone()),
+                    });
+                }
+            }
+            P2pChannelsRpcAction::ResponseSend {
+                peer_id,
+                id,
+                response,
+            } => {
+                let msg = RpcChannelMsg::Response(id, response);
+                store
+                    .service()
+                    .channel_send(peer_id, MsgId::first(), msg.into());
+            }
+            P2pChannelsRpcAction::Pending { .. }
+            | P2pChannelsRpcAction::Ready { .. }
+            | P2pChannelsRpcAction::Timeout { .. }
+            | P2pChannelsRpcAction::RequestReceived { .. } => {}
         }
-    }
-}
-
-impl P2pChannelsRpcResponseSendAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-        Store::Service: P2pChannelsService,
-    {
-        let msg = RpcChannelMsg::Response(self.id, self.response);
-        store
-            .service()
-            .channel_send(self.peer_id, MsgId::first(), msg.into());
     }
 }

--- a/p2p/src/channels/rpc/p2p_channels_rpc_reducer.rs
+++ b/p2p/src/channels/rpc/p2p_channels_rpc_reducer.rs
@@ -7,13 +7,13 @@ impl P2pChannelsRpcState {
     pub fn reducer(&mut self, action: P2pChannelsRpcActionWithMetaRef<'_>) {
         let (action, meta) = action.split();
         match action {
-            P2pChannelsRpcAction::Init(_) => {
+            P2pChannelsRpcAction::Init { .. } => {
                 *self = Self::Init { time: meta.time() };
             }
-            P2pChannelsRpcAction::Pending(_) => {
+            P2pChannelsRpcAction::Pending { .. } => {
                 *self = Self::Pending { time: meta.time() };
             }
-            P2pChannelsRpcAction::Ready(_) => {
+            P2pChannelsRpcAction::Ready { .. } => {
                 *self = Self::Ready {
                     time: meta.time(),
                     local: P2pRpcLocalState::WaitingForRequest { time: meta.time() },
@@ -25,7 +25,7 @@ impl P2pChannelsRpcState {
                     next_local_rpc_id: 0,
                 };
             }
-            P2pChannelsRpcAction::RequestSend(action) => {
+            P2pChannelsRpcAction::RequestSend { id, request, .. } => {
                 let Self::Ready {
                     local,
                     next_local_rpc_id,
@@ -37,50 +37,43 @@ impl P2pChannelsRpcState {
                 *next_local_rpc_id += 1;
                 *local = P2pRpcLocalState::Requested {
                     time: meta.time(),
-                    id: action.id,
-                    request: action.request.clone(),
+                    id: *id,
+                    request: request.clone(),
                 };
             }
-            P2pChannelsRpcAction::Timeout(_) => {}
-            P2pChannelsRpcAction::ResponseReceived(_) => {
+            P2pChannelsRpcAction::Timeout { .. } => {}
+            P2pChannelsRpcAction::ResponseReceived { .. } => {
                 let Self::Ready { local, .. } = self else {
                     return;
                 };
                 let P2pRpcLocalState::Requested { id, request, .. } = local else {
                     return;
                 };
-
                 *local = P2pRpcLocalState::Responded {
                     time: meta.time(),
                     id: *id,
                     request: std::mem::take(request),
                 };
             }
-            P2pChannelsRpcAction::RequestReceived(action) => {
+            P2pChannelsRpcAction::RequestReceived { id, request, .. } => {
                 let Self::Ready { remote, .. } = self else {
                     return;
                 };
-
                 remote
                     .pending_requests
                     .push(P2pRpcRemotePendingRequestState {
                         time: meta.time(),
-                        id: action.id,
-                        request: action.request.clone(),
+                        id: *id,
+                        request: request.clone(),
                     });
             }
-            P2pChannelsRpcAction::ResponseSend(action) => {
+            P2pChannelsRpcAction::ResponseSend { id, .. } => {
                 let Self::Ready { remote, .. } = self else {
                     return;
                 };
-                let Some(i) = remote
-                    .pending_requests
-                    .iter()
-                    .position(|v| v.id == action.id)
-                else {
-                    return;
-                };
-                remote.pending_requests.remove(i);
+                if let Some(pos) = remote.pending_requests.iter().position(|r| r.id == *id) {
+                    remote.pending_requests.remove(pos);
+                }
             }
         }
     }

--- a/p2p/src/channels/snark/p2p_channels_snark_actions.rs
+++ b/p2p/src/channels/snark/p2p_channels_snark_actions.rs
@@ -1,297 +1,181 @@
+use crate::{channels::P2pChannelsAction, P2pState, PeerId};
 use openmina_core::snark::Snark;
 use serde::{Deserialize, Serialize};
-
-use crate::{P2pState, PeerId};
 
 use super::{P2pChannelsSnarkState, SnarkInfo, SnarkPropagationState};
 
 pub type P2pChannelsSnarkActionWithMetaRef<'a> = redux::ActionWithMeta<&'a P2pChannelsSnarkAction>;
 
-#[derive(derive_more::From, Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum P2pChannelsSnarkAction {
-    Init(P2pChannelsSnarkInitAction),
-    Pending(P2pChannelsSnarkPendingAction),
-    Ready(P2pChannelsSnarkReadyAction),
-
-    RequestSend(P2pChannelsSnarkRequestSendAction),
-    PromiseReceived(P2pChannelsSnarkPromiseReceivedAction),
-    Received(P2pChannelsSnarkReceivedAction),
-
-    RequestReceived(P2pChannelsSnarkRequestReceivedAction),
-    ResponseSend(P2pChannelsSnarkResponseSendAction),
-
-    Libp2pReceived(P2pChannelsSnarkLibp2pReceivedAction),
-    Libp2pBroadcast(P2pChannelsSnarkLibp2pBroadcastAction),
+    Init {
+        peer_id: PeerId,
+    },
+    Pending {
+        peer_id: PeerId,
+    },
+    Ready {
+        peer_id: PeerId,
+    },
+    RequestSend {
+        peer_id: PeerId,
+        limit: u8,
+    },
+    PromiseReceived {
+        peer_id: PeerId,
+        promised_count: u8,
+    },
+    Received {
+        peer_id: PeerId,
+        snark: SnarkInfo,
+    },
+    RequestReceived {
+        peer_id: PeerId,
+        limit: u8,
+    },
+    ResponseSend {
+        peer_id: PeerId,
+        snarks: Vec<SnarkInfo>,
+        first_index: u64,
+        last_index: u64,
+    },
+    Libp2pReceived {
+        peer_id: PeerId,
+        snark: Snark,
+        nonce: u32,
+    },
+    Libp2pBroadcast {
+        snark: Snark,
+        nonce: u32,
+    },
 }
 
 impl P2pChannelsSnarkAction {
     pub fn peer_id(&self) -> Option<&PeerId> {
-        Some(match self {
-            Self::Init(v) => &v.peer_id,
-            Self::Pending(v) => &v.peer_id,
-            Self::Ready(v) => &v.peer_id,
-            Self::RequestSend(v) => &v.peer_id,
-            Self::PromiseReceived(v) => &v.peer_id,
-            Self::Received(v) => &v.peer_id,
-            Self::RequestReceived(v) => &v.peer_id,
-            Self::ResponseSend(v) => &v.peer_id,
-            Self::Libp2pReceived(_) | Self::Libp2pBroadcast(_) => return None,
-        })
+        match self {
+            Self::Init { peer_id }
+            | Self::Pending { peer_id }
+            | Self::Ready { peer_id }
+            | Self::RequestSend { peer_id, .. }
+            | Self::PromiseReceived { peer_id, .. }
+            | Self::Received { peer_id, .. }
+            | Self::RequestReceived { peer_id, .. }
+            | Self::ResponseSend { peer_id, .. }
+            | Self::Libp2pReceived { peer_id, .. } => Some(peer_id),
+            Self::Libp2pBroadcast { .. } => None,
+        }
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pChannelsSnarkInitAction {
-    pub peer_id: PeerId,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pChannelsSnarkInitAction {
+impl redux::EnablingCondition<P2pState> for P2pChannelsSnarkAction {
     fn is_enabled(&self, state: &P2pState) -> bool {
-        state.get_ready_peer(&self.peer_id).map_or(false, |p| {
-            matches!(&p.channels.snark, P2pChannelsSnarkState::Enabled)
-        })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pChannelsSnarkPendingAction {
-    pub peer_id: PeerId,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pChannelsSnarkPendingAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state.get_ready_peer(&self.peer_id).map_or(false, |p| {
-            matches!(&p.channels.snark, P2pChannelsSnarkState::Init { .. })
-        })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pChannelsSnarkReadyAction {
-    pub peer_id: PeerId,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pChannelsSnarkReadyAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state.get_ready_peer(&self.peer_id).map_or(false, |p| {
-            matches!(&p.channels.snark, P2pChannelsSnarkState::Pending { .. })
-        })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pChannelsSnarkRequestSendAction {
-    pub peer_id: PeerId,
-    pub limit: u8,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pChannelsSnarkRequestSendAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .get_ready_peer(&self.peer_id)
-            .map_or(false, |p| match &p.channels.snark {
-                P2pChannelsSnarkState::Ready { local, .. } => match local {
-                    SnarkPropagationState::WaitingForRequest { .. } => true,
-                    SnarkPropagationState::Responded { .. } => true,
-                    _ => false,
-                },
-                _ => false,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pChannelsSnarkPromiseReceivedAction {
-    pub peer_id: PeerId,
-    pub promised_count: u8,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pChannelsSnarkPromiseReceivedAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .get_ready_peer(&self.peer_id)
-            .map_or(false, |p| match &p.channels.snark {
-                P2pChannelsSnarkState::Ready { local, .. } => match local {
-                    SnarkPropagationState::Requested {
-                        requested_limit, ..
-                    } => self.promised_count > 0 && self.promised_count <= *requested_limit,
-                    _ => false,
-                },
-                _ => false,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pChannelsSnarkReceivedAction {
-    pub peer_id: PeerId,
-    pub snark: SnarkInfo,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pChannelsSnarkReceivedAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .get_ready_peer(&self.peer_id)
-            .map_or(false, |p| match &p.channels.snark {
-                P2pChannelsSnarkState::Ready { local, .. } => match local {
-                    SnarkPropagationState::Responding { .. } => true,
-                    _ => false,
-                },
-                _ => false,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pChannelsSnarkRequestReceivedAction {
-    pub peer_id: PeerId,
-    pub limit: u8,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pChannelsSnarkRequestReceivedAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        self.limit > 0
-            && state
-                .get_ready_peer(&self.peer_id)
+        match self {
+            P2pChannelsSnarkAction::Init { peer_id } => {
+                state.get_ready_peer(peer_id).map_or(false, |p| {
+                    matches!(&p.channels.snark, P2pChannelsSnarkState::Enabled)
+                })
+            }
+            P2pChannelsSnarkAction::Pending { peer_id } => {
+                state.get_ready_peer(peer_id).map_or(false, |p| {
+                    matches!(&p.channels.snark, P2pChannelsSnarkState::Init { .. })
+                })
+            }
+            P2pChannelsSnarkAction::Ready { peer_id } => {
+                state.get_ready_peer(peer_id).map_or(false, |p| {
+                    matches!(&p.channels.snark, P2pChannelsSnarkState::Pending { .. })
+                })
+            }
+            P2pChannelsSnarkAction::RequestSend { peer_id, .. } => state
+                .get_ready_peer(peer_id)
                 .map_or(false, |p| match &p.channels.snark {
-                    P2pChannelsSnarkState::Ready { remote, .. } => match remote {
+                    P2pChannelsSnarkState::Ready { local, .. } => match local {
                         SnarkPropagationState::WaitingForRequest { .. } => true,
                         SnarkPropagationState::Responded { .. } => true,
                         _ => false,
                     },
                     _ => false,
-                })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pChannelsSnarkResponseSendAction {
-    pub peer_id: PeerId,
-    pub snarks: Vec<SnarkInfo>,
-    pub first_index: u64,
-    pub last_index: u64,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pChannelsSnarkResponseSendAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        !self.snarks.is_empty()
-            && self.first_index < self.last_index
-            && state
-                .get_ready_peer(&self.peer_id)
+                }),
+            P2pChannelsSnarkAction::PromiseReceived {
+                peer_id,
+                promised_count,
+            } => state
+                .get_ready_peer(peer_id)
                 .map_or(false, |p| match &p.channels.snark {
-                    P2pChannelsSnarkState::Ready {
-                        remote,
-                        next_send_index,
-                        ..
-                    } => {
-                        if self.first_index < *next_send_index {
-                            return false;
-                        }
-                        match remote {
-                            SnarkPropagationState::Requested {
-                                requested_limit, ..
-                            } => self.snarks.len() <= *requested_limit as usize,
-                            _ => false,
-                        }
-                    }
+                    P2pChannelsSnarkState::Ready { local, .. } => match local {
+                        SnarkPropagationState::Requested {
+                            requested_limit, ..
+                        } => *promised_count > 0 && promised_count <= requested_limit,
+                        _ => false,
+                    },
                     _ => false,
-                })
+                }),
+            P2pChannelsSnarkAction::Received { peer_id, .. } => state
+                .get_ready_peer(peer_id)
+                .map_or(false, |p| match &p.channels.snark {
+                    P2pChannelsSnarkState::Ready { local, .. } => match local {
+                        SnarkPropagationState::Responding { .. } => true,
+                        _ => false,
+                    },
+                    _ => false,
+                }),
+            P2pChannelsSnarkAction::RequestReceived { peer_id, limit } => {
+                *limit > 0
+                    && state
+                        .get_ready_peer(peer_id)
+                        .map_or(false, |p| match &p.channels.snark {
+                            P2pChannelsSnarkState::Ready { remote, .. } => match remote {
+                                SnarkPropagationState::WaitingForRequest { .. } => true,
+                                SnarkPropagationState::Responded { .. } => true,
+                                _ => false,
+                            },
+                            _ => false,
+                        })
+            }
+            P2pChannelsSnarkAction::ResponseSend {
+                peer_id,
+                snarks,
+                first_index,
+                last_index,
+            } => {
+                !snarks.is_empty()
+                    && first_index < last_index
+                    && state
+                        .get_ready_peer(peer_id)
+                        .map_or(false, |p| match &p.channels.snark {
+                            P2pChannelsSnarkState::Ready {
+                                remote,
+                                next_send_index,
+                                ..
+                            } => {
+                                if first_index < next_send_index {
+                                    return false;
+                                }
+                                match remote {
+                                    SnarkPropagationState::Requested {
+                                        requested_limit, ..
+                                    } => snarks.len() <= *requested_limit as usize,
+                                    _ => false,
+                                }
+                            }
+                            _ => false,
+                        })
+            }
+            P2pChannelsSnarkAction::Libp2pReceived { peer_id, .. } => state
+                .peers
+                .get(peer_id)
+                .filter(|p| p.is_libp2p())
+                .and_then(|p| p.status.as_ready())
+                .map_or(false, |p| p.channels.snark.is_ready()),
+            P2pChannelsSnarkAction::Libp2pBroadcast { .. } => state
+                .peers
+                .iter()
+                .any(|(_, p)| p.is_libp2p() && p.status.as_ready().is_some()),
+        }
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pChannelsSnarkLibp2pReceivedAction {
-    pub peer_id: PeerId,
-    pub snark: Snark,
-    pub nonce: u32,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pChannelsSnarkLibp2pReceivedAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .peers
-            .get(&self.peer_id)
-            .filter(|p| p.is_libp2p())
-            .and_then(|p| p.status.as_ready())
-            .map_or(false, |p| p.channels.snark.is_ready())
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pChannelsSnarkLibp2pBroadcastAction {
-    pub snark: Snark,
-    pub nonce: u32,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pChannelsSnarkLibp2pBroadcastAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .peers
-            .iter()
-            .any(|(_, p)| p.is_libp2p() && p.status.as_ready().is_some())
-    }
-}
-
-// --- From<LeafAction> for Action impls.
-
-use crate::channels::P2pChannelsAction;
-
-impl From<P2pChannelsSnarkInitAction> for crate::P2pAction {
-    fn from(a: P2pChannelsSnarkInitAction) -> Self {
-        Self::Channels(P2pChannelsAction::Snark(a.into()))
-    }
-}
-
-impl From<P2pChannelsSnarkPendingAction> for crate::P2pAction {
-    fn from(a: P2pChannelsSnarkPendingAction) -> Self {
-        Self::Channels(P2pChannelsAction::Snark(a.into()))
-    }
-}
-
-impl From<P2pChannelsSnarkReadyAction> for crate::P2pAction {
-    fn from(a: P2pChannelsSnarkReadyAction) -> Self {
-        Self::Channels(P2pChannelsAction::Snark(a.into()))
-    }
-}
-
-impl From<P2pChannelsSnarkRequestSendAction> for crate::P2pAction {
-    fn from(a: P2pChannelsSnarkRequestSendAction) -> Self {
-        Self::Channels(P2pChannelsAction::Snark(a.into()))
-    }
-}
-
-impl From<P2pChannelsSnarkPromiseReceivedAction> for crate::P2pAction {
-    fn from(a: P2pChannelsSnarkPromiseReceivedAction) -> Self {
-        Self::Channels(P2pChannelsAction::Snark(a.into()))
-    }
-}
-
-impl From<P2pChannelsSnarkReceivedAction> for crate::P2pAction {
-    fn from(a: P2pChannelsSnarkReceivedAction) -> Self {
-        Self::Channels(P2pChannelsAction::Snark(a.into()))
-    }
-}
-
-impl From<P2pChannelsSnarkRequestReceivedAction> for crate::P2pAction {
-    fn from(a: P2pChannelsSnarkRequestReceivedAction) -> Self {
-        Self::Channels(P2pChannelsAction::Snark(a.into()))
-    }
-}
-
-impl From<P2pChannelsSnarkResponseSendAction> for crate::P2pAction {
-    fn from(a: P2pChannelsSnarkResponseSendAction) -> Self {
-        Self::Channels(P2pChannelsAction::Snark(a.into()))
-    }
-}
-
-impl From<P2pChannelsSnarkLibp2pReceivedAction> for crate::P2pAction {
-    fn from(a: P2pChannelsSnarkLibp2pReceivedAction) -> Self {
-        Self::Channels(P2pChannelsAction::Snark(a.into()))
-    }
-}
-
-impl From<P2pChannelsSnarkLibp2pBroadcastAction> for crate::P2pAction {
-    fn from(a: P2pChannelsSnarkLibp2pBroadcastAction) -> Self {
-        Self::Channels(P2pChannelsAction::Snark(a.into()))
+impl From<P2pChannelsSnarkAction> for crate::P2pAction {
+    fn from(action: P2pChannelsSnarkAction) -> Self {
+        Self::Channels(P2pChannelsAction::Snark(action))
     }
 }

--- a/p2p/src/channels/snark/p2p_channels_snark_effects.rs
+++ b/p2p/src/channels/snark/p2p_channels_snark_effects.rs
@@ -2,98 +2,58 @@ use redux::ActionMeta;
 
 use crate::channels::{ChannelId, MsgId, P2pChannelsService};
 
-use super::{
-    P2pChannelsSnarkInitAction, P2pChannelsSnarkLibp2pBroadcastAction,
-    P2pChannelsSnarkPendingAction, P2pChannelsSnarkReadyAction, P2pChannelsSnarkReceivedAction,
-    P2pChannelsSnarkRequestSendAction, P2pChannelsSnarkResponseSendAction,
-    SnarkPropagationChannelMsg,
-};
+use super::{P2pChannelsSnarkAction, SnarkPropagationChannelMsg};
 
-impl P2pChannelsSnarkInitAction {
+impl P2pChannelsSnarkAction {
     pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
     where
         Store: crate::P2pStore<S>,
         Store::Service: P2pChannelsService,
-        P2pChannelsSnarkPendingAction: redux::EnablingCondition<S>,
+        Self: redux::EnablingCondition<S>,
     {
-        let peer_id = self.peer_id;
-        store
-            .service()
-            .channel_open(peer_id, ChannelId::SnarkPropagation);
-        store.dispatch(P2pChannelsSnarkPendingAction { peer_id });
-    }
-}
+        match self {
+            P2pChannelsSnarkAction::Init { peer_id } => {
+                store
+                    .service()
+                    .channel_open(peer_id, ChannelId::SnarkPropagation);
+                store.dispatch(P2pChannelsSnarkAction::Pending { peer_id });
+            }
+            P2pChannelsSnarkAction::Ready { .. } => {}
+            P2pChannelsSnarkAction::RequestSend { peer_id, limit } => {
+                let msg = SnarkPropagationChannelMsg::GetNext { limit };
+                store
+                    .service()
+                    .channel_send(peer_id, MsgId::first(), msg.into());
+            }
+            P2pChannelsSnarkAction::Received { .. } => {}
+            P2pChannelsSnarkAction::ResponseSend {
+                peer_id, snarks, ..
+            } => {
+                if snarks.is_empty() {
+                    return;
+                }
 
-impl P2pChannelsSnarkReadyAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, _store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-        Store::Service: P2pChannelsService,
-        P2pChannelsSnarkRequestSendAction: redux::EnablingCondition<S>,
-    {
-    }
-}
+                let msg = SnarkPropagationChannelMsg::WillSend {
+                    count: snarks.len() as u8,
+                };
+                store
+                    .service()
+                    .channel_send(peer_id, MsgId::first(), msg.into());
 
-impl P2pChannelsSnarkRequestSendAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-        Store::Service: P2pChannelsService,
-    {
-        let peer_id = self.peer_id;
-        let limit = self.limit;
-        let msg = SnarkPropagationChannelMsg::GetNext { limit };
-        store
-            .service()
-            .channel_send(peer_id, MsgId::first(), msg.into());
-    }
-}
-
-impl P2pChannelsSnarkReceivedAction {
-    pub fn effects<Store, S>(&self, _: &ActionMeta, _store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-        Store::Service: P2pChannelsService,
-        P2pChannelsSnarkRequestSendAction: redux::EnablingCondition<S>,
-    {
-    }
-}
-
-impl P2pChannelsSnarkResponseSendAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-        Store::Service: P2pChannelsService,
-    {
-        if self.snarks.is_empty() {
-            return;
+                for snark in snarks {
+                    let msg = SnarkPropagationChannelMsg::Snark(snark);
+                    store
+                        .service()
+                        .channel_send(peer_id, MsgId::first(), msg.into());
+                }
+            }
+            P2pChannelsSnarkAction::Libp2pBroadcast { snark, nonce } => {
+                store.service().libp2p_broadcast_snark(snark, nonce);
+            }
+            P2pChannelsSnarkAction::Pending { .. } => {}
+            P2pChannelsSnarkAction::PromiseReceived { .. } => {}
+            P2pChannelsSnarkAction::RequestReceived { .. } => {}
+            P2pChannelsSnarkAction::Libp2pReceived { .. } => {}
         }
-
-        let peer_id = self.peer_id;
-        let msg = SnarkPropagationChannelMsg::WillSend {
-            count: self.snarks.len() as u8,
-        };
-        store
-            .service()
-            .channel_send(peer_id, MsgId::first(), msg.into());
-
-        for snark in self.snarks {
-            let msg = SnarkPropagationChannelMsg::Snark(snark);
-            store
-                .service()
-                .channel_send(peer_id, MsgId::first(), msg.into());
-        }
-    }
-}
-
-impl P2pChannelsSnarkLibp2pBroadcastAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-        Store::Service: P2pChannelsService,
-    {
-        store
-            .service()
-            .libp2p_broadcast_snark(self.snark, self.nonce);
     }
 }

--- a/p2p/src/channels/snark_job_commitment/p2p_channels_snark_job_commitment_effects.rs
+++ b/p2p/src/channels/snark_job_commitment/p2p_channels_snark_job_commitment_effects.rs
@@ -2,92 +2,62 @@ use redux::ActionMeta;
 
 use crate::channels::{ChannelId, MsgId, P2pChannelsService};
 
-use super::{
-    P2pChannelsSnarkJobCommitmentInitAction, P2pChannelsSnarkJobCommitmentPendingAction,
-    P2pChannelsSnarkJobCommitmentReadyAction, P2pChannelsSnarkJobCommitmentReceivedAction,
-    P2pChannelsSnarkJobCommitmentRequestSendAction,
-    P2pChannelsSnarkJobCommitmentResponseSendAction, SnarkJobCommitmentPropagationChannelMsg,
-};
+use super::{P2pChannelsSnarkJobCommitmentAction, SnarkJobCommitmentPropagationChannelMsg};
 
-impl P2pChannelsSnarkJobCommitmentInitAction {
+impl P2pChannelsSnarkJobCommitmentAction {
     pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
     where
         Store: crate::P2pStore<S>,
         Store::Service: P2pChannelsService,
-        P2pChannelsSnarkJobCommitmentPendingAction: redux::EnablingCondition<S>,
+        P2pChannelsSnarkJobCommitmentAction: redux::EnablingCondition<S>,
     {
-        let peer_id = self.peer_id;
-        store
-            .service()
-            .channel_open(peer_id, ChannelId::SnarkJobCommitmentPropagation);
-        store.dispatch(P2pChannelsSnarkJobCommitmentPendingAction { peer_id });
-    }
-}
+        match self {
+            P2pChannelsSnarkJobCommitmentAction::Init { peer_id } => {
+                store
+                    .service()
+                    .channel_open(peer_id, ChannelId::SnarkJobCommitmentPropagation);
+                store.dispatch(P2pChannelsSnarkJobCommitmentAction::Pending { peer_id });
+            }
+            P2pChannelsSnarkJobCommitmentAction::Ready { peer_id } => {
+                let limit = 16;
+                store.dispatch(P2pChannelsSnarkJobCommitmentAction::RequestSend { peer_id, limit });
+            }
+            P2pChannelsSnarkJobCommitmentAction::RequestSend { peer_id, limit } => {
+                let msg = SnarkJobCommitmentPropagationChannelMsg::GetNext { limit };
+                store
+                    .service()
+                    .channel_send(peer_id, MsgId::first(), msg.into());
+            }
+            P2pChannelsSnarkJobCommitmentAction::Received { peer_id, .. } => {
+                let limit = 16;
+                store.dispatch(P2pChannelsSnarkJobCommitmentAction::RequestSend { peer_id, limit });
+            }
+            P2pChannelsSnarkJobCommitmentAction::ResponseSend {
+                peer_id,
+                commitments,
+                ..
+            } => {
+                if commitments.is_empty() {
+                    return;
+                }
 
-impl P2pChannelsSnarkJobCommitmentReadyAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-        Store::Service: P2pChannelsService,
-        P2pChannelsSnarkJobCommitmentRequestSendAction: redux::EnablingCondition<S>,
-    {
-        let peer_id = self.peer_id;
-        let limit = 16;
-        store.dispatch(P2pChannelsSnarkJobCommitmentRequestSendAction { peer_id, limit });
-    }
-}
+                let msg = SnarkJobCommitmentPropagationChannelMsg::WillSend {
+                    count: commitments.len() as u8,
+                };
+                store
+                    .service()
+                    .channel_send(peer_id, MsgId::first(), msg.into());
 
-impl P2pChannelsSnarkJobCommitmentRequestSendAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-        Store::Service: P2pChannelsService,
-    {
-        let peer_id = self.peer_id;
-        let limit = self.limit;
-        let msg = SnarkJobCommitmentPropagationChannelMsg::GetNext { limit };
-        store
-            .service()
-            .channel_send(peer_id, MsgId::first(), msg.into());
-    }
-}
-
-impl P2pChannelsSnarkJobCommitmentReceivedAction {
-    pub fn effects<Store, S>(&self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-        Store::Service: P2pChannelsService,
-        P2pChannelsSnarkJobCommitmentRequestSendAction: redux::EnablingCondition<S>,
-    {
-        let peer_id = self.peer_id;
-        let limit = 16;
-        store.dispatch(P2pChannelsSnarkJobCommitmentRequestSendAction { peer_id, limit });
-    }
-}
-
-impl P2pChannelsSnarkJobCommitmentResponseSendAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-        Store::Service: P2pChannelsService,
-    {
-        if self.commitments.is_empty() {
-            return;
-        }
-
-        let peer_id = self.peer_id;
-        let msg = SnarkJobCommitmentPropagationChannelMsg::WillSend {
-            count: self.commitments.len() as u8,
-        };
-        store
-            .service()
-            .channel_send(peer_id, MsgId::first(), msg.into());
-
-        for commitment in self.commitments {
-            let msg = SnarkJobCommitmentPropagationChannelMsg::Commitment(commitment);
-            store
-                .service()
-                .channel_send(peer_id, MsgId::first(), msg.into());
+                for commitment in commitments {
+                    let msg = SnarkJobCommitmentPropagationChannelMsg::Commitment(commitment);
+                    store
+                        .service()
+                        .channel_send(peer_id, MsgId::first(), msg.into());
+                }
+            }
+            P2pChannelsSnarkJobCommitmentAction::Pending { .. } => {}
+            P2pChannelsSnarkJobCommitmentAction::PromiseReceived { .. } => {}
+            P2pChannelsSnarkJobCommitmentAction::RequestReceived { .. } => {}
         }
     }
 }

--- a/p2p/src/peer/p2p_peer_actions.rs
+++ b/p2p/src/peer/p2p_peer_actions.rs
@@ -44,7 +44,7 @@ pub struct P2pPeerBestTipUpdateAction {
 
 impl redux::EnablingCondition<P2pState> for P2pPeerBestTipUpdateAction {
     fn is_enabled(&self, state: &P2pState) -> bool {
-        // TODO(binier): don't enable if block inferrior than existing peer's
+        // TODO(binier): don't enable if block inferior than existing peer's
         // best tip.
         state.get_ready_peer(&self.peer_id).is_some()
     }

--- a/p2p/src/peer/p2p_peer_effects.rs
+++ b/p2p/src/peer/p2p_peer_effects.rs
@@ -2,8 +2,8 @@ use redux::ActionMeta;
 
 use crate::channels::{
     best_tip::P2pChannelsBestTipAction, rpc::P2pChannelsRpcInitAction,
-    snark::P2pChannelsSnarkInitAction,
-    snark_job_commitment::P2pChannelsSnarkJobCommitmentInitAction, ChannelId,
+    snark::P2pChannelsSnarkInitAction, snark_job_commitment::P2pChannelsSnarkJobCommitmentAction,
+    ChannelId,
 };
 
 use super::P2pPeerReadyAction;
@@ -14,7 +14,7 @@ impl P2pPeerReadyAction {
         Store: crate::P2pStore<S>,
         P2pChannelsBestTipAction: redux::EnablingCondition<S>,
         P2pChannelsSnarkInitAction: redux::EnablingCondition<S>,
-        P2pChannelsSnarkJobCommitmentInitAction: redux::EnablingCondition<S>,
+        P2pChannelsSnarkJobCommitmentAction: redux::EnablingCondition<S>,
         P2pChannelsRpcInitAction: redux::EnablingCondition<S>,
     {
         let peer_id = self.peer_id;
@@ -29,7 +29,7 @@ impl P2pPeerReadyAction {
                     store.dispatch(P2pChannelsSnarkInitAction { peer_id });
                 }
                 ChannelId::SnarkJobCommitmentPropagation => {
-                    store.dispatch(P2pChannelsSnarkJobCommitmentInitAction { peer_id });
+                    store.dispatch(P2pChannelsSnarkJobCommitmentAction::Init { peer_id });
                 }
                 ChannelId::Rpc => {
                     store.dispatch(P2pChannelsRpcInitAction { peer_id });

--- a/p2p/src/peer/p2p_peer_effects.rs
+++ b/p2p/src/peer/p2p_peer_effects.rs
@@ -1,7 +1,7 @@
 use redux::ActionMeta;
 
 use crate::channels::{
-    best_tip::P2pChannelsBestTipInitAction, rpc::P2pChannelsRpcInitAction,
+    best_tip::P2pChannelsBestTipAction, rpc::P2pChannelsRpcInitAction,
     snark::P2pChannelsSnarkInitAction,
     snark_job_commitment::P2pChannelsSnarkJobCommitmentInitAction, ChannelId,
 };
@@ -12,7 +12,7 @@ impl P2pPeerReadyAction {
     pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
     where
         Store: crate::P2pStore<S>,
-        P2pChannelsBestTipInitAction: redux::EnablingCondition<S>,
+        P2pChannelsBestTipAction: redux::EnablingCondition<S>,
         P2pChannelsSnarkInitAction: redux::EnablingCondition<S>,
         P2pChannelsSnarkJobCommitmentInitAction: redux::EnablingCondition<S>,
         P2pChannelsRpcInitAction: redux::EnablingCondition<S>,
@@ -23,7 +23,7 @@ impl P2pPeerReadyAction {
         for id in ChannelId::iter_all() {
             match id {
                 ChannelId::BestTipPropagation => {
-                    store.dispatch(P2pChannelsBestTipInitAction { peer_id });
+                    store.dispatch(P2pChannelsBestTipAction::Init { peer_id });
                 }
                 ChannelId::SnarkPropagation => {
                     store.dispatch(P2pChannelsSnarkInitAction { peer_id });

--- a/p2p/src/peer/p2p_peer_effects.rs
+++ b/p2p/src/peer/p2p_peer_effects.rs
@@ -1,9 +1,8 @@
 use redux::ActionMeta;
 
 use crate::channels::{
-    best_tip::P2pChannelsBestTipAction, rpc::P2pChannelsRpcInitAction,
-    snark::P2pChannelsSnarkAction, snark_job_commitment::P2pChannelsSnarkJobCommitmentAction,
-    ChannelId,
+    best_tip::P2pChannelsBestTipAction, rpc::P2pChannelsRpcAction, snark::P2pChannelsSnarkAction,
+    snark_job_commitment::P2pChannelsSnarkJobCommitmentAction, ChannelId,
 };
 
 use super::P2pPeerReadyAction;
@@ -15,7 +14,7 @@ impl P2pPeerReadyAction {
         P2pChannelsBestTipAction: redux::EnablingCondition<S>,
         P2pChannelsSnarkAction: redux::EnablingCondition<S>,
         P2pChannelsSnarkJobCommitmentAction: redux::EnablingCondition<S>,
-        P2pChannelsRpcInitAction: redux::EnablingCondition<S>,
+        P2pChannelsRpcAction: redux::EnablingCondition<S>,
     {
         let peer_id = self.peer_id;
         // Dispatches can be done without a loop, but inside we do
@@ -32,7 +31,7 @@ impl P2pPeerReadyAction {
                     store.dispatch(P2pChannelsSnarkJobCommitmentAction::Init { peer_id });
                 }
                 ChannelId::Rpc => {
-                    store.dispatch(P2pChannelsRpcInitAction { peer_id });
+                    store.dispatch(P2pChannelsRpcAction::Init { peer_id });
                 }
             }
         }

--- a/p2p/src/peer/p2p_peer_effects.rs
+++ b/p2p/src/peer/p2p_peer_effects.rs
@@ -2,7 +2,7 @@ use redux::ActionMeta;
 
 use crate::channels::{
     best_tip::P2pChannelsBestTipAction, rpc::P2pChannelsRpcInitAction,
-    snark::P2pChannelsSnarkInitAction, snark_job_commitment::P2pChannelsSnarkJobCommitmentAction,
+    snark::P2pChannelsSnarkAction, snark_job_commitment::P2pChannelsSnarkJobCommitmentAction,
     ChannelId,
 };
 
@@ -13,7 +13,7 @@ impl P2pPeerReadyAction {
     where
         Store: crate::P2pStore<S>,
         P2pChannelsBestTipAction: redux::EnablingCondition<S>,
-        P2pChannelsSnarkInitAction: redux::EnablingCondition<S>,
+        P2pChannelsSnarkAction: redux::EnablingCondition<S>,
         P2pChannelsSnarkJobCommitmentAction: redux::EnablingCondition<S>,
         P2pChannelsRpcInitAction: redux::EnablingCondition<S>,
     {
@@ -26,7 +26,7 @@ impl P2pPeerReadyAction {
                     store.dispatch(P2pChannelsBestTipAction::Init { peer_id });
                 }
                 ChannelId::SnarkPropagation => {
-                    store.dispatch(P2pChannelsSnarkInitAction { peer_id });
+                    store.dispatch(P2pChannelsSnarkAction::Init { peer_id });
                 }
                 ChannelId::SnarkJobCommitmentPropagation => {
                     store.dispatch(P2pChannelsSnarkJobCommitmentAction::Init { peer_id });

--- a/snark/src/block_verify/snark_block_verify_effects.rs
+++ b/snark/src/block_verify/snark_block_verify_effects.rs
@@ -1,47 +1,31 @@
 use redux::ActionMeta;
 
-use super::{
-    SnarkBlockVerifyErrorAction, SnarkBlockVerifyFinishAction, SnarkBlockVerifyInitAction,
-    SnarkBlockVerifyPendingAction, SnarkBlockVerifyService, SnarkBlockVerifySuccessAction,
-};
+use super::{SnarkBlockVerifyAction, SnarkBlockVerifyService};
 
-impl SnarkBlockVerifyInitAction {
-    pub fn effects<Store, S>(&self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::SnarkStore<S>,
-        Store::Service: SnarkBlockVerifyService,
-        SnarkBlockVerifyPendingAction: redux::EnablingCondition<S>,
-    {
-        let req_id = self.req_id;
-        let verifier_index = store.state().block_verify.verifier_index.clone();
-        let verifier_srs = store.state().block_verify.verifier_srs.clone();
-        store
-            .service()
-            .verify_init(req_id, verifier_index, verifier_srs, self.block.clone());
-        store.dispatch(SnarkBlockVerifyPendingAction { req_id });
-    }
-}
-
-impl SnarkBlockVerifyErrorAction {
+impl SnarkBlockVerifyAction {
     pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
     where
         Store: crate::SnarkStore<S>,
         Store::Service: SnarkBlockVerifyService,
-        SnarkBlockVerifyFinishAction: redux::EnablingCondition<S>,
+        SnarkBlockVerifyAction: redux::EnablingCondition<S>,
     {
-        let req_id = self.req_id;
-        store.dispatch(SnarkBlockVerifyFinishAction { req_id });
-    }
-}
-
-impl SnarkBlockVerifySuccessAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::SnarkStore<S>,
-        Store::Service: SnarkBlockVerifyService,
-        SnarkBlockVerifyFinishAction: redux::EnablingCondition<S>,
-    {
-        let req_id = self.req_id;
-        store.dispatch(SnarkBlockVerifyFinishAction { req_id });
+        match self {
+            SnarkBlockVerifyAction::Init { req_id, block, .. } => {
+                let verifier_index = store.state().block_verify.verifier_index.clone();
+                let verifier_srs = store.state().block_verify.verifier_srs.clone();
+                store
+                    .service()
+                    .verify_init(req_id, verifier_index, verifier_srs, block);
+                store.dispatch(SnarkBlockVerifyAction::Pending { req_id });
+            }
+            SnarkBlockVerifyAction::Error { req_id, .. } => {
+                store.dispatch(SnarkBlockVerifyAction::Finish { req_id });
+            }
+            SnarkBlockVerifyAction::Success { req_id, .. } => {
+                store.dispatch(SnarkBlockVerifyAction::Finish { req_id });
+            }
+            SnarkBlockVerifyAction::Pending { .. } => {}
+            SnarkBlockVerifyAction::Finish { .. } => {}
+        }
     }
 }

--- a/snark/src/block_verify/snark_block_verify_reducer.rs
+++ b/snark/src/block_verify/snark_block_verify_reducer.rs
@@ -7,14 +7,14 @@ impl SnarkBlockVerifyState {
     pub fn reducer(&mut self, action: SnarkBlockVerifyActionWithMetaRef<'_>) {
         let (action, meta) = action.split();
         match action {
-            SnarkBlockVerifyAction::Init(action) => {
+            SnarkBlockVerifyAction::Init { block, .. } => {
                 self.jobs.add(SnarkBlockVerifyStatus::Init {
                     time: meta.time(),
-                    block: action.block.clone(),
+                    block: block.clone(),
                 });
             }
-            SnarkBlockVerifyAction::Pending(action) => {
-                if let Some(req) = self.jobs.get_mut(action.req_id) {
+            SnarkBlockVerifyAction::Pending { req_id, .. } => {
+                if let Some(req) = self.jobs.get_mut(*req_id) {
                     *req = match req {
                         SnarkBlockVerifyStatus::Init { block, .. } => {
                             SnarkBlockVerifyStatus::Pending {
@@ -26,22 +26,22 @@ impl SnarkBlockVerifyState {
                     };
                 }
             }
-            SnarkBlockVerifyAction::Error(action) => {
-                if let Some(req) = self.jobs.get_mut(action.req_id) {
+            SnarkBlockVerifyAction::Error { req_id, error, .. } => {
+                if let Some(req) = self.jobs.get_mut(*req_id) {
                     *req = match req {
                         SnarkBlockVerifyStatus::Pending { block, .. } => {
                             SnarkBlockVerifyStatus::Error {
                                 time: meta.time(),
                                 block: block.clone(),
-                                error: action.error.clone(),
+                                error: error.clone(),
                             }
                         }
                         _ => return,
                     };
                 }
             }
-            SnarkBlockVerifyAction::Success(action) => {
-                if let Some(req) = self.jobs.get_mut(action.req_id) {
+            SnarkBlockVerifyAction::Success { req_id, .. } => {
+                if let Some(req) = self.jobs.get_mut(*req_id) {
                     *req = match req {
                         SnarkBlockVerifyStatus::Pending { block, .. } => {
                             SnarkBlockVerifyStatus::Success {
@@ -53,8 +53,8 @@ impl SnarkBlockVerifyState {
                     };
                 }
             }
-            SnarkBlockVerifyAction::Finish(action) => {
-                self.jobs.remove(action.req_id);
+            SnarkBlockVerifyAction::Finish { req_id, .. } => {
+                self.jobs.remove(*req_id);
             }
         }
     }

--- a/snark/src/work_verify/snark_work_verify_actions.rs
+++ b/snark/src/work_verify/snark_work_verify_actions.rs
@@ -7,101 +7,62 @@ use super::{SnarkWorkVerifyError, SnarkWorkVerifyId};
 pub type SnarkWorkVerifyActionWithMeta = redux::ActionWithMeta<SnarkWorkVerifyAction>;
 pub type SnarkWorkVerifyActionWithMetaRef<'a> = redux::ActionWithMeta<&'a SnarkWorkVerifyAction>;
 
-#[derive(derive_more::From, Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum SnarkWorkVerifyAction {
-    Init(SnarkWorkVerifyInitAction),
-    Pending(SnarkWorkVerifyPendingAction),
-    Error(SnarkWorkVerifyErrorAction),
-    Success(SnarkWorkVerifySuccessAction),
-    Finish(SnarkWorkVerifyFinishAction),
+    Init {
+        req_id: SnarkWorkVerifyId,
+        batch: Vec<Snark>,
+        sender: String,
+    },
+    Pending {
+        req_id: SnarkWorkVerifyId,
+    },
+    Error {
+        req_id: SnarkWorkVerifyId,
+        error: SnarkWorkVerifyError,
+    },
+    Success {
+        req_id: SnarkWorkVerifyId,
+    },
+    Finish {
+        req_id: SnarkWorkVerifyId,
+    },
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct SnarkWorkVerifyInitAction {
-    pub req_id: SnarkWorkVerifyId,
-    pub batch: Vec<Snark>,
-    pub sender: String,
-}
-
-impl redux::EnablingCondition<crate::SnarkState> for SnarkWorkVerifyInitAction {
+impl redux::EnablingCondition<crate::SnarkState> for SnarkWorkVerifyAction {
     fn is_enabled(&self, state: &crate::SnarkState) -> bool {
-        !self.batch.is_empty() && state.work_verify.jobs.next_req_id() == self.req_id
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct SnarkWorkVerifyPendingAction {
-    pub req_id: SnarkWorkVerifyId,
-}
-
-impl redux::EnablingCondition<crate::SnarkState> for SnarkWorkVerifyPendingAction {
-    fn is_enabled(&self, state: &crate::SnarkState) -> bool {
-        state
-            .work_verify
-            .jobs
-            .get(self.req_id)
-            .map_or(false, |v| v.is_init())
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct SnarkWorkVerifyErrorAction {
-    pub req_id: SnarkWorkVerifyId,
-    pub error: SnarkWorkVerifyError,
-}
-
-impl redux::EnablingCondition<crate::SnarkState> for SnarkWorkVerifyErrorAction {
-    fn is_enabled(&self, state: &crate::SnarkState) -> bool {
-        state
-            .work_verify
-            .jobs
-            .get(self.req_id)
-            .map_or(false, |v| v.is_pending())
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct SnarkWorkVerifySuccessAction {
-    pub req_id: SnarkWorkVerifyId,
-}
-
-impl redux::EnablingCondition<crate::SnarkState> for SnarkWorkVerifySuccessAction {
-    fn is_enabled(&self, state: &crate::SnarkState) -> bool {
-        state
-            .work_verify
-            .jobs
-            .get(self.req_id)
-            .map_or(false, |v| v.is_pending())
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct SnarkWorkVerifyFinishAction {
-    pub req_id: SnarkWorkVerifyId,
-}
-
-impl redux::EnablingCondition<crate::SnarkState> for SnarkWorkVerifyFinishAction {
-    fn is_enabled(&self, state: &crate::SnarkState) -> bool {
-        state
-            .work_verify
-            .jobs
-            .get(self.req_id)
-            .map_or(false, |v| v.is_finished())
-    }
-}
-
-macro_rules! impl_into_snark_action {
-    ($a:ty) => {
-        impl From<$a> for crate::SnarkAction {
-            fn from(value: $a) -> Self {
-                Self::WorkVerify(value.into())
-            }
+        match self {
+            SnarkWorkVerifyAction::Init { req_id, batch, .. } => {
+                !batch.is_empty() && state.work_verify.jobs.next_req_id() == *req_id
+            },
+            SnarkWorkVerifyAction::Pending { req_id } => {
+                state
+                    .work_verify
+                    .jobs
+                    .get(*req_id)
+                    .map_or(false, |v| v.is_init())
+            },
+            SnarkWorkVerifyAction::Error { req_id, .. } => {
+                state
+                    .work_verify
+                    .jobs
+                    .get(*req_id)
+                    .map_or(false, |v| v.is_pending())
+            },
+            SnarkWorkVerifyAction::Success { req_id } => {
+                state
+                    .work_verify
+                    .jobs
+                    .get(*req_id)
+                    .map_or(false, |v| v.is_pending())
+            },
+            SnarkWorkVerifyAction::Finish { req_id } => {
+                state
+                    .work_verify
+                    .jobs
+                    .get(*req_id)
+                    .map_or(false, |v| v.is_finished())
+            },
         }
-    };
+    }
 }
-
-impl_into_snark_action!(SnarkWorkVerifyInitAction);
-impl_into_snark_action!(SnarkWorkVerifyPendingAction);
-impl_into_snark_action!(SnarkWorkVerifyErrorAction);
-impl_into_snark_action!(SnarkWorkVerifySuccessAction);
-impl_into_snark_action!(SnarkWorkVerifyFinishAction);

--- a/snark/src/work_verify/snark_work_verify_effects.rs
+++ b/snark/src/work_verify/snark_work_verify_effects.rs
@@ -1,47 +1,31 @@
 use redux::ActionMeta;
 
-use super::{
-    SnarkWorkVerifyErrorAction, SnarkWorkVerifyFinishAction, SnarkWorkVerifyInitAction,
-    SnarkWorkVerifyPendingAction, SnarkWorkVerifyService, SnarkWorkVerifySuccessAction,
-};
+use super::{SnarkWorkVerifyAction, SnarkWorkVerifyService};
 
-impl SnarkWorkVerifyInitAction {
-    pub fn effects<Store, S>(&self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::SnarkStore<S>,
-        Store::Service: SnarkWorkVerifyService,
-        SnarkWorkVerifyPendingAction: redux::EnablingCondition<S>,
-    {
-        let req_id = self.req_id;
-        let verifier_index = store.state().work_verify.verifier_index.clone();
-        let verifier_srs = store.state().work_verify.verifier_srs.clone();
-        store
-            .service()
-            .verify_init(req_id, verifier_index, verifier_srs, self.batch.clone());
-        store.dispatch(SnarkWorkVerifyPendingAction { req_id });
-    }
-}
-
-impl SnarkWorkVerifyErrorAction {
+impl SnarkWorkVerifyAction {
     pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
     where
         Store: crate::SnarkStore<S>,
         Store::Service: SnarkWorkVerifyService,
-        SnarkWorkVerifyFinishAction: redux::EnablingCondition<S>,
+        SnarkWorkVerifyAction: redux::EnablingCondition<S>,
     {
-        let req_id = self.req_id;
-        store.dispatch(SnarkWorkVerifyFinishAction { req_id });
-    }
-}
-
-impl SnarkWorkVerifySuccessAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::SnarkStore<S>,
-        Store::Service: SnarkWorkVerifyService,
-        SnarkWorkVerifyFinishAction: redux::EnablingCondition<S>,
-    {
-        let req_id = self.req_id;
-        store.dispatch(SnarkWorkVerifyFinishAction { req_id });
+        match self {
+            SnarkWorkVerifyAction::Init { req_id, batch, .. } => {
+                let verifier_index = store.state().work_verify.verifier_index.clone();
+                let verifier_srs = store.state().work_verify.verifier_srs.clone();
+                store
+                    .service()
+                    .verify_init(req_id, verifier_index, verifier_srs, batch);
+                store.dispatch(SnarkWorkVerifyAction::Pending { req_id });
+            }
+            SnarkWorkVerifyAction::Error { req_id, .. } => {
+                store.dispatch(SnarkWorkVerifyAction::Finish { req_id });
+            }
+            SnarkWorkVerifyAction::Success { req_id } => {
+                store.dispatch(SnarkWorkVerifyAction::Finish { req_id });
+            }
+            SnarkWorkVerifyAction::Pending { .. } => {}
+            SnarkWorkVerifyAction::Finish { .. } => {}
+        }
     }
 }


### PR DESCRIPTION
Example of getting rid of "leaf" types used for single action definitions and replacing them with a single action type for the whole group by inlining all fields in the enum tags.

Updated modules so far:
- [x] p2p_channels_rpc
- [x] p2p_channels_snark
- [x] p2p_channels_snark_job_commitment
- [x] p2p_channels_best_tip
- [x] external_snark_worker
- [x] snark_work_verify
- [x] snark_block_verify
- [x] consensus
- [x] snark_pool_candidate
- [x] snark_pool