### PR TITLE
Fix for services in libp2p replacement

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,6 +63,11 @@ jobs:
           jq -r '. | select(.executable != null and (.target.kind | (contains(["test"])))) | [.target.name, .executable ] | @tsv' cargo-build-test.json > tests.tsv
           while read NAME FILE; do cp -a $FILE target/release/tests/webrtc_$NAME; done < tests.tsv
 
+          cargo build --release --features=scenario-generators,p2p-libp2p --package=openmina-node-testing --tests
+          cargo build --release --features=scenario-generators,p2p-libp2p --package=openmina-node-testing --tests --message-format=json > cargo-build-test.json
+          jq -r '. | select(.executable != null and (.target.kind | (contains(["test"])))) | [.target.name, .executable ] | @tsv' cargo-build-test.json > tests.tsv
+          while read NAME FILE; do cp -a $FILE target/release/tests/libp2p_$NAME; done < tests.tsv
+
           tar cf tests.tar -C target/release/tests .
 
       - name: Upload tests
@@ -79,7 +84,10 @@ jobs:
     strategy:
       matrix:
         test: [p2p_basic_connections, p2p_basic_incoming, p2p_basic_outgoing]
+        libp2p: ['external', 'internal']
       fail-fast: false
+    env:
+      TEST: ${{ matrix.libp2p == 'external' && format('libp2p_{0}', matrix.test) || matrix.test }}
 
     steps:
       - name: Download tests
@@ -89,11 +97,11 @@ jobs:
 
       - name: Unpack tests
         run: |
-          tar xf tests.tar ./${{ matrix.test }}
+          tar xf tests.tar ./${{ env.TEST }}
 
       - name: Run the test
         run: |
-          ./${{ matrix.test }} --nocapture --test-threads=1
+          ./${{ env.TEST }} --nocapture --test-threads=1
 
   scenario-tests:
     needs: [ build ]

--- a/node/src/action_kind.rs
+++ b/node/src/action_kind.rs
@@ -493,7 +493,7 @@ pub enum ActionKind {
 }
 
 impl ActionKind {
-    pub const COUNT: u16 = 250;
+    pub const COUNT: u16 = 251;
 }
 
 impl std::fmt::Display for ActionKind {

--- a/node/src/effects.rs
+++ b/node/src/effects.rs
@@ -259,7 +259,7 @@ fn p2p_request_snarks_if_needed<S: Service>(store: &mut Store<S>) {
 /// Iterate all connected peers and check the time of the last response to the peer discovery request.
 /// If the elapsed time is large enough, send another discovery request.
 #[cfg(feature = "p2p-webrtc")]
-fn p2p_discovery_request<S: Service>(store: &mut Store<S>, meta: &ActionMeta) {
+fn p2p_discovery_request<S: Service>(store: &mut Store<S>, meta: &redux::ActionMeta) {
     use crate::p2p::discovery::P2pDiscoveryInitAction;
 
     let peer_ids = store

--- a/node/src/p2p/p2p_effects.rs
+++ b/node/src/p2p/p2p_effects.rs
@@ -283,29 +283,33 @@ pub fn p2p_effects<S: Service>(store: &mut Store<S>, action: P2pActionWithMeta) 
             }
             P2pDiscoveryAction::Success(_) => {}
             P2pDiscoveryAction::KademliaBootstrap(_) => {
-                // seed node doesn't have initial peers
-                // it will rely on incoming peers
-                let initial_peers = if !store.state().p2p.config.initial_peers.is_empty() {
-                    store.state().p2p.config.initial_peers.clone()
-                } else if !store.state().p2p.kademlia.routes.is_empty() {
-                    store
-                        .state()
-                        .p2p
-                        .kademlia
-                        .routes
-                        .values()
-                        .flatten()
-                        .cloned()
-                        .collect()
-                } else {
-                    vec![]
-                };
+                #[cfg(feature = "p2p-libp2p")]
+                {
+                    // seed node doesn't have initial peers
+                    // it will rely on incoming peers
+                    let initial_peers = if !store.state().p2p.config.initial_peers.is_empty() {
+                        store.state().p2p.config.initial_peers.clone()
+                    } else if !store.state().p2p.kademlia.routes.is_empty() {
+                        store
+                            .state()
+                            .p2p
+                            .kademlia
+                            .routes
+                            .values()
+                            .flatten()
+                            .cloned()
+                            .collect()
+                    } else {
+                        vec![]
+                    };
 
-                if !initial_peers.is_empty() {
-                    store.service().start_discovery(initial_peers);
+                    if !initial_peers.is_empty() {
+                        store.service().start_discovery(initial_peers);
+                    }
                 }
             }
             P2pDiscoveryAction::KademliaInit(_) => {
+                #[cfg(feature = "p2p-libp2p")]
                 store.service().find_random_peer();
             }
             P2pDiscoveryAction::KademliaAddRoute(_) => {}

--- a/node/testing/src/scenarios/solo_node/bootstrap.rs
+++ b/node/testing/src/scenarios/solo_node/bootstrap.rs
@@ -1,8 +1,7 @@
 use std::time::Duration;
 
 use node::{
-    event_source::Event,
-    p2p::{connection::outgoing::P2pConnectionOutgoingInitOpts, P2pEvent},
+    p2p::connection::outgoing::P2pConnectionOutgoingInitOpts,
     transition_frontier::sync::TransitionFrontierSyncState,
 };
 use tokio::time::Instant;
@@ -42,18 +41,9 @@ impl SoloNodeBootstrap {
             let steps = runner
                 .pending_events()
                 .map(|(node_id, _, events)| {
-                    events.map(move |(_, event)| {
-                        match event {
-                            Event::P2p(P2pEvent::MioEvent(event)) => {
-                                // eprintln!("event: {event}");
-                                let _ = event;
-                            }
-                            _ => {}
-                        }
-                        ScenarioStep::Event {
-                            node_id,
-                            event: event.to_string(),
-                        }
+                    events.map(move |(_, event)| ScenarioStep::Event {
+                        node_id,
+                        event: event.to_string(),
                     })
                 })
                 .flatten()

--- a/p2p/src/connection/p2p_connection_service.rs
+++ b/p2p/src/connection/p2p_connection_service.rs
@@ -20,7 +20,11 @@ pub trait P2pConnectionService: redux::Service {
 
     fn http_signaling_request(&mut self, url: String, offer: webrtc::Offer);
 
+    // TODO: move methods below to a separate trait.
+
+    #[cfg(feature = "p2p-libp2p")]
     fn start_discovery(&mut self, peers: Vec<P2pConnectionOutgoingInitOpts>);
 
+    #[cfg(feature = "p2p-libp2p")]
     fn find_random_peer(&mut self);
 }

--- a/p2p/src/service_impl/mod.rs
+++ b/p2p/src/service_impl/mod.rs
@@ -4,7 +4,7 @@ pub mod libp2p;
 pub mod mio;
 #[cfg(feature = "p2p-webrtc")]
 pub mod webrtc;
-#[cfg(all(not(target_arch = "wasm32"), feature = "p2p-libp2p"))]
+#[cfg(all(not(target_arch = "wasm32")))]
 pub mod webrtc_with_libp2p;
 
 use std::future::Future;

--- a/p2p/src/service_impl/webrtc_with_libp2p.rs
+++ b/p2p/src/service_impl/webrtc_with_libp2p.rs
@@ -1,5 +1,5 @@
-use openmina_core::channels::mpsc;
 use openmina_core::snark::Snark;
+use openmina_core::channels::mpsc;
 
 use crate::{
     channels::{ChannelId, ChannelMsg, MsgId, P2pChannelsService},
@@ -9,37 +9,60 @@ use crate::{
     P2pChannelEvent, P2pEvent, PeerId,
 };
 
-use super::{libp2p::Libp2pService, webrtc::P2pServiceWebrtc, TaskSpawner};
+#[cfg(not(feature = "p2p-libp2p"))]
+use super::mio::MioService;
+#[cfg(not(feature = "p2p-libp2p"))]
+use crate::P2pMioService;
+
+use super::{webrtc::P2pServiceWebrtc, TaskSpawner};
 
 pub struct P2pServiceCtx {
     pub webrtc: super::webrtc::P2pServiceCtx,
-    pub libp2p: Libp2pService,
+    #[cfg(feature = "p2p-libp2p")]
+    pub libp2p: super::libp2p::Libp2pService,
+    #[cfg(not(feature = "p2p-libp2p"))]
+    pub mio: MioService,
 }
 
 pub trait P2pServiceWebrtcWithLibp2p: P2pServiceWebrtc {
-    fn libp2p(&mut self) -> &mut Libp2pService;
+    #[cfg(feature = "p2p-libp2p")]
+    fn libp2p(&mut self) -> &mut super::libp2p::Libp2pService;
+
+    #[cfg(not(feature = "p2p-libp2p"))]
+    fn mio(&mut self) -> &mut MioService;
 
     fn init<E: From<P2pEvent> + Send + 'static, S: TaskSpawner>(
-        libp2p_port: Option<u16>,
+        _libp2p_port: Option<u16>,
         secret_key: SecretKey,
-        chain_id: String,
+        _chain_id: String,
         event_source_sender: mpsc::UnboundedSender<E>,
         spawner: S,
     ) -> P2pServiceCtx {
         P2pServiceCtx {
-            webrtc: <Self as P2pServiceWebrtc>::init(secret_key.clone(), spawner.clone()),
-            libp2p: Libp2pService::run::<E, S>(
-                libp2p_port,
-                secret_key,
-                chain_id,
+            #[cfg(feature = "p2p-libp2p")]
+            libp2p: super::libp2p::Libp2pService::run::<E, S>(
+                _libp2p_port,
+                secret_key.clone(),
+                _chain_id,
                 event_source_sender,
-                spawner,
+                spawner.clone(),
             ),
+            webrtc: <Self as P2pServiceWebrtc>::init(secret_key, spawner),
+            #[cfg(not(feature = "p2p-libp2p"))]
+            mio: MioService::run({
+                move |mio_event| {
+                    event_source_sender
+                        .send(P2pEvent::MioEvent(mio_event).into())
+                        .unwrap_or_default()
+                }
+            }),
         }
     }
 
+    #[cfg(feature = "p2p-libp2p")]
     fn find_random_peer(&mut self);
 
+    #[cfg(feature = "p2p-libp2p")]
     fn start_discovery(&mut self, peers: Vec<P2pConnectionOutgoingInitOpts>);
 }
 
@@ -56,9 +79,27 @@ impl<T: P2pServiceWebrtcWithLibp2p> P2pConnectionService for T {
             P2pConnectionOutgoingInitOpts::WebRTC { peer_id, .. } => {
                 P2pServiceWebrtc::outgoing_init(self, peer_id);
             }
+            #[cfg(feature = "p2p-libp2p")]
             P2pConnectionOutgoingInitOpts::LibP2P(opts) => {
                 let cmd = super::libp2p::Cmd::Dial(opts.peer_id.into(), vec![opts.to_maddr()]);
                 let _ = self.libp2p().cmd_sender().send(cmd);
+            }
+            #[cfg(not(feature = "p2p-libp2p"))]
+            P2pConnectionOutgoingInitOpts::LibP2P(opts) => {
+                use crate::webrtc::Host;
+                let addr = match opts.host {
+                    Host::Ipv4(ip4) => ip4.into(),
+                    Host::Ipv6(ip6) => ip6.into(),
+                    host => {
+                        openmina_core::error!(openmina_core::log::system_time(); "unsupported host for internal libp2p: {host}");
+                        return;
+                    }
+                };
+                let _ = self
+                    .mio()
+                    .send_mio_cmd(crate::MioCmd::Connect(std::net::SocketAddr::new(
+                        addr, opts.port,
+                    )));
             }
         }
     }
@@ -75,10 +116,12 @@ impl<T: P2pServiceWebrtcWithLibp2p> P2pConnectionService for T {
         P2pServiceWebrtc::http_signaling_request(self, url, offer)
     }
 
+    #[cfg(feature = "p2p-libp2p")]
     fn start_discovery(&mut self, peers: Vec<P2pConnectionOutgoingInitOpts>) {
         P2pServiceWebrtcWithLibp2p::start_discovery(self, peers)
     }
 
+    #[cfg(feature = "p2p-libp2p")]
     fn find_random_peer(&mut self) {
         P2pServiceWebrtcWithLibp2p::find_random_peer(self);
     }
@@ -90,11 +133,19 @@ impl<T: P2pServiceWebrtcWithLibp2p> P2pDisconnectionService for T {
         // cause `peer_loop` to end.
         let is_libp2p_peer = self.peers().remove(&peer_id).is_none();
         if is_libp2p_peer {
-            use super::libp2p::Cmd;
-            let _ = self
-                .libp2p()
-                .cmd_sender()
-                .send(Cmd::Disconnect(peer_id.into()));
+            #[cfg(not(feature = "p2p-libp2p"))]
+            {
+                // TODO(akoptelov): pass dial_opt here to get IP address
+                // self.mio().send_mio_cmd(MioCmd::Disconnect())
+            }
+            #[cfg(feature = "p2p-libp2p")]
+            {
+                use super::libp2p::Cmd;
+                let _ = self
+                    .libp2p()
+                    .cmd_sender()
+                    .send(Cmd::Disconnect(peer_id.into()));
+            }
         }
     }
 }
@@ -118,19 +169,33 @@ impl<T: P2pServiceWebrtcWithLibp2p> P2pChannelsService for T {
         if self.peers().contains_key(&peer_id) {
             P2pServiceWebrtc::channel_send(self, peer_id, msg_id, msg)
         } else {
+            #[cfg(feature = "p2p-libp2p")]
+            {
+                use super::libp2p::Cmd;
+                let _ = self
+                    .libp2p()
+                    .cmd_sender()
+                    .send(Cmd::SendMessage(peer_id.into(), msg));
+            }
+            #[cfg(not(feature = "p2p-libp2p"))]
+            {
+                todo!("unimplemented");
+            }
+        }
+    }
+
+    fn libp2p_broadcast_snark(&mut self, _snark: Snark, _nonce: u32) {
+        #[cfg(feature = "p2p-libp2p")]
+        {
             use super::libp2p::Cmd;
             let _ = self
                 .libp2p()
                 .cmd_sender()
-                .send(Cmd::SendMessage(peer_id.into(), msg));
+                .send(Cmd::SnarkBroadcast(_snark, _nonce));
         }
-    }
-
-    fn libp2p_broadcast_snark(&mut self, snark: Snark, nonce: u32) {
-        use super::libp2p::Cmd;
-        let _ = self
-            .libp2p()
-            .cmd_sender()
-            .send(Cmd::SnarkBroadcast(snark, nonce));
+        #[cfg(not(feature = "p2p-libp2p"))]
+        {
+            todo!("unimplemented");
+        }
     }
 }


### PR DESCRIPTION
@vlad9486 Instead of having new stubs for P2p-related services when internal libp2p is used, it is better to have an alternative implementation for existing ones, with conditional implementations. These services are used by webrtc logic as well, and as far as I concerned, we want to keep it working, either with external or internal libp2p. Also methods like `outgoing_init` should be defined for any p2p implementation.

Please take a look, probably I can make it even more elegant, like to factor out external libp2p service (discovery related methods).