### PR TITLE
Vrf evaluator cleanup

### DIFF
--- a/node/native/src/block_producer/vrf_evaluator.rs
+++ b/node/native/src/block_producer/vrf_evaluator.rs
@@ -20,7 +20,7 @@ pub fn vrf_evaluator(
     while let Some(vrf_evaluator_input) = vrf_evaluation_receiver.blocking_recv() {
         let mut vrf_result = VrfEvaluationOutput::SlotLost(vrf_evaluator_input.global_slot);
 
-        for (index, account) in vrf_evaluator_input.delegatee_table.iter() {
+        for (index, account) in vrf_evaluator_input.delegator_table.iter() {
             let vrf_input = VrfEvaluationInput::new(
                 keypair.clone(),
                 vrf_evaluator_input.epoch_seed.clone(),

--- a/node/src/block_producer/block_producer_effects.rs
+++ b/node/src/block_producer/block_producer_effects.rs
@@ -32,9 +32,6 @@ pub fn block_producer_effects<S: crate::Service>(
             BlockProducerVrfEvaluatorAction::EvaluateVrf(action) => {
                 action.effects(&meta, store);
             }
-            // BlockProducerVrfEvaluatorAction::EvaluationPending(action) => {
-            //     action.effects(&meta, store);
-            // },
             BlockProducerVrfEvaluatorAction::EvaluationSuccess(action) => {
                 let has_won_slot =
                     matches!(action.vrf_output, vrf::VrfEvaluationOutput::SlotWon(_));

--- a/node/src/block_producer/block_producer_state.rs
+++ b/node/src/block_producer/block_producer_state.rs
@@ -153,6 +153,12 @@ impl BlockProducerState {
     pub fn vrf_evaluator(&self) -> Option<&BlockProducerVrfEvaluatorState> {
         self.with(None, |this| Some(&this.vrf_evaluator))
     }
+
+    pub fn vrf_evaluator_with_config(
+        &self,
+    ) -> Option<(&BlockProducerVrfEvaluatorState, &BlockProducerConfig)> {
+        self.with(None, |this| Some((&this.vrf_evaluator, &this.config)))
+    }
 }
 
 impl BlockProducerCurrentState {

--- a/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_actions.rs
+++ b/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_actions.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
 use crate::account::AccountPublicKey;
 use crate::block_producer::{vrf_evaluator::BlockProducerVrfEvaluatorStatus, BlockProducerAction};
@@ -10,7 +11,7 @@ use mina_p2p_messages::v2::{
 use serde::{Deserialize, Serialize};
 use vrf::VrfEvaluationOutput;
 
-use super::VrfEvaluatorInput;
+use super::{DelegatorTable, VrfEvaluatorInput};
 
 pub type BlockProducerVrfEvaluatorActionWithMeta =
     redux::ActionWithMeta<BlockProducerVrfEvaluatorAction>;
@@ -50,8 +51,8 @@ impl redux::EnablingCondition<crate::State>
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct BlockProducerVrfEvaluatorUpdateProducerAndDelegatesSuccessAction {
-    pub current_epoch_producer_and_delegators: BTreeMap<AccountIndex, (AccountPublicKey, u64)>,
-    pub next_epoch_producer_and_delegators: BTreeMap<AccountIndex, (AccountPublicKey, u64)>,
+    pub current_epoch_producer_and_delegators: Arc<DelegatorTable>,
+    pub next_epoch_producer_and_delegators: Arc<DelegatorTable>,
     pub staking_ledger_hash: LedgerHash,
 }
 

--- a/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_actions.rs
+++ b/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_actions.rs
@@ -32,7 +32,7 @@ pub enum BlockProducerVrfEvaluatorAction {
 pub struct BlockProducerVrfEvaluatorUpdateProducerAndDelegatesAction {
     pub current_epoch_ledger_hash: LedgerHash,
     pub next_epoch_ledger_hash: LedgerHash,
-    pub producer: String,
+    pub producer: AccountPublicKey,
 }
 
 impl redux::EnablingCondition<crate::State>

--- a/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_effects.rs
+++ b/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_effects.rs
@@ -77,24 +77,18 @@ impl BlockProducerVrfEvaluatorEvaluationSuccessAction {
 
 impl BlockProducerVrfEvaluatorUpdateProducerAndDelegatesAction {
     pub fn effects<S: Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        let current_epoch_producer_and_delegators: std::collections::BTreeMap<
-            ledger::AccountIndex,
-            (AccountPublicKey, u64),
-        > = store.service.get_producer_and_delegates(
+        let current_epoch_producer_and_delegators = store.service.get_producer_and_delegates(
             self.current_epoch_ledger_hash.clone(),
             self.producer.clone(),
         );
-        let next_epoch_producer_and_delegators: std::collections::BTreeMap<
-            ledger::AccountIndex,
-            (AccountPublicKey, u64),
-        > = store
+        let next_epoch_producer_and_delegators = store
             .service
             .get_producer_and_delegates(self.next_epoch_ledger_hash, self.producer.clone());
 
         store.dispatch(
             BlockProducerVrfEvaluatorUpdateProducerAndDelegatesSuccessAction {
-                current_epoch_producer_and_delegators,
-                next_epoch_producer_and_delegators,
+                current_epoch_producer_and_delegators: current_epoch_producer_and_delegators.into(),
+                next_epoch_producer_and_delegators: next_epoch_producer_and_delegators.into(),
                 staking_ledger_hash: self.current_epoch_ledger_hash,
             },
         );

--- a/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_effects.rs
+++ b/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_effects.rs
@@ -92,9 +92,10 @@ impl BlockProducerVrfEvaluatorUpdateProducerAndDelegatesAction {
         let current_epoch_producer_and_delegators: std::collections::BTreeMap<
             ledger::AccountIndex,
             (AccountPublicKey, u64),
-        > = store
-            .service
-            .get_producer_and_delegates(self.current_epoch_ledger_hash, self.producer.clone());
+        > = store.service.get_producer_and_delegates(
+            self.current_epoch_ledger_hash.clone(),
+            self.producer.clone(),
+        );
         let next_epoch_producer_and_delegators: std::collections::BTreeMap<
             ledger::AccountIndex,
             (AccountPublicKey, u64),
@@ -106,6 +107,7 @@ impl BlockProducerVrfEvaluatorUpdateProducerAndDelegatesAction {
             BlockProducerVrfEvaluatorUpdateProducerAndDelegatesSuccessAction {
                 current_epoch_producer_and_delegators,
                 next_epoch_producer_and_delegators,
+                staking_ledger_hash: self.current_epoch_ledger_hash,
             },
         );
     }

--- a/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_effects.rs
+++ b/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_effects.rs
@@ -14,21 +14,13 @@ use super::{
 
 impl BlockProducerVrfEvaluatorEpochDataUpdateAction {
     pub fn effects<S: Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        // TODO(adonagy): once block producer is enabled
-        // if let Some(config) = store.state().block_producer.config() {
-        //     store.dispatch(BlockProducerVrfEvaluatorUpdateProducerAndDelegatesAction {
-        //         current_epoch_ledger_hash: self.epoch_data.ledger.hash,
-        //         next_epoch_ledger_hash: self.next_epoch_data.ledger.hash,
-        //         producer: config.pub_key.to_string(),
-        //     });
-        // }
-
-        // let vrf_evaluator_state = store.state().block_producer.vrf_evaluator();
-        if let Some(vrf_evaluator_state) = store.state().block_producer.vrf_evaluator() {
+        let vrf_evaluator_state_with_config =
+            store.state().block_producer.vrf_evaluator_with_config();
+        if let Some((vrf_evaluator_state, config)) = vrf_evaluator_state_with_config {
             store.dispatch(BlockProducerVrfEvaluatorUpdateProducerAndDelegatesAction {
                 current_epoch_ledger_hash: self.epoch_data.ledger.hash,
                 next_epoch_ledger_hash: self.next_epoch_data.ledger.hash,
-                producer: vrf_evaluator_state.producer_pub_key.to_string(),
+                producer: config.pub_key.clone().into(),
             });
         }
     }
@@ -39,10 +31,6 @@ impl BlockProducerVrfEvaluatorEvaluateVrfAction {
         store.service.evaluate(self.vrf_input);
     }
 }
-
-// impl BlockProducerVrfEvaluatorEvaluationPendingAction {
-//     pub fn effects<S: Service>(self, _: &ActionMeta, store: &mut Store<S>) {}
-// }
 
 impl BlockProducerVrfEvaluatorEvaluationSuccessAction {
     pub fn effects<S: Service>(self, _: &ActionMeta, store: &mut Store<S>) {

--- a/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_event.rs
+++ b/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_event.rs
@@ -13,7 +13,7 @@ impl std::fmt::Display for BlockProducerVrfEvaluatorEvent {
         write!(f, "VrfEvaluator, ")?;
         match self {
             Self::Evaluated(vrf_output) => {
-                write!(f, "Evaluated, {:?}", vrf_output)
+                write!(f, "Evaluated, {}", vrf_output)
             }
         }
     }

--- a/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_reducer.rs
+++ b/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_reducer.rs
@@ -21,9 +21,12 @@ impl BlockProducerVrfEvaluatorState {
                 ));
                 self.current_epoch = Some(action.new_epoch_number);
             }
-            BlockProducerVrfEvaluatorAction::EvaluateVrf(_) => {
-                // self.status = BlockProducerVrfEvaluatorStatus::Pending(action.vrf_input.global_slot);
-                self.status = BlockProducerVrfEvaluatorStatus::SlotsRequested { time: meta.time() };
+            BlockProducerVrfEvaluatorAction::EvaluateVrf(action) => {
+                self.status = BlockProducerVrfEvaluatorStatus::SlotsRequested {
+                    time: meta.time(),
+                    global_slot: action.vrf_input.global_slot,
+                    staking_ledger_hash: action.vrf_input.staking_ledger_hash.clone(),
+                };
             }
             // BlockProducerVrfEvaluatorAction::EvaluationPending(_) => todo!(),
             BlockProducerVrfEvaluatorAction::EvaluationSuccess(action) => {
@@ -40,7 +43,11 @@ impl BlockProducerVrfEvaluatorState {
                     }
                     vrf::VrfEvaluationOutput::SlotLost(global_slot) => *global_slot,
                 };
-                self.status = BlockProducerVrfEvaluatorStatus::SlotsReceived { time: meta.time() };
+                self.status = BlockProducerVrfEvaluatorStatus::SlotsReceived {
+                    time: meta.time(),
+                    global_slot: global_slot_evaluated,
+                    staking_ledger_hash: action.staking_ledger_hash.clone(),
+                };
                 self.latest_evaluated_slot = global_slot_evaluated;
             }
             BlockProducerVrfEvaluatorAction::UpdateProducerAndDelegates(_) => {

--- a/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_service.rs
+++ b/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_service.rs
@@ -5,7 +5,7 @@ use mina_p2p_messages::v2::LedgerHash;
 
 use crate::account::AccountPublicKey;
 
-use super::VrfEvaluatorInput;
+use super::{DelegatorTable, VrfEvaluatorInput};
 
 pub trait BlockProducerVrfEvaluatorService: redux::Service {
     fn evaluate(&mut self, data: VrfEvaluatorInput);
@@ -16,5 +16,5 @@ pub trait BlockProducerVrfEvaluatorLedgerService: redux::Service {
         &mut self,
         ledger_hash: LedgerHash,
         producer: AccountPublicKey,
-    ) -> BTreeMap<AccountIndex, (AccountPublicKey, u64)>;
+    ) -> DelegatorTable;
 }

--- a/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_service.rs
+++ b/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_service.rs
@@ -15,6 +15,6 @@ pub trait BlockProducerVrfEvaluatorLedgerService: redux::Service {
     fn get_producer_and_delegates(
         &mut self,
         ledger_hash: LedgerHash,
-        producer: String,
+        producer: AccountPublicKey,
     ) -> BTreeMap<AccountIndex, (AccountPublicKey, u64)>;
 }

--- a/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_state.rs
+++ b/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_state.rs
@@ -67,11 +67,49 @@ impl EpochData {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum BlockProducerVrfEvaluatorStatus {
-    Idle { time: redux::Timestamp },
-    EpochChanged { time: redux::Timestamp },
-    DataPending { time: redux::Timestamp },
-    DataSuccess { time: redux::Timestamp },
-    DataFail { time: redux::Timestamp },
-    SlotsRequested { time: redux::Timestamp },
-    SlotsReceived { time: redux::Timestamp },
+    Idle {
+        time: redux::Timestamp,
+    },
+    EpochChanged {
+        time: redux::Timestamp,
+    },
+    DataPending {
+        time: redux::Timestamp,
+    },
+    DataSuccess {
+        time: redux::Timestamp,
+    },
+    DataFail {
+        time: redux::Timestamp,
+    },
+    SlotsRequested {
+        time: redux::Timestamp,
+        global_slot: u32,
+        staking_ledger_hash: LedgerHash,
+    },
+    SlotsReceived {
+        time: redux::Timestamp,
+        global_slot: u32,
+        staking_ledger_hash: LedgerHash,
+    },
+}
+
+impl BlockProducerVrfEvaluatorStatus {
+    pub fn matches_requsted_slot(
+        &self,
+        expected_global_slot: u32,
+        expected_staking_ledger_hash: &LedgerHash,
+    ) -> bool {
+        match self {
+            Self::SlotsRequested {
+                global_slot,
+                staking_ledger_hash,
+                ..
+            } => {
+                &expected_global_slot == global_slot
+                    && expected_staking_ledger_hash == staking_ledger_hash
+            }
+            _ => false,
+        }
+    }
 }

--- a/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_state.rs
+++ b/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_state.rs
@@ -19,7 +19,6 @@ pub struct BlockProducerVrfEvaluatorState {
     pub won_slots: BTreeMap<u32, VrfWonSlotWithHash>,
     pub current_epoch_data: Option<EpochData>,
     pub next_epoch_data: Option<EpochData>,
-    pub producer_pub_key: String,
     // TODO(adonagy): move to block producer state probably
     pub current_epoch: Option<u32>,
     pub current_best_tip_slot: u32,
@@ -30,13 +29,11 @@ pub struct BlockProducerVrfEvaluatorState {
 
 impl BlockProducerVrfEvaluatorState {
     pub fn new(now: redux::Timestamp, config: BlockProducerConfig) -> Self {
-        let producer_pub_key = config.pub_key.to_string();
         Self {
             status: BlockProducerVrfEvaluatorStatus::Idle { time: now },
             won_slots: Default::default(),
             current_epoch_data: Default::default(),
             next_epoch_data: Default::default(),
-            producer_pub_key,
             current_epoch: None,
             current_best_tip_slot: Default::default(),
             latest_evaluated_slot: Default::default(),

--- a/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_state.rs
+++ b/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_state.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
 use ledger::AccountIndex;
 use mina_p2p_messages::v2::LedgerHash;
@@ -8,7 +9,7 @@ use vrf::VrfWonSlot;
 use crate::account::AccountPublicKey;
 use crate::BlockProducerConfig;
 
-use super::VrfWonSlotWithHash;
+use super::{DelegatorTable, VrfWonSlotWithHash};
 
 // TODO(adonagy): consodilate types, make more clear
 // pub type AccountAddressAndBalance = (String, u64);
@@ -47,7 +48,7 @@ impl BlockProducerVrfEvaluatorState {
 pub struct EpochData {
     pub seed: String,
     pub ledger: LedgerHash,
-    pub delegator_table: BTreeMap<AccountIndex, (AccountPublicKey, u64)>,
+    pub delegator_table: Arc<DelegatorTable>,
     pub total_currency: u64,
 }
 

--- a/node/src/block_producer/vrf_evaluator/mod.rs
+++ b/node/src/block_producer/vrf_evaluator/mod.rs
@@ -53,6 +53,20 @@ pub struct VrfEvaluationOutputWithHash {
     pub staking_ledger_hash: LedgerHash,
 }
 
+impl std::fmt::Display for VrfEvaluationOutputWithHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} ", self.staking_ledger_hash.to_string())?;
+        match &self.evaluation_result {
+            VrfEvaluationOutput::SlotWon(won_slot) => {
+                write!(f, "SlotWon {}", won_slot.global_slot)
+            }
+            VrfEvaluationOutput::SlotLost(global_slot) => {
+                write!(f, "SlotLost {}", global_slot)
+            }
+        }
+    }
+}
+
 impl VrfEvaluationOutputWithHash {
     pub fn new(evaluation_result: VrfEvaluationOutput, staking_ledger_hash: LedgerHash) -> Self {
         Self {

--- a/node/src/block_producer/vrf_evaluator/mod.rs
+++ b/node/src/block_producer/vrf_evaluator/mod.rs
@@ -3,6 +3,7 @@ use crate::account::AccountPublicKey;
 use ledger::AccountIndex;
 use mina_p2p_messages::v2::LedgerHash;
 use std::collections::BTreeMap;
+use std::sync::Arc;
 use vrf::{VrfEvaluationOutput, VrfWonSlot};
 
 pub use block_producer_vrf_evaluator_state::*;
@@ -23,10 +24,12 @@ mod block_producer_vrf_evaluator_service;
 pub use block_producer_vrf_evaluator_service::*;
 use serde::{Deserialize, Serialize};
 
+pub type DelegatorTable = BTreeMap<AccountIndex, (AccountPublicKey, u64)>;
+
 #[derive(Debug, Deserialize, Clone, Serialize)]
 pub struct VrfEvaluatorInput {
     pub epoch_seed: String,
-    pub delegatee_table: BTreeMap<AccountIndex, (AccountPublicKey, u64)>,
+    pub delegator_table: Arc<DelegatorTable>,
     pub global_slot: u32,
     pub total_currency: u64,
     pub staking_ledger_hash: LedgerHash,
@@ -79,14 +82,14 @@ impl VrfEvaluationOutputWithHash {
 impl VrfEvaluatorInput {
     pub fn new(
         epoch_seed: String,
-        delegatee_table: BTreeMap<AccountIndex, (AccountPublicKey, u64)>,
+        delegator_table: Arc<DelegatorTable>,
         global_slot: u32,
         total_currency: u64,
         staking_ledger_hash: LedgerHash,
     ) -> Self {
         Self {
             epoch_seed,
-            delegatee_table,
+            delegator_table,
             global_slot,
             total_currency,
             staking_ledger_hash,

--- a/node/src/ledger/ledger_service.rs
+++ b/node/src/ledger/ledger_service.rs
@@ -950,19 +950,17 @@ impl<T: LedgerService> RpcLedgerService for T {
 }
 
 impl<T: LedgerService> BlockProducerVrfEvaluatorLedgerService for T {
-    // TODO(adonagy): avoid using strings for account pub keys.
-    // Use `AccountPublicKey` instead.
     fn get_producer_and_delegates(
         &mut self,
         ledger_hash: LedgerHash,
-        producer: String,
+        producer: AccountPublicKey,
     ) -> BTreeMap<ledger::AccountIndex, (AccountPublicKey, u64)> {
-        let producer_pub_key = PubKey::from_address(&producer).unwrap().into_compressed();
-
-        // TODO(adonagy): unwrap
+        // TODO(adonagy): Error handling
         let delegate_table = self
             .ctx()
-            .producers_with_delegates(&ledger_hash, |pub_key| pub_key == &producer_pub_key)
+            .producers_with_delegates(&ledger_hash, |pub_key| {
+                AccountPublicKey::from(pub_key.clone()) == producer
+            })
             .unwrap()
             .into_values()
             .next()

--- a/node/src/ledger/ledger_service.rs
+++ b/node/src/ledger/ledger_service.rs
@@ -40,7 +40,6 @@ use openmina_core::snark::{Snark, SnarkJobId};
 use mina_signer::{CompressedPubKey, PubKey};
 use openmina_core::block::ArcBlockWithHash;
 
-use crate::account::AccountPublicKey;
 use crate::block_producer::vrf_evaluator::BlockProducerVrfEvaluatorLedgerService;
 use crate::block_producer::{
     BlockProducerService, BlockProducerWonSlot, StagedLedgerDiffCreateOutput,
@@ -51,6 +50,7 @@ use crate::transition_frontier::sync::{
     TransitionFrontierRootSnarkedLedgerUpdates,
 };
 use crate::transition_frontier::TransitionFrontierService;
+use crate::{account::AccountPublicKey, block_producer::vrf_evaluator::DelegatorTable};
 use crate::{
     p2p::channels::rpc::StagedLedgerAuxAndPendingCoinbases, transition_frontier::CommitResult,
 };
@@ -954,7 +954,7 @@ impl<T: LedgerService> BlockProducerVrfEvaluatorLedgerService for T {
         &mut self,
         ledger_hash: LedgerHash,
         producer: AccountPublicKey,
-    ) -> BTreeMap<ledger::AccountIndex, (AccountPublicKey, u64)> {
+    ) -> DelegatorTable {
         // TODO(adonagy): Error handling
         let delegate_table = self
             .ctx()

--- a/vrf/src/lib.rs
+++ b/vrf/src/lib.rs
@@ -79,6 +79,15 @@ pub enum VrfEvaluationOutput {
     SlotLost(u32), // TODO(adonagy): create or use existing a type
 }
 
+impl VrfEvaluationOutput {
+    pub fn global_slot(&self) -> u32 {
+        match self {
+            Self::SlotWon(won_slot) => won_slot.global_slot,
+            Self::SlotLost(global_slot) => *global_slot,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct VrfEvaluationInput {
     producer_key: Keypair,


### PR DESCRIPTION
Addressing the review in #151 

Cleaned up the vrf evaluator code accordingly. 

One last thing that is hanging is moving the logic out of `BlockProducerVrfEvaluatorEvaluationSuccessAction` effects to the enabling condition. I don't really grasp the point made in this [comment](https://github.com/openmina/openmina/pull/151#discussion_r1466140896). Moving the same logic to the enabling condition seems a bit redundant to me as the effect will only dispatch the action with values that makes sense (no input sent for 2 epoch in the future as we have no data for that yet).

I think it could be more elegant if we made the vrf evaluator aware what epoch it's currently evaluating but that would require the overhaul of the evaluator state (later polishing). 