### PR TITLE
Cache verifier index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3408,6 +3408,7 @@ dependencies = [
 name = "mina-tree"
 version = "0.2.0"
 dependencies = [
+ "anyhow",
  "ark-ec",
  "ark-ff",
  "ark-poly",

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -69,6 +69,7 @@ blake2 = "0.10"
 crc32fast = "1"
 chrono = "0.4"
 serde_with = "3.6.1"
+anyhow = "1.0.75"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }


### PR DESCRIPTION
In this commit I've implemented very basic caching of indices. If that would work fine, we should also include SRS hash to the file name (in case input for verifier index is changed). and probably also move it directly to ledger (unless we don't want to have OS ops in that crate)