### PR TITLE
chores(new-libp2p): better error handling

### DIFF
--- a/node/src/logger/logger_effects.rs
+++ b/node/src/logger/logger_effects.rs
@@ -543,14 +543,16 @@ pub fn logger_effects<S: Service>(store: &Store<S>, action: ActionWithMetaRef<'_
                             openmina_core::log::error!(
                                 meta.time();
                                 kind = kind.to_string(),
-                                summary = format!("failed select authentication on addr: {}", action.addr),
+                                error = action.error,
+                                summary = format!("failed select authentication on addr {}: {}", action.addr, action.error),
                             )
                         }
                         SelectKind::Multiplexing(peer_id) => {
                             openmina_core::log::error!(
                                 meta.time();
                                 kind = kind.to_string(),
-                                summary = format!("failed select multiplexing on addr: {}", action.addr),
+                                error = action.error,
+                                summary = format!("failed select multiplexing on addr {}: {}", action.addr, action.error),
                                 peer_id = peer_id.to_string(),
                             )
                         }
@@ -558,7 +560,8 @@ pub fn logger_effects<S: Service>(store: &Store<S>, action: ActionWithMetaRef<'_
                             openmina_core::log::error!(
                                 meta.time();
                                 kind = kind.to_string(),
-                                summary = format!("failed select stream on addr: {}", action.addr),
+                                error = action.error,
+                                summary = format!("failed select stream on addr {}: {}", action.addr, action.error),
                                 peer_id = peer_id.to_string(),
                                 stream_id = stream_id,
                             )
@@ -722,6 +725,9 @@ pub fn logger_effects<S: Service>(store: &Store<S>, action: ActionWithMetaRef<'_
                     }
                     _ => {}
                 },
+                P2pNetworkAction::Kad(_) => {
+                    //
+                }
                 P2pNetworkAction::Rpc(action) => match action {
                     P2pNetworkRpcAction::Init(action) => {
                         openmina_core::log::info!(

--- a/p2p/src/network/scheduler/p2p_network_scheduler_actions.rs
+++ b/p2p/src/network/scheduler/p2p_network_scheduler_actions.rs
@@ -72,6 +72,7 @@ pub struct P2pNetworkSchedulerSelectDoneAction {
 pub struct P2pNetworkSchedulerSelectErrorAction {
     pub addr: SocketAddr,
     pub kind: SelectKind,
+    pub error: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]


### PR DESCRIPTION
We need to see what missing protocol our peer is trying to use.