### PR TITLE
Refactor: Inline action group definitions into the parent enum type (continued)

### DIFF
--- a/node/src/action.rs
+++ b/node/src/action.rs
@@ -49,18 +49,6 @@ pub struct CheckTimeoutsAction {}
 
 impl redux::EnablingCondition<crate::State> for CheckTimeoutsAction {}
 
-macro_rules! impl_into_global_action {
-    ($selector:ident : $($action:ty),* $(,)?) => {
-        $(
-            impl From<$action> for crate::Action {
-                fn from(value: $action) -> Self {
-                    Self::$selector(value.into())
-                }
-            }
-        )*
-    };
-}
-
 #[cfg(feature = "replay")]
 impl redux::EnablingCondition<crate::State> for Action {
     fn is_enabled(&self, _: &crate::State) -> bool {

--- a/node/src/block_producer/block_producer_actions.rs
+++ b/node/src/block_producer/block_producer_actions.rs
@@ -11,228 +11,116 @@ use super::{BlockProducerCurrentState, BlockProducerWonSlot, BlockProducerWonSlo
 pub type BlockProducerActionWithMeta = redux::ActionWithMeta<BlockProducerAction>;
 pub type BlockProducerActionWithMetaRef<'a> = redux::ActionWithMeta<&'a BlockProducerAction>;
 
-#[derive(derive_more::From, Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum BlockProducerAction {
     VrfEvaluator(BlockProducerVrfEvaluatorAction),
-    BestTipUpdate(BlockProducerBestTipUpdateAction),
-    WonSlotSearch(BlockProducerWonSlotSearchAction),
-    WonSlot(BlockProducerWonSlotAction),
-    WonSlotDiscard(BlockProducerWonSlotDiscardAction),
-    WonSlotWait(BlockProducerWonSlotWaitAction),
-    WonSlotProduceInit(BlockProducerWonSlotProduceInitAction),
-    StagedLedgerDiffCreateInit(BlockProducerStagedLedgerDiffCreateInitAction),
-    StagedLedgerDiffCreatePending(BlockProducerStagedLedgerDiffCreatePendingAction),
-    StagedLedgerDiffCreateSuccess(BlockProducerStagedLedgerDiffCreateSuccessAction),
-    BlockUnprovenBuild(BlockProducerBlockUnprovenBuildAction),
-    BlockProduced(BlockProducerBlockProducedAction),
-    BlockInject(BlockProducerBlockInjectAction),
-    BlockInjected(BlockProducerBlockInjectedAction),
+    BestTipUpdate {
+        best_tip: ArcBlockWithHash,
+    },
+    WonSlotSearch,
+    WonSlot {
+        won_slot: BlockProducerWonSlot,
+    },
+    WonSlotDiscard {
+        reason: BlockProducerWonSlotDiscardReason,
+    },
+    WonSlotWait,
+    WonSlotProduceInit,
+    StagedLedgerDiffCreateInit,
+    StagedLedgerDiffCreatePending,
+    StagedLedgerDiffCreateSuccess {
+        diff: StagedLedgerDiffDiffStableV2,
+        diff_hash: ConsensusBodyReferenceStableV1,
+        staged_ledger_hash: MinaBaseStagedLedgerHashStableV1,
+        emitted_ledger_proof: Option<LedgerProofProdStableV2>,
+    },
+    BlockUnprovenBuild,
+    BlockProduced,
+    BlockInject,
+    BlockInjected,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct BlockProducerBestTipUpdateAction {
-    pub best_tip: ArcBlockWithHash,
-}
-
-impl redux::EnablingCondition<crate::State> for BlockProducerBestTipUpdateAction {
-    fn is_enabled(&self, _state: &crate::State) -> bool {
-        true
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct BlockProducerWonSlotSearchAction {}
-
-impl redux::EnablingCondition<crate::State> for BlockProducerWonSlotSearchAction {
+impl redux::EnablingCondition<crate::State> for BlockProducerAction {
     fn is_enabled(&self, state: &crate::State) -> bool {
-        state
-            .block_producer
-            .with(None, |this| {
-                if !this.current.won_slot_should_search() {
-                    return None;
-                }
-                let best_tip = state.transition_frontier.best_tip()?;
-                let cur_global_slot = state.cur_global_slot()?;
-                let next = this.vrf_evaluator.next_won_slot(cur_global_slot, best_tip);
-                Some(next.is_some())
-            })
-            .is_some_and(|v| v)
-    }
-}
+        match self {
+            BlockProducerAction::VrfEvaluator(a) => a.is_enabled(state),
+            BlockProducerAction::BestTipUpdate { .. } => true,
+            BlockProducerAction::WonSlotSearch => state
+                .block_producer
+                .with(None, |this| {
+                    if !this.current.won_slot_should_search() {
+                        return None;
+                    }
+                    let best_tip = state.transition_frontier.best_tip()?;
+                    let cur_global_slot = state.cur_global_slot()?;
+                    let next = this.vrf_evaluator.next_won_slot(cur_global_slot, best_tip);
+                    Some(next.is_some())
+                })
+                .is_some_and(|v| v),
+            BlockProducerAction::WonSlot { won_slot } => state.block_producer.with(false, |this| {
+                let Some(best_tip) = state.transition_frontier.best_tip() else {
+                    return false;
+                };
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct BlockProducerWonSlotAction {
-    pub won_slot: BlockProducerWonSlot,
-}
-
-impl redux::EnablingCondition<crate::State> for BlockProducerWonSlotAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state.block_producer.with(false, |this| {
-            let Some(best_tip) = state.transition_frontier.best_tip() else {
-                return false;
-            };
-
-            this.current.won_slot_should_search()
-                && self.won_slot.global_slot() >= state.cur_global_slot().unwrap()
-                && &self.won_slot > best_tip
-        })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct BlockProducerWonSlotWaitAction {}
-
-impl redux::EnablingCondition<crate::State> for BlockProducerWonSlotWaitAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state.block_producer.with(false, |this| {
-            this.current.won_slot_should_wait(state.time())
-        })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct BlockProducerWonSlotProduceInitAction {}
-
-impl redux::EnablingCondition<crate::State> for BlockProducerWonSlotProduceInitAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state.block_producer.with(false, |this| {
-            this.current.won_slot_should_produce(state.time())
-        })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct BlockProducerStagedLedgerDiffCreateInitAction {}
-
-impl redux::EnablingCondition<crate::State> for BlockProducerStagedLedgerDiffCreateInitAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state.block_producer.with(false, |this| {
-            matches!(
-                this.current,
-                BlockProducerCurrentState::WonSlotProduceInit { .. }
-            )
-        })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct BlockProducerStagedLedgerDiffCreatePendingAction {}
-
-impl redux::EnablingCondition<crate::State> for BlockProducerStagedLedgerDiffCreatePendingAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state.block_producer.with(false, |this| {
-            matches!(
-                this.current,
-                BlockProducerCurrentState::WonSlotProduceInit { .. }
-            )
-        })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct BlockProducerStagedLedgerDiffCreateSuccessAction {
-    pub diff: StagedLedgerDiffDiffStableV2,
-    pub diff_hash: ConsensusBodyReferenceStableV1,
-    pub staged_ledger_hash: MinaBaseStagedLedgerHashStableV1,
-    pub emitted_ledger_proof: Option<LedgerProofProdStableV2>,
-}
-
-impl redux::EnablingCondition<crate::State> for BlockProducerStagedLedgerDiffCreateSuccessAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state.block_producer.with(false, |this| {
-            matches!(
-                this.current,
-                BlockProducerCurrentState::StagedLedgerDiffCreatePending { .. }
-            )
-        })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct BlockProducerBlockUnprovenBuildAction {}
-
-impl redux::EnablingCondition<crate::State> for BlockProducerBlockUnprovenBuildAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state.block_producer.with(false, |this| {
-            matches!(
-                this.current,
-                BlockProducerCurrentState::StagedLedgerDiffCreateSuccess { .. }
-            )
-        })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct BlockProducerBlockProducedAction {}
-
-impl redux::EnablingCondition<crate::State> for BlockProducerBlockProducedAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state.block_producer.with(false, |this| {
-            matches!(
-                this.current,
-                BlockProducerCurrentState::BlockUnprovenBuilt { .. }
-            )
-        })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct BlockProducerBlockInjectAction {}
-
-impl redux::EnablingCondition<crate::State> for BlockProducerBlockInjectAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state.block_producer.with(false, |this| {
-            matches!(this.current, BlockProducerCurrentState::Produced { .. })
-        })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct BlockProducerBlockInjectedAction {}
-
-impl redux::EnablingCondition<crate::State> for BlockProducerBlockInjectedAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state.block_producer.with(false, |this| {
-            matches!(this.current, BlockProducerCurrentState::Produced { .. })
-        })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct BlockProducerWonSlotDiscardAction {
-    pub reason: BlockProducerWonSlotDiscardReason,
-}
-
-impl redux::EnablingCondition<crate::State> for BlockProducerWonSlotDiscardAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        let reason = state.block_producer.with(None, |bp| {
-            let best_tip = state.transition_frontier.best_tip()?;
-            bp.current.won_slot_should_discard(best_tip)
-        });
-        Some(&self.reason) == reason.as_ref()
-    }
-}
-
-macro_rules! impl_into_global_action {
-    ($a:ty) => {
-        impl From<$a> for crate::Action {
-            fn from(value: $a) -> Self {
-                Self::BlockProducer(value.into())
+                this.current.won_slot_should_search()
+                    && won_slot.global_slot() >= state.cur_global_slot().unwrap()
+                    && won_slot > best_tip
+            }),
+            BlockProducerAction::WonSlotWait => state.block_producer.with(false, |this| {
+                this.current.won_slot_should_wait(state.time())
+            }),
+            BlockProducerAction::WonSlotProduceInit => state.block_producer.with(false, |this| {
+                this.current.won_slot_should_produce(state.time())
+            }),
+            BlockProducerAction::StagedLedgerDiffCreateInit => {
+                state.block_producer.with(false, |this| {
+                    matches!(
+                        this.current,
+                        BlockProducerCurrentState::WonSlotProduceInit { .. }
+                    )
+                })
+            }
+            BlockProducerAction::StagedLedgerDiffCreatePending => {
+                state.block_producer.with(false, |this| {
+                    matches!(
+                        this.current,
+                        BlockProducerCurrentState::WonSlotProduceInit { .. }
+                    )
+                })
+            }
+            BlockProducerAction::StagedLedgerDiffCreateSuccess { .. } => {
+                state.block_producer.with(false, |this| {
+                    matches!(
+                        this.current,
+                        BlockProducerCurrentState::StagedLedgerDiffCreatePending { .. }
+                    )
+                })
+            }
+            BlockProducerAction::BlockUnprovenBuild => state.block_producer.with(false, |this| {
+                matches!(
+                    this.current,
+                    BlockProducerCurrentState::StagedLedgerDiffCreateSuccess { .. }
+                )
+            }),
+            BlockProducerAction::BlockProduced => state.block_producer.with(false, |this| {
+                matches!(
+                    this.current,
+                    BlockProducerCurrentState::BlockUnprovenBuilt { .. }
+                )
+            }),
+            BlockProducerAction::BlockInject => state.block_producer.with(false, |this| {
+                matches!(this.current, BlockProducerCurrentState::Produced { .. })
+            }),
+            BlockProducerAction::BlockInjected => state.block_producer.with(false, |this| {
+                matches!(this.current, BlockProducerCurrentState::Produced { .. })
+            }),
+            BlockProducerAction::WonSlotDiscard { reason } => {
+                let current_reason = state.block_producer.with(None, |bp| {
+                    let best_tip = state.transition_frontier.best_tip()?;
+                    bp.current.won_slot_should_discard(best_tip)
+                });
+                Some(reason) == current_reason.as_ref()
             }
         }
-    };
+    }
 }
-
-impl_into_global_action!(BlockProducerBestTipUpdateAction);
-impl_into_global_action!(BlockProducerWonSlotSearchAction);
-impl_into_global_action!(BlockProducerWonSlotAction);
-impl_into_global_action!(BlockProducerWonSlotDiscardAction);
-impl_into_global_action!(BlockProducerWonSlotWaitAction);
-impl_into_global_action!(BlockProducerWonSlotProduceInitAction);
-impl_into_global_action!(BlockProducerStagedLedgerDiffCreateInitAction);
-impl_into_global_action!(BlockProducerStagedLedgerDiffCreatePendingAction);
-impl_into_global_action!(BlockProducerStagedLedgerDiffCreateSuccessAction);
-impl_into_global_action!(BlockProducerBlockUnprovenBuildAction);
-impl_into_global_action!(BlockProducerBlockProducedAction);
-impl_into_global_action!(BlockProducerBlockInjectAction);
-impl_into_global_action!(BlockProducerBlockInjectedAction);

--- a/node/src/block_producer/block_producer_effects.rs
+++ b/node/src/block_producer/block_producer_effects.rs
@@ -1,19 +1,8 @@
-use redux::ActionMeta;
-
 use crate::transition_frontier::sync::TransitionFrontierSyncAction;
 use crate::Store;
 
 use super::vrf_evaluator::BlockProducerVrfEvaluatorAction;
-use super::{
-    BlockProducerAction, BlockProducerActionWithMeta, BlockProducerBestTipUpdateAction,
-    BlockProducerBlockInjectAction, BlockProducerBlockInjectedAction,
-    BlockProducerBlockProducedAction, BlockProducerBlockUnprovenBuildAction, BlockProducerService,
-    BlockProducerStagedLedgerDiffCreateInitAction,
-    BlockProducerStagedLedgerDiffCreatePendingAction,
-    BlockProducerStagedLedgerDiffCreateSuccessAction, BlockProducerWonSlotAction,
-    BlockProducerWonSlotDiscardAction, BlockProducerWonSlotProduceInitAction,
-    BlockProducerWonSlotSearchAction, BlockProducerWonSlotWaitAction,
-};
+use super::{BlockProducerAction, BlockProducerActionWithMeta};
 
 pub fn block_producer_effects<S: crate::Service>(
     store: &mut Store<S>,
@@ -22,205 +11,141 @@ pub fn block_producer_effects<S: crate::Service>(
     let (action, meta) = action.split();
 
     match action {
-        BlockProducerAction::VrfEvaluator(action) => {
+        BlockProducerAction::VrfEvaluator(ref a) => {
             // TODO: does the order matter? can this clone be avoided?
-            action.clone().effects(&meta, store);
-            match action {
+            a.clone().effects(&meta, store);
+            match a {
                 BlockProducerVrfEvaluatorAction::EvaluationSuccess { vrf_output, .. } => {
                     let has_won_slot = matches!(vrf_output, vrf::VrfEvaluationOutput::SlotWon(_));
                     if has_won_slot {
-                        store.dispatch(BlockProducerWonSlotSearchAction {});
+                        store.dispatch(BlockProducerAction::WonSlotSearch);
                     }
                 }
                 _ => {}
             }
         }
-        BlockProducerAction::BestTipUpdate(action) => {
-            action.effects(&meta, store);
-        }
-        BlockProducerAction::WonSlotSearch(action) => {
-            action.effects(&meta, store);
-        }
-        BlockProducerAction::WonSlot(action) => {
-            action.effects(&meta, store);
-        }
-        BlockProducerAction::WonSlotWait(_) => {}
-        BlockProducerAction::WonSlotDiscard(action) => {
-            action.effects(&meta, store);
-        }
-        BlockProducerAction::WonSlotProduceInit(action) => {
-            action.effects(&meta, store);
-        }
-        BlockProducerAction::StagedLedgerDiffCreateInit(action) => {
-            action.effects(&meta, store);
-        }
-        BlockProducerAction::StagedLedgerDiffCreatePending(_) => {}
-        BlockProducerAction::StagedLedgerDiffCreateSuccess(action) => {
-            action.effects(&meta, store);
-        }
-        BlockProducerAction::BlockUnprovenBuild(action) => {
-            action.effects(&meta, store);
-        }
-        BlockProducerAction::BlockProduced(action) => {
-            action.effects(&meta, store);
-        }
-        BlockProducerAction::BlockInject(action) => {
-            action.effects(&meta, store);
-        }
-        BlockProducerAction::BlockInjected(action) => {
-            action.effects(&meta, store);
-        }
-    }
-}
+        BlockProducerAction::BestTipUpdate { best_tip } => {
+            let best_tip_staking_ledger = best_tip.staking_epoch_ledger_hash();
+            let protocol_state = &best_tip.block.header.protocol_state.body;
 
-impl BlockProducerBestTipUpdateAction {
-    pub fn effects<S: redux::Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        let best_tip_staking_ledger = self.best_tip.staking_epoch_ledger_hash();
-        let protocol_state = &self.best_tip.block.header.protocol_state.body;
+            let vrf_evaluator_current_epoch_ledger = store
+                .state()
+                .block_producer
+                .vrf_evaluator()
+                .and_then(|vrf_evaluator| {
+                    vrf_evaluator
+                        .current_epoch_data
+                        .as_ref()
+                        .map(|epoch_data| &epoch_data.ledger)
+                });
 
-        let vrf_evaluator_current_epoch_ledger = store
-            .state()
-            .block_producer
-            .vrf_evaluator()
-            .and_then(|vrf_evaluator| {
-                vrf_evaluator
-                    .current_epoch_data
-                    .as_ref()
-                    .map(|epoch_data| &epoch_data.ledger)
+            if vrf_evaluator_current_epoch_ledger != Some(best_tip_staking_ledger) {
+                store.dispatch(BlockProducerVrfEvaluatorAction::EpochDataUpdate {
+                    new_epoch_number: protocol_state.consensus_state.epoch_count.as_u32(),
+                    epoch_data: protocol_state.consensus_state.staking_epoch_data.clone(),
+                    next_epoch_data: protocol_state.consensus_state.next_epoch_data.clone(),
+                });
+            }
+
+            if let Some(reason) = store
+                .state()
+                .block_producer
+                .with(None, |bp| bp.current.won_slot_should_discard(&best_tip))
+            {
+                store.dispatch(BlockProducerAction::WonSlotDiscard { reason });
+            }
+        }
+        BlockProducerAction::WonSlotSearch => {
+            if let Some(won_slot) = store.state().block_producer.with(None, |bp| {
+                let best_tip = store.state().transition_frontier.best_tip()?;
+                let cur_global_slot = store.state().cur_global_slot()?;
+                bp.vrf_evaluator.next_won_slot(cur_global_slot, best_tip)
+            }) {
+                store.dispatch(BlockProducerAction::WonSlot { won_slot });
+            }
+        }
+        BlockProducerAction::WonSlot { .. } => {
+            if !store.dispatch(BlockProducerAction::WonSlotWait) {
+                store.dispatch(BlockProducerAction::WonSlotProduceInit);
+            }
+        }
+        BlockProducerAction::WonSlotProduceInit => {
+            store.dispatch(BlockProducerAction::StagedLedgerDiffCreateInit);
+        }
+        BlockProducerAction::StagedLedgerDiffCreateInit => {
+            let state = store.state.get();
+            let Some((won_slot, pred_block, coinbase_receiver)) = None.or_else(|| {
+                let pred_block = state.block_producer.current_parent_chain()?.last()?;
+                let won_slot = state.block_producer.current_won_slot()?;
+                let coinbase_receiver = state.block_producer.config()?.coinbase_receiver();
+                Some((won_slot, pred_block, coinbase_receiver))
+            }) else {
+                return;
+            };
+
+            let completed_snarks = state
+                .snark_pool
+                .completed_snarks_iter()
+                .map(|snark| (snark.job_id(), snark.clone()))
+                .collect();
+            // TODO(binier)
+            let supercharge_coinbase = false;
+
+            // TODO(binier): error handling
+            let output = store
+                .service
+                .staged_ledger_diff_create(
+                    pred_block,
+                    won_slot,
+                    coinbase_receiver,
+                    completed_snarks,
+                    supercharge_coinbase,
+                )
+                .unwrap();
+
+            store.dispatch(BlockProducerAction::StagedLedgerDiffCreatePending);
+            store.dispatch(BlockProducerAction::StagedLedgerDiffCreateSuccess {
+                diff: output.diff,
+                diff_hash: output.diff_hash,
+                staged_ledger_hash: output.staged_ledger_hash,
+                emitted_ledger_proof: output.emitted_ledger_proof,
             });
-
-        if vrf_evaluator_current_epoch_ledger != Some(best_tip_staking_ledger) {
-            store.dispatch(BlockProducerVrfEvaluatorAction::EpochDataUpdate {
-                new_epoch_number: protocol_state.consensus_state.epoch_count.as_u32(),
-                epoch_data: protocol_state.consensus_state.staking_epoch_data.clone(),
-                next_epoch_data: protocol_state.consensus_state.next_epoch_data.clone(),
-            });
         }
-
-        if let Some(reason) = store.state().block_producer.with(None, |bp| {
-            bp.current.won_slot_should_discard(&self.best_tip)
-        }) {
-            store.dispatch(BlockProducerWonSlotDiscardAction { reason });
+        BlockProducerAction::StagedLedgerDiffCreateSuccess { .. } => {
+            store.dispatch(BlockProducerAction::BlockUnprovenBuild);
         }
-    }
-}
-
-impl BlockProducerWonSlotSearchAction {
-    pub fn effects<S: redux::Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        if let Some(won_slot) = store.state().block_producer.with(None, |bp| {
-            let best_tip = store.state().transition_frontier.best_tip()?;
-            let cur_global_slot = store.state().cur_global_slot()?;
-            bp.vrf_evaluator.next_won_slot(cur_global_slot, best_tip)
-        }) {
-            store.dispatch(BlockProducerWonSlotAction { won_slot });
+        BlockProducerAction::BlockUnprovenBuild => {
+            store.dispatch(BlockProducerAction::BlockProduced);
         }
-    }
-}
-
-impl BlockProducerWonSlotAction {
-    pub fn effects<S: redux::Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        if !store.dispatch(BlockProducerWonSlotWaitAction {}) {
-            store.dispatch(BlockProducerWonSlotProduceInitAction {});
+        BlockProducerAction::BlockProduced => {
+            store.dispatch(BlockProducerAction::BlockInject);
         }
-    }
-}
+        BlockProducerAction::BlockInject => {
+            let Some((best_tip, root_block, blocks_inbetween)) = None.or_else(|| {
+                let (best_tip, chain) = store.state().block_producer.produced_block_with_chain()?;
+                let mut iter = chain.iter();
+                let root_block = iter.next()?;
+                let blocks_inbetween = iter.map(|b| b.hash().clone()).collect();
+                Some((best_tip.clone(), root_block.clone(), blocks_inbetween))
+            }) else {
+                return;
+            };
 
-impl BlockProducerWonSlotProduceInitAction {
-    pub fn effects<S: redux::Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        store.dispatch(BlockProducerStagedLedgerDiffCreateInitAction {});
-    }
-}
-
-impl BlockProducerStagedLedgerDiffCreateInitAction {
-    pub fn effects<S: BlockProducerService>(self, _: &ActionMeta, store: &mut Store<S>) {
-        let state = store.state.get();
-        let Some((won_slot, pred_block, coinbase_receiver)) = None.or_else(|| {
-            let pred_block = state.block_producer.current_parent_chain()?.last()?;
-            let won_slot = state.block_producer.current_won_slot()?;
-            let coinbase_receiver = state.block_producer.config()?.coinbase_receiver();
-            Some((won_slot, pred_block, coinbase_receiver))
-        }) else {
-            return;
-        };
-
-        let completed_snarks = state
-            .snark_pool
-            .completed_snarks_iter()
-            .map(|snark| (snark.job_id(), snark.clone()))
-            .collect();
-        // TODO(binier)
-        let supercharge_coinbase = false;
-
-        // TODO(binier): error handling
-        let output = store
-            .service
-            .staged_ledger_diff_create(
-                pred_block,
-                won_slot,
-                coinbase_receiver,
-                completed_snarks,
-                supercharge_coinbase,
-            )
-            .unwrap();
-
-        store.dispatch(BlockProducerStagedLedgerDiffCreatePendingAction {});
-        store.dispatch(BlockProducerStagedLedgerDiffCreateSuccessAction {
-            diff: output.diff,
-            diff_hash: output.diff_hash,
-            staged_ledger_hash: output.staged_ledger_hash,
-            emitted_ledger_proof: output.emitted_ledger_proof,
-        });
-    }
-}
-
-impl BlockProducerStagedLedgerDiffCreateSuccessAction {
-    pub fn effects<S: redux::Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        store.dispatch(BlockProducerBlockUnprovenBuildAction {});
-    }
-}
-
-impl BlockProducerBlockUnprovenBuildAction {
-    pub fn effects<S: redux::Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        store.dispatch(BlockProducerBlockProducedAction {});
-    }
-}
-
-impl BlockProducerBlockProducedAction {
-    pub fn effects<S: redux::Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        store.dispatch(BlockProducerBlockInjectAction {});
-    }
-}
-
-impl BlockProducerBlockInjectAction {
-    pub fn effects<S: redux::Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        let Some((best_tip, root_block, blocks_inbetween)) = None.or_else(|| {
-            let (best_tip, chain) = store.state().block_producer.produced_block_with_chain()?;
-            let mut iter = chain.iter();
-            let root_block = iter.next()?;
-            let blocks_inbetween = iter.map(|b| b.hash().clone()).collect();
-            Some((best_tip.clone(), root_block.clone(), blocks_inbetween))
-        }) else {
-            return;
-        };
-
-        if store.dispatch(TransitionFrontierSyncAction::BestTipUpdate {
-            best_tip,
-            root_block,
-            blocks_inbetween,
-        }) {
-            store.dispatch(BlockProducerBlockInjectedAction {});
+            if store.dispatch(TransitionFrontierSyncAction::BestTipUpdate {
+                best_tip,
+                root_block,
+                blocks_inbetween,
+            }) {
+                store.dispatch(BlockProducerAction::BlockInjected);
+            }
         }
-    }
-}
-
-impl BlockProducerBlockInjectedAction {
-    pub fn effects<S: redux::Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        store.dispatch(BlockProducerWonSlotSearchAction {});
-    }
-}
-
-impl BlockProducerWonSlotDiscardAction {
-    pub fn effects<S: redux::Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        store.dispatch(BlockProducerWonSlotSearchAction {});
+        BlockProducerAction::BlockInjected => {
+            store.dispatch(BlockProducerAction::WonSlotSearch);
+        }
+        BlockProducerAction::WonSlotDiscard { .. } => {
+            store.dispatch(BlockProducerAction::WonSlotSearch);
+        }
+        BlockProducerAction::StagedLedgerDiffCreatePending => {}
+        BlockProducerAction::WonSlotWait => {}
     }
 }

--- a/node/src/block_producer/block_producer_effects.rs
+++ b/node/src/block_producer/block_producer_effects.rs
@@ -1,6 +1,6 @@
 use redux::ActionMeta;
 
-use crate::transition_frontier::sync::TransitionFrontierSyncBestTipUpdateAction;
+use crate::transition_frontier::sync::TransitionFrontierSyncAction;
 use crate::Store;
 
 use super::vrf_evaluator::BlockProducerVrfEvaluatorAction;
@@ -203,7 +203,7 @@ impl BlockProducerBlockInjectAction {
             return;
         };
 
-        if store.dispatch(TransitionFrontierSyncBestTipUpdateAction {
+        if store.dispatch(TransitionFrontierSyncAction::BestTipUpdate {
             best_tip,
             root_block,
             blocks_inbetween,

--- a/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_actions.rs
+++ b/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_actions.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::account::AccountPublicKey;
-use crate::block_producer::{vrf_evaluator::BlockProducerVrfEvaluatorStatus, BlockProducerAction};
+use crate::block_producer::vrf_evaluator::BlockProducerVrfEvaluatorStatus;
 use mina_p2p_messages::v2::{
     ConsensusProofOfStakeDataEpochDataNextValueVersionedValueStableV1,
     ConsensusProofOfStakeDataEpochDataStakingValueVersionedValueStableV1, LedgerHash,
@@ -16,119 +16,80 @@ pub type BlockProducerVrfEvaluatorActionWithMeta =
 pub type BlockProducerVrfEvaluatorActionWithMetaRef<'a> =
     redux::ActionWithMeta<&'a BlockProducerVrfEvaluatorAction>;
 
-#[derive(derive_more::From, Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum BlockProducerVrfEvaluatorAction {
-    EpochDataUpdate(BlockProducerVrfEvaluatorEpochDataUpdateAction),
-    EvaluateVrf(BlockProducerVrfEvaluatorEvaluateVrfAction),
-    EvaluationSuccess(BlockProducerVrfEvaluatorEvaluationSuccessAction),
-    UpdateProducerAndDelegates(BlockProducerVrfEvaluatorUpdateProducerAndDelegatesAction),
-    UpdateProducerAndDelegatesSuccess(
-        BlockProducerVrfEvaluatorUpdateProducerAndDelegatesSuccessAction,
-    ),
+    EpochDataUpdate {
+        new_epoch_number: u32,
+        epoch_data: ConsensusProofOfStakeDataEpochDataStakingValueVersionedValueStableV1,
+        next_epoch_data: ConsensusProofOfStakeDataEpochDataNextValueVersionedValueStableV1,
+    },
+    EvaluateVrf {
+        vrf_input: VrfEvaluatorInput,
+    },
+    EvaluationSuccess {
+        vrf_output: VrfEvaluationOutput,
+        staking_ledger_hash: LedgerHash,
+    },
+    UpdateProducerAndDelegates {
+        current_epoch_ledger_hash: LedgerHash,
+        next_epoch_ledger_hash: LedgerHash,
+        producer: AccountPublicKey,
+    },
+    UpdateProducerAndDelegatesSuccess {
+        current_epoch_producer_and_delegators: Arc<DelegatorTable>,
+        next_epoch_producer_and_delegators: Arc<DelegatorTable>,
+        staking_ledger_hash: LedgerHash,
+    },
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct BlockProducerVrfEvaluatorUpdateProducerAndDelegatesAction {
-    pub current_epoch_ledger_hash: LedgerHash,
-    pub next_epoch_ledger_hash: LedgerHash,
-    pub producer: AccountPublicKey,
-}
-
-impl redux::EnablingCondition<crate::State>
-    for BlockProducerVrfEvaluatorUpdateProducerAndDelegatesAction
-{
+impl redux::EnablingCondition<crate::State> for BlockProducerVrfEvaluatorAction {
     fn is_enabled(&self, state: &crate::State) -> bool {
-        state.block_producer.with(false, |this| {
-            matches!(
-                this.vrf_evaluator.status,
-                BlockProducerVrfEvaluatorStatus::EpochChanged { .. }
-            )
-        })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct BlockProducerVrfEvaluatorUpdateProducerAndDelegatesSuccessAction {
-    pub current_epoch_producer_and_delegators: Arc<DelegatorTable>,
-    pub next_epoch_producer_and_delegators: Arc<DelegatorTable>,
-    pub staking_ledger_hash: LedgerHash,
-}
-
-impl redux::EnablingCondition<crate::State>
-    for BlockProducerVrfEvaluatorUpdateProducerAndDelegatesSuccessAction
-{
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state.block_producer.with(false, |this| {
-            matches!(
-                this.vrf_evaluator.status,
-                BlockProducerVrfEvaluatorStatus::DataPending { .. }
-            ) && this
-                .vrf_evaluator
-                .current_epoch_data
-                .as_ref()
-                .is_some_and(|epoch_data| epoch_data.ledger == self.staking_ledger_hash)
-        })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct BlockProducerVrfEvaluatorEvaluateVrfAction {
-    pub vrf_input: VrfEvaluatorInput,
-}
-
-impl redux::EnablingCondition<crate::State> for BlockProducerVrfEvaluatorEvaluateVrfAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state.block_producer.with(false, |this| {
-            matches!(
-                this.vrf_evaluator.status,
-                BlockProducerVrfEvaluatorStatus::SlotsReceived { .. }
-                    | BlockProducerVrfEvaluatorStatus::DataSuccess { .. }
-            )
-        })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct BlockProducerVrfEvaluatorEvaluationSuccessAction {
-    pub vrf_output: VrfEvaluationOutput,
-    pub staking_ledger_hash: LedgerHash,
-}
-
-impl redux::EnablingCondition<crate::State> for BlockProducerVrfEvaluatorEvaluationSuccessAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state.block_producer.with(false, |this| {
-            this.vrf_evaluator
-                .status
-                .matches_requsted_slot(self.vrf_output.global_slot(), &self.staking_ledger_hash)
-        })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct BlockProducerVrfEvaluatorEpochDataUpdateAction {
-    pub new_epoch_number: u32,
-    pub epoch_data: ConsensusProofOfStakeDataEpochDataStakingValueVersionedValueStableV1,
-    pub next_epoch_data: ConsensusProofOfStakeDataEpochDataNextValueVersionedValueStableV1,
-}
-
-impl redux::EnablingCondition<crate::State> for BlockProducerVrfEvaluatorEpochDataUpdateAction {
-    fn is_enabled(&self, _: &crate::State) -> bool {
-        true
-    }
-}
-
-macro_rules! impl_into_global_action {
-    ($a:ty) => {
-        impl From<$a> for crate::Action {
-            fn from(value: $a) -> Self {
-                Self::BlockProducer(BlockProducerAction::VrfEvaluator(value.into()))
+        match self {
+            BlockProducerVrfEvaluatorAction::UpdateProducerAndDelegates { .. } => {
+                state.block_producer.with(false, |this| {
+                    matches!(
+                        this.vrf_evaluator.status,
+                        BlockProducerVrfEvaluatorStatus::EpochChanged { .. }
+                    )
+                })
             }
+            BlockProducerVrfEvaluatorAction::UpdateProducerAndDelegatesSuccess {
+                staking_ledger_hash,
+                ..
+            } => state.block_producer.with(false, |this| {
+                matches!(
+                    this.vrf_evaluator.status,
+                    BlockProducerVrfEvaluatorStatus::DataPending { .. }
+                ) && this
+                    .vrf_evaluator
+                    .current_epoch_data
+                    .as_ref()
+                    .is_some_and(|epoch_data| &epoch_data.ledger == staking_ledger_hash)
+            }),
+            BlockProducerVrfEvaluatorAction::EvaluateVrf { .. } => {
+                state.block_producer.with(false, |this| {
+                    matches!(
+                        this.vrf_evaluator.status,
+                        BlockProducerVrfEvaluatorStatus::SlotsReceived { .. }
+                            | BlockProducerVrfEvaluatorStatus::DataSuccess { .. }
+                    )
+                })
+            }
+            BlockProducerVrfEvaluatorAction::EvaluationSuccess {
+                vrf_output,
+                staking_ledger_hash,
+            } => state.block_producer.with(false, |this| {
+                this.vrf_evaluator
+                    .status
+                    .matches_requested_slot(vrf_output.global_slot(), staking_ledger_hash)
+            }),
+            BlockProducerVrfEvaluatorAction::EpochDataUpdate { .. } => true,
         }
-    };
+    }
 }
 
-impl_into_global_action!(BlockProducerVrfEvaluatorEpochDataUpdateAction);
-impl_into_global_action!(BlockProducerVrfEvaluatorEvaluateVrfAction);
-impl_into_global_action!(BlockProducerVrfEvaluatorEvaluationSuccessAction);
-impl_into_global_action!(BlockProducerVrfEvaluatorUpdateProducerAndDelegatesAction);
-impl_into_global_action!(BlockProducerVrfEvaluatorUpdateProducerAndDelegatesSuccessAction);
+impl From<BlockProducerVrfEvaluatorAction> for crate::Action {
+    fn from(value: BlockProducerVrfEvaluatorAction) -> Self {
+        Self::BlockProducer(value.into())
+    }
+}

--- a/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_actions.rs
+++ b/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_actions.rs
@@ -90,6 +90,6 @@ impl redux::EnablingCondition<crate::State> for BlockProducerVrfEvaluatorAction 
 
 impl From<BlockProducerVrfEvaluatorAction> for crate::Action {
     fn from(value: BlockProducerVrfEvaluatorAction) -> Self {
-        Self::BlockProducer(value.into())
+        Self::BlockProducer(crate::BlockProducerAction::VrfEvaluator(value.into()))
     }
 }

--- a/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_effects.rs
+++ b/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_effects.rs
@@ -4,115 +4,115 @@ use crate::block_producer::vrf_evaluator::VrfEvaluatorInput;
 use crate::Service;
 use crate::Store;
 
-use super::BlockProducerVrfEvaluatorUpdateProducerAndDelegatesAction;
-use super::BlockProducerVrfEvaluatorUpdateProducerAndDelegatesSuccessAction;
-use super::{
-    BlockProducerVrfEvaluatorEpochDataUpdateAction, BlockProducerVrfEvaluatorEvaluateVrfAction,
-    BlockProducerVrfEvaluatorEvaluationSuccessAction,
-};
+use super::BlockProducerVrfEvaluatorAction;
 
-impl BlockProducerVrfEvaluatorEpochDataUpdateAction {
+impl BlockProducerVrfEvaluatorAction {
     pub fn effects<S: Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        let vrf_evaluator_state_with_config =
-            store.state().block_producer.vrf_evaluator_with_config();
-        if let Some((_, config)) = vrf_evaluator_state_with_config {
-            store.dispatch(BlockProducerVrfEvaluatorUpdateProducerAndDelegatesAction {
-                current_epoch_ledger_hash: self.epoch_data.ledger.hash,
-                next_epoch_ledger_hash: self.next_epoch_data.ledger.hash,
-                producer: config.pub_key.clone().into(),
-            });
-        }
-    }
-}
+        match self {
+            BlockProducerVrfEvaluatorAction::EpochDataUpdate {
+                epoch_data,
+                next_epoch_data,
+                ..
+            } => {
+                let vrf_evaluator_state_with_config =
+                    store.state().block_producer.vrf_evaluator_with_config();
+                if let Some((_, config)) = vrf_evaluator_state_with_config {
+                    store.dispatch(
+                        BlockProducerVrfEvaluatorAction::UpdateProducerAndDelegates {
+                            current_epoch_ledger_hash: epoch_data.ledger.hash,
+                            next_epoch_ledger_hash: next_epoch_data.ledger.hash,
+                            producer: config.pub_key.clone().into(),
+                        },
+                    );
+                }
+            }
+            BlockProducerVrfEvaluatorAction::EvaluateVrf { vrf_input } => {
+                store.service.evaluate(vrf_input);
+            }
+            BlockProducerVrfEvaluatorAction::EvaluationSuccess { .. } => {
+                let Some((next_slot, current_epoch, current_epoch_data, next_epoch_data)) =
+                    store.state().block_producer.with(None, |block_producer| {
+                        let vrf_evaluator = &block_producer.vrf_evaluator;
+                        let next_slot = vrf_evaluator.latest_evaluated_slot + 1;
+                        let next_slot = next_slot.max(store.state().cur_global_slot()?);
 
-impl BlockProducerVrfEvaluatorEvaluateVrfAction {
-    pub fn effects<S: Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        store.service.evaluate(self.vrf_input);
-    }
-}
+                        Some((
+                            next_slot,
+                            vrf_evaluator.current_epoch.as_ref()?,
+                            vrf_evaluator.current_epoch_data.as_ref()?,
+                            vrf_evaluator.next_epoch_data.as_ref()?,
+                        ))
+                    })
+                else {
+                    return;
+                };
 
-impl BlockProducerVrfEvaluatorEvaluationSuccessAction {
-    pub fn effects<S: Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        let Some((next_slot, current_epoch, current_epoch_data, next_epoch_data)) =
-            store.state().block_producer.with(None, |block_producer| {
-                let vrf_evaluator = &block_producer.vrf_evaluator;
-                let next_slot = vrf_evaluator.latest_evaluated_slot + 1;
-                let next_slot = next_slot.max(store.state().cur_global_slot()?);
+                // TODO(adonagy): Can we get this from somewhere?
+                const SLOTS_PER_EPOCH: u32 = 7140;
+                let current_epoch_end = current_epoch * SLOTS_PER_EPOCH + SLOTS_PER_EPOCH - 1;
+                let next_epoch_end = (current_epoch + 1) * SLOTS_PER_EPOCH + SLOTS_PER_EPOCH - 1;
 
-                Some((
-                    next_slot,
-                    vrf_evaluator.current_epoch.as_ref()?,
-                    vrf_evaluator.current_epoch_data.as_ref()?,
-                    vrf_evaluator.next_epoch_data.as_ref()?,
-                ))
-            })
-        else {
-            return;
-        };
+                // slot is in the current epoch
+                if next_slot <= current_epoch_end {
+                    let vrf_input = VrfEvaluatorInput::new(
+                        current_epoch_data.seed.clone(),
+                        current_epoch_data.delegator_table.clone(),
+                        next_slot,
+                        current_epoch_data.total_currency,
+                        current_epoch_data.ledger.clone(),
+                    );
+                    store.dispatch(BlockProducerVrfEvaluatorAction::EvaluateVrf { vrf_input });
+                // slot is in the next epoch
+                } else if next_slot > current_epoch_end && next_slot <= next_epoch_end {
+                    let vrf_input = VrfEvaluatorInput::new(
+                        next_epoch_data.seed.clone(),
+                        next_epoch_data.delegator_table.clone(),
+                        next_slot,
+                        next_epoch_data.total_currency,
+                        next_epoch_data.ledger.clone(),
+                    );
+                    store.dispatch(BlockProducerVrfEvaluatorAction::EvaluateVrf { vrf_input });
+                }
+            }
+            BlockProducerVrfEvaluatorAction::UpdateProducerAndDelegates {
+                current_epoch_ledger_hash,
+                next_epoch_ledger_hash,
+                producer,
+            } => {
+                let current_epoch_producer_and_delegators =
+                    store.service.get_producer_and_delegates(
+                        current_epoch_ledger_hash.clone(),
+                        producer.clone(),
+                    );
+                let next_epoch_producer_and_delegators = store
+                    .service
+                    .get_producer_and_delegates(next_epoch_ledger_hash, producer.clone());
 
-        // TODO(adonagy): Can we get this from somewhere?
-        const SLOTS_PER_EPOCH: u32 = 7140;
-        let current_epoch_end = current_epoch * SLOTS_PER_EPOCH + SLOTS_PER_EPOCH - 1;
-        let next_epoch_end = (current_epoch + 1) * SLOTS_PER_EPOCH + SLOTS_PER_EPOCH - 1;
-
-        // slot is in the current epoch
-        if next_slot <= current_epoch_end {
-            let vrf_input = VrfEvaluatorInput::new(
-                current_epoch_data.seed.clone(),
-                current_epoch_data.delegator_table.clone(),
-                next_slot,
-                current_epoch_data.total_currency,
-                current_epoch_data.ledger.clone(),
-            );
-            store.dispatch(BlockProducerVrfEvaluatorEvaluateVrfAction { vrf_input });
-        // slot is in the next epoch
-        } else if next_slot > current_epoch_end && next_slot <= next_epoch_end {
-            let vrf_input = VrfEvaluatorInput::new(
-                next_epoch_data.seed.clone(),
-                next_epoch_data.delegator_table.clone(),
-                next_slot,
-                next_epoch_data.total_currency,
-                next_epoch_data.ledger.clone(),
-            );
-            store.dispatch(BlockProducerVrfEvaluatorEvaluateVrfAction { vrf_input });
-        }
-    }
-}
-
-impl BlockProducerVrfEvaluatorUpdateProducerAndDelegatesAction {
-    pub fn effects<S: Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        let current_epoch_producer_and_delegators = store.service.get_producer_and_delegates(
-            self.current_epoch_ledger_hash.clone(),
-            self.producer.clone(),
-        );
-        let next_epoch_producer_and_delegators = store
-            .service
-            .get_producer_and_delegates(self.next_epoch_ledger_hash, self.producer.clone());
-
-        store.dispatch(
-            BlockProducerVrfEvaluatorUpdateProducerAndDelegatesSuccessAction {
-                current_epoch_producer_and_delegators: current_epoch_producer_and_delegators.into(),
-                next_epoch_producer_and_delegators: next_epoch_producer_and_delegators.into(),
-                staking_ledger_hash: self.current_epoch_ledger_hash,
-            },
-        );
-    }
-}
-
-impl BlockProducerVrfEvaluatorUpdateProducerAndDelegatesSuccessAction {
-    pub fn effects<S: Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        let vrf_evaluator_state = store.state().block_producer.vrf_evaluator();
-
-        if let Some(vrf_evaluator_state) = vrf_evaluator_state {
-            if let Some(current_epoch_data) = &vrf_evaluator_state.current_epoch_data {
-                let vrf_input: VrfEvaluatorInput = VrfEvaluatorInput::new(
-                    current_epoch_data.seed.clone(),
-                    current_epoch_data.delegator_table.clone(),
-                    vrf_evaluator_state.current_best_tip_slot + 1,
-                    current_epoch_data.total_currency,
-                    current_epoch_data.ledger.clone(),
+                store.dispatch(
+                    BlockProducerVrfEvaluatorAction::UpdateProducerAndDelegatesSuccess {
+                        current_epoch_producer_and_delegators:
+                            current_epoch_producer_and_delegators.into(),
+                        next_epoch_producer_and_delegators: next_epoch_producer_and_delegators
+                            .into(),
+                        staking_ledger_hash: current_epoch_ledger_hash,
+                    },
                 );
-                store.dispatch(BlockProducerVrfEvaluatorEvaluateVrfAction { vrf_input });
+            }
+            BlockProducerVrfEvaluatorAction::UpdateProducerAndDelegatesSuccess { .. } => {
+                let vrf_evaluator_state = store.state().block_producer.vrf_evaluator();
+
+                if let Some(vrf_evaluator_state) = vrf_evaluator_state {
+                    if let Some(current_epoch_data) = &vrf_evaluator_state.current_epoch_data {
+                        let vrf_input: VrfEvaluatorInput = VrfEvaluatorInput::new(
+                            current_epoch_data.seed.clone(),
+                            current_epoch_data.delegator_table.clone(),
+                            vrf_evaluator_state.current_best_tip_slot + 1,
+                            current_epoch_data.total_currency,
+                            current_epoch_data.ledger.clone(),
+                        );
+                        store.dispatch(BlockProducerVrfEvaluatorAction::EvaluateVrf { vrf_input });
+                    }
+                }
             }
         }
     }

--- a/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_reducer.rs
+++ b/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_reducer.rs
@@ -7,36 +7,43 @@ impl BlockProducerVrfEvaluatorState {
     pub fn reducer(&mut self, action: BlockProducerVrfEvaluatorActionWithMetaRef<'_>) {
         let (action, meta) = action.split();
         match action {
-            BlockProducerVrfEvaluatorAction::EpochDataUpdate(action) => {
+            BlockProducerVrfEvaluatorAction::EpochDataUpdate {
+                new_epoch_number,
+                epoch_data,
+                next_epoch_data,
+            } => {
                 self.status = BlockProducerVrfEvaluatorStatus::EpochChanged { time: meta.time() };
                 self.current_epoch_data = Some(EpochData::new(
-                    action.epoch_data.seed.to_string(),
-                    action.epoch_data.ledger.hash.clone(),
-                    action.epoch_data.ledger.total_currency.as_u64(),
+                    epoch_data.seed.to_string(),
+                    epoch_data.ledger.hash.clone(),
+                    epoch_data.ledger.total_currency.as_u64(),
                 ));
                 self.next_epoch_data = Some(EpochData::new(
-                    action.next_epoch_data.seed.to_string(),
-                    action.next_epoch_data.ledger.hash.clone(),
-                    action.next_epoch_data.ledger.total_currency.as_u64(),
+                    next_epoch_data.seed.to_string(),
+                    next_epoch_data.ledger.hash.clone(),
+                    next_epoch_data.ledger.total_currency.as_u64(),
                 ));
-                self.current_epoch = Some(action.new_epoch_number);
+                self.current_epoch = Some(*new_epoch_number);
             }
-            BlockProducerVrfEvaluatorAction::EvaluateVrf(action) => {
+            BlockProducerVrfEvaluatorAction::EvaluateVrf { vrf_input } => {
                 self.status = BlockProducerVrfEvaluatorStatus::SlotsRequested {
                     time: meta.time(),
-                    global_slot: action.vrf_input.global_slot,
-                    staking_ledger_hash: action.vrf_input.staking_ledger_hash.clone(),
+                    global_slot: vrf_input.global_slot,
+                    staking_ledger_hash: vrf_input.staking_ledger_hash.clone(),
                 };
             }
             // BlockProducerVrfEvaluatorAction::EvaluationPending(_) => todo!(),
-            BlockProducerVrfEvaluatorAction::EvaluationSuccess(action) => {
-                let global_slot_evaluated = match &action.vrf_output {
+            BlockProducerVrfEvaluatorAction::EvaluationSuccess {
+                vrf_output,
+                staking_ledger_hash,
+            } => {
+                let global_slot_evaluated = match vrf_output {
                     vrf::VrfEvaluationOutput::SlotWon(won_slot_data) => {
                         self.won_slots.insert(
                             won_slot_data.global_slot,
                             VrfWonSlotWithHash::new(
                                 won_slot_data.clone(),
-                                action.staking_ledger_hash.clone(),
+                                staking_ledger_hash.clone(),
                             ),
                         );
                         won_slot_data.global_slot
@@ -46,14 +53,17 @@ impl BlockProducerVrfEvaluatorState {
                 self.status = BlockProducerVrfEvaluatorStatus::SlotsReceived {
                     time: meta.time(),
                     global_slot: global_slot_evaluated,
-                    staking_ledger_hash: action.staking_ledger_hash.clone(),
+                    staking_ledger_hash: staking_ledger_hash.clone(),
                 };
                 self.latest_evaluated_slot = global_slot_evaluated;
             }
-            BlockProducerVrfEvaluatorAction::UpdateProducerAndDelegates(_) => {
+            BlockProducerVrfEvaluatorAction::UpdateProducerAndDelegates { .. } => {
                 self.status = BlockProducerVrfEvaluatorStatus::DataPending { time: meta.time() };
             }
-            BlockProducerVrfEvaluatorAction::UpdateProducerAndDelegatesSuccess(action) => {
+            BlockProducerVrfEvaluatorAction::UpdateProducerAndDelegatesSuccess {
+                current_epoch_producer_and_delegators,
+                ..
+            } => {
                 self.status = BlockProducerVrfEvaluatorStatus::DataSuccess { time: meta.time() };
                 // TODO(adonagy): causes reevaluation of already evaluated slots.
                 // Needed since delegate table changed and we might miss slots
@@ -64,13 +74,11 @@ impl BlockProducerVrfEvaluatorState {
                 self.latest_evaluated_slot = 0;
 
                 if let Some(epoch_data) = self.current_epoch_data.as_mut() {
-                    epoch_data.delegator_table =
-                        action.current_epoch_producer_and_delegators.clone();
+                    epoch_data.delegator_table = current_epoch_producer_and_delegators.clone();
                 }
 
                 if let Some(epoch_data) = self.next_epoch_data.as_mut() {
-                    epoch_data.delegator_table =
-                        action.current_epoch_producer_and_delegators.clone();
+                    epoch_data.delegator_table = current_epoch_producer_and_delegators.clone();
                 }
             }
         }

--- a/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_state.rs
+++ b/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_state.rs
@@ -131,7 +131,7 @@ pub enum BlockProducerVrfEvaluatorStatus {
 }
 
 impl BlockProducerVrfEvaluatorStatus {
-    pub fn matches_requsted_slot(
+    pub fn matches_requested_slot(
         &self,
         expected_global_slot: u32,
         expected_staking_ledger_hash: &LedgerHash,

--- a/node/src/consensus/consensus_effects.rs
+++ b/node/src/consensus/consensus_effects.rs
@@ -1,7 +1,5 @@
 use crate::snark::block_verify::SnarkBlockVerifyAction;
-use crate::transition_frontier::sync::{
-    TransitionFrontierSyncBestTipUpdateAction, TransitionFrontierSyncInitAction,
-};
+use crate::transition_frontier::sync::TransitionFrontierSyncAction;
 use crate::watched_accounts::WatchedAccountsAction;
 use crate::Store;
 
@@ -87,13 +85,13 @@ fn transition_frontier_new_best_tip<S: crate::Service>(store: &mut Store<S>) {
     };
 
     if !state.transition_frontier.sync.is_pending() && !state.transition_frontier.sync.is_synced() {
-        store.dispatch(TransitionFrontierSyncInitAction {
+        store.dispatch(TransitionFrontierSyncAction::Init {
             best_tip,
             root_block,
             blocks_inbetween,
         });
     } else {
-        store.dispatch(TransitionFrontierSyncBestTipUpdateAction {
+        store.dispatch(TransitionFrontierSyncAction::BestTipUpdate {
             best_tip,
             root_block,
             blocks_inbetween,

--- a/node/src/consensus/consensus_effects.rs
+++ b/node/src/consensus/consensus_effects.rs
@@ -1,12 +1,9 @@
+use crate::snark::block_verify::SnarkBlockVerifyAction;
 use crate::transition_frontier::sync::{
     TransitionFrontierSyncBestTipUpdateAction, TransitionFrontierSyncInitAction,
 };
-use crate::watched_accounts::WatchedAccountsLedgerInitialStateGetInitAction;
+use crate::watched_accounts::WatchedAccountsAction;
 use crate::Store;
-use crate::{
-    snark::block_verify::SnarkBlockVerifyAction,
-    watched_accounts::WatchedAccountsBlockTransactionsIncludedAction,
-};
 
 use super::{ConsensusAction, ConsensusActionWithMeta};
 
@@ -46,10 +43,10 @@ pub fn consensus_effects<S: crate::Service>(store: &mut Store<S>, action: Consen
                 return;
             };
             for pub_key in store.state().watched_accounts.accounts() {
-                store.dispatch(WatchedAccountsLedgerInitialStateGetInitAction {
+                store.dispatch(WatchedAccountsAction::LedgerInitialStateGetInit {
                     pub_key: pub_key.clone(),
                 });
-                store.dispatch(WatchedAccountsBlockTransactionsIncludedAction {
+                store.dispatch(WatchedAccountsAction::TransactionsIncludedInBlock {
                     pub_key,
                     block: block.clone(),
                 });

--- a/node/src/effects.rs
+++ b/node/src/effects.rs
@@ -12,7 +12,7 @@ use crate::p2p::connection::outgoing::{
     P2pConnectionOutgoingRandomInitAction, P2pConnectionOutgoingReconnectAction,
     P2pConnectionOutgoingTimeoutAction,
 };
-use crate::p2p::discovery::{P2pDiscoveryKademliaBootstrapAction, P2pDiscoveryKademliaInitAction};
+use crate::p2p::discovery::P2pDiscoveryAction;
 use crate::p2p::p2p_effects;
 use crate::rpc::rpc_effects;
 use crate::snark::snark_effects;
@@ -58,8 +58,8 @@ pub fn effects<S: Service>(store: &mut Store<S>, action: ActionWithMeta) {
 
             p2p_request_snarks_if_needed(store);
 
-            store.dispatch(P2pDiscoveryKademliaBootstrapAction {});
-            store.dispatch(P2pDiscoveryKademliaInitAction {});
+            store.dispatch(P2pDiscoveryAction::KademliaBootstrap);
+            store.dispatch(P2pDiscoveryAction::KademliaInit);
             #[cfg(feature = "p2p-webrtc")]
             p2p_discovery_request(store, &meta);
 
@@ -214,8 +214,6 @@ fn p2p_request_snarks_if_needed<S: Service>(store: &mut Store<S>) {
 /// If the elapsed time is large enough, send another discovery request.
 #[cfg(feature = "p2p-webrtc")]
 fn p2p_discovery_request<S: Service>(store: &mut Store<S>, meta: &ActionMeta) {
-    use crate::p2p::discovery::P2pDiscoveryInitAction;
-
     let peer_ids = store
         .state()
         .p2p
@@ -245,6 +243,6 @@ fn p2p_discovery_request<S: Service>(store: &mut Store<S>, meta: &ActionMeta) {
         .collect::<Vec<_>>();
 
     for peer_id in peer_ids {
-        store.dispatch(P2pDiscoveryInitAction { peer_id });
+        store.dispatch(P2pDiscoveryAction::Init { peer_id });
     }
 }

--- a/node/src/effects.rs
+++ b/node/src/effects.rs
@@ -7,7 +7,7 @@ use crate::event_source::event_source_effects;
 use crate::external_snark_worker::external_snark_worker_effects;
 use crate::logger::logger_effects;
 use crate::p2p::channels::rpc::{P2pChannelsRpcAction, P2pRpcKind, P2pRpcRequest};
-use crate::p2p::connection::incoming::P2pConnectionIncomingTimeoutAction;
+use crate::p2p::connection::incoming::P2pConnectionIncomingAction;
 use crate::p2p::connection::outgoing::{
     P2pConnectionOutgoingRandomInitAction, P2pConnectionOutgoingReconnectAction,
     P2pConnectionOutgoingTimeoutAction,
@@ -128,7 +128,7 @@ fn p2p_connection_timeouts<S: Service>(store: &mut Store<S>, meta: &ActionMeta) 
     for (peer_id, is_outgoing) in p2p_connection_timeouts {
         match is_outgoing {
             true => store.dispatch(P2pConnectionOutgoingTimeoutAction { peer_id }),
-            false => store.dispatch(P2pConnectionIncomingTimeoutAction { peer_id }),
+            false => store.dispatch(P2pConnectionIncomingAction::Timeout { peer_id }),
         };
     }
 }

--- a/node/src/effects.rs
+++ b/node/src/effects.rs
@@ -1,7 +1,7 @@
 use p2p::channels::snark::P2pChannelsSnarkAction;
 use redux::ActionMeta;
 
-use crate::block_producer::{block_producer_effects, BlockProducerWonSlotProduceInitAction};
+use crate::block_producer::{block_producer_effects, BlockProducerAction};
 use crate::consensus::consensus_effects;
 use crate::event_source::event_source_effects;
 use crate::external_snark_worker::external_snark_worker_effects;
@@ -74,7 +74,7 @@ pub fn effects<S: Service>(store: &mut Store<S>, action: ActionWithMeta) {
             store.dispatch(ExternalSnarkWorkerAction::StartTimeout { now: meta.time() });
             store.dispatch(ExternalSnarkWorkerAction::WorkTimeout { now: meta.time() });
 
-            store.dispatch(BlockProducerWonSlotProduceInitAction {});
+            store.dispatch(BlockProducerAction::WonSlotProduceInit);
         }
         Action::EventSource(action) => {
             event_source_effects(store, meta.with_action(action));

--- a/node/src/effects.rs
+++ b/node/src/effects.rs
@@ -18,7 +18,7 @@ use crate::rpc::rpc_effects;
 use crate::snark::snark_effects;
 use crate::snark_pool::candidate::SnarkPoolCandidateAction;
 use crate::snark_pool::{snark_pool_effects, SnarkPoolAction};
-use crate::transition_frontier::sync::TransitionFrontierSyncBlocksNextApplyInitAction;
+use crate::transition_frontier::sync::TransitionFrontierSyncAction;
 use crate::transition_frontier::transition_frontier_effects;
 use crate::watched_accounts::watched_accounts_effects;
 use crate::{Action, ActionWithMeta, ExternalSnarkWorkerAction, Service, Store};
@@ -69,7 +69,7 @@ pub fn effects<S: Service>(store: &mut Store<S>, action: ActionWithMeta) {
             }
 
             // TODO(binier): remove once ledger communication is async.
-            store.dispatch(TransitionFrontierSyncBlocksNextApplyInitAction {});
+            store.dispatch(TransitionFrontierSyncAction::BlocksNextApplyInit);
 
             store.dispatch(ExternalSnarkWorkerAction::StartTimeout { now: meta.time() });
             store.dispatch(ExternalSnarkWorkerAction::WorkTimeout { now: meta.time() });

--- a/node/src/event_source/event_source_actions.rs
+++ b/node/src/event_source/event_source_actions.rs
@@ -2,82 +2,34 @@ use serde::{Deserialize, Serialize};
 
 pub type EventSourceActionWithMeta = redux::ActionWithMeta<EventSourceAction>;
 
-#[derive(derive_more::From, Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum EventSourceAction {
-    ProcessEvents(EventSourceProcessEventsAction),
-    NewEvent(EventSourceNewEventAction),
-    WaitForEvents(EventSourceWaitForEventsAction),
-    WaitTimeout(EventSourceWaitTimeoutAction),
+    /// Notify state machine that the new events might be received/available,
+    /// so trigger processing of those events.
+    ///
+    /// This action will be continuously triggered, until there are no more
+    /// events in the queue, in which case `EventSourceWaitForEventsAction`
+    /// will be dispatched.
+    ProcessEvents,
+
+    /// Process newly retrieved event.
+    NewEvent { event: super::Event },
+
+    /// Next action won't be dispatched, until new events are available or
+    /// wait times out.
+    WaitForEvents,
+
+    /// Waiting for events has timed out.
+    WaitTimeout,
 }
 
-/// Notify state machine that the new events might be received/available,
-/// so trigger processing of those events.
-///
-/// This action will be continously triggered, until there are no more
-/// events in the queue, in which case `EventSourceWaitForEventsAction`
-/// will be dispatched.
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct EventSourceProcessEventsAction {}
-
-impl redux::EnablingCondition<crate::State> for EventSourceProcessEventsAction {
+impl redux::EnablingCondition<crate::State> for EventSourceAction {
     fn is_enabled(&self, _: &crate::State) -> bool {
-        true
-    }
-}
-
-/// Process newly retrieved event.
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct EventSourceNewEventAction {
-    pub event: super::Event,
-}
-
-impl redux::EnablingCondition<crate::State> for EventSourceNewEventAction {
-    fn is_enabled(&self, _: &crate::State) -> bool {
-        true
-    }
-}
-
-/// Next action won't be dispatched, until new events are available or
-/// wait times out.
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct EventSourceWaitForEventsAction {}
-
-impl redux::EnablingCondition<crate::State> for EventSourceWaitForEventsAction {
-    fn is_enabled(&self, _: &crate::State) -> bool {
-        true
-    }
-}
-
-/// Waiting for events has timed out.
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct EventSourceWaitTimeoutAction {}
-
-impl redux::EnablingCondition<crate::State> for EventSourceWaitTimeoutAction {
-    fn is_enabled(&self, _: &crate::State) -> bool {
-        true
-    }
-}
-
-impl From<EventSourceProcessEventsAction> for crate::Action {
-    fn from(a: EventSourceProcessEventsAction) -> Self {
-        Self::EventSource(EventSourceAction::ProcessEvents(a))
-    }
-}
-
-impl From<EventSourceNewEventAction> for crate::Action {
-    fn from(a: EventSourceNewEventAction) -> Self {
-        Self::EventSource(EventSourceAction::NewEvent(a))
-    }
-}
-
-impl From<EventSourceWaitForEventsAction> for crate::Action {
-    fn from(a: EventSourceWaitForEventsAction) -> Self {
-        Self::EventSource(EventSourceAction::WaitForEvents(a))
-    }
-}
-
-impl From<EventSourceWaitTimeoutAction> for crate::Action {
-    fn from(a: EventSourceWaitTimeoutAction) -> Self {
-        Self::EventSource(EventSourceAction::WaitTimeout(a))
+        match self {
+            EventSourceAction::ProcessEvents => true,
+            EventSourceAction::NewEvent { event: _ } => true,
+            EventSourceAction::WaitForEvents => true,
+            EventSourceAction::WaitTimeout => true,
+        }
     }
 }

--- a/node/src/event_source/event_source_effects.rs
+++ b/node/src/event_source/event_source_effects.rs
@@ -1,7 +1,5 @@
 use p2p::channels::snark::P2pChannelsSnarkAction;
-use p2p::listen::{
-    P2pListenClosedAction, P2pListenErrorAction, P2pListenExpiredAction, P2pListenNewAction,
-};
+use p2p::listen::P2pListenAction;
 use p2p::P2pListenEvent;
 
 use crate::action::CheckTimeoutsAction;
@@ -60,16 +58,16 @@ pub fn event_source_effects<S: Service>(store: &mut Store<S>, action: EventSourc
             Event::P2p(e) => match e {
                 P2pEvent::Listen(e) => match e {
                     P2pListenEvent::NewListenAddr { listener_id, addr } => {
-                        store.dispatch(P2pListenNewAction { listener_id, addr });
+                        store.dispatch(P2pListenAction::New { listener_id, addr });
                     }
                     P2pListenEvent::ExpiredListenAddr { listener_id, addr } => {
-                        store.dispatch(P2pListenExpiredAction { listener_id, addr });
+                        store.dispatch(P2pListenAction::Expired { listener_id, addr });
                     }
                     P2pListenEvent::ListenerError { listener_id, error } => {
-                        store.dispatch(P2pListenErrorAction { listener_id, error });
+                        store.dispatch(P2pListenAction::Error { listener_id, error });
                     }
                     P2pListenEvent::ListenerClosed { listener_id, error } => {
-                        store.dispatch(P2pListenClosedAction { listener_id, error });
+                        store.dispatch(P2pListenAction::Closed { listener_id, error });
                     }
                 },
                 P2pEvent::Connection(e) => match e {

--- a/node/src/event_source/event_source_effects.rs
+++ b/node/src/event_source/event_source_effects.rs
@@ -26,14 +26,7 @@ use crate::p2p::connection::{P2pConnectionErrorResponse, P2pConnectionResponse};
 use crate::p2p::disconnection::{P2pDisconnectionAction, P2pDisconnectionReason};
 use crate::p2p::discovery::P2pDiscoveryAction;
 use crate::p2p::P2pChannelEvent;
-use crate::rpc::{
-    RpcActionStatsGetAction, RpcGlobalStateGetAction, RpcHealthCheckAction,
-    RpcP2pConnectionIncomingInitAction, RpcP2pConnectionOutgoingInitAction, RpcPeersGetAction,
-    RpcReadinessCheckAction, RpcRequest, RpcScanStateSummaryGetAction,
-    RpcSnarkPoolAvailableJobsGetAction, RpcSnarkPoolJobGetAction, RpcSnarkerConfigGetAction,
-    RpcSnarkerJobCommitAction, RpcSnarkerJobSpecAction, RpcSnarkersWorkersGetAction,
-    RpcSyncStatsGetAction,
-};
+use crate::rpc::{RpcAction, RpcRequest};
 use crate::snark::block_verify::SnarkBlockVerifyAction;
 use crate::snark::work_verify::SnarkWorkVerifyAction;
 use crate::snark::SnarkEvent;
@@ -241,52 +234,52 @@ pub fn event_source_effects<S: Service>(store: &mut Store<S>, action: EventSourc
             },
             Event::Rpc(rpc_id, e) => match e {
                 RpcRequest::StateGet => {
-                    store.dispatch(RpcGlobalStateGetAction { rpc_id });
+                    store.dispatch(RpcAction::GlobalStateGet { rpc_id });
                 }
                 RpcRequest::ActionStatsGet(query) => {
-                    store.dispatch(RpcActionStatsGetAction { rpc_id, query });
+                    store.dispatch(RpcAction::ActionStatsGet { rpc_id, query });
                 }
                 RpcRequest::SyncStatsGet(query) => {
-                    store.dispatch(RpcSyncStatsGetAction { rpc_id, query });
+                    store.dispatch(RpcAction::SyncStatsGet { rpc_id, query });
                 }
                 RpcRequest::PeersGet => {
-                    store.dispatch(RpcPeersGetAction { rpc_id });
+                    store.dispatch(RpcAction::PeersGet { rpc_id });
                 }
                 RpcRequest::P2pConnectionOutgoing(opts) => {
-                    store.dispatch(RpcP2pConnectionOutgoingInitAction { rpc_id, opts });
+                    store.dispatch(RpcAction::P2pConnectionOutgoingInit { rpc_id, opts });
                 }
                 RpcRequest::P2pConnectionIncoming(opts) => {
-                    store.dispatch(RpcP2pConnectionIncomingInitAction {
+                    store.dispatch(RpcAction::P2pConnectionIncomingInit {
                         rpc_id,
                         opts: opts.clone(),
                     });
                 }
                 RpcRequest::ScanStateSummaryGet(query) => {
-                    store.dispatch(RpcScanStateSummaryGetAction { rpc_id, query });
+                    store.dispatch(RpcAction::ScanStateSummaryGet { rpc_id, query });
                 }
                 RpcRequest::SnarkPoolGet => {
-                    store.dispatch(RpcSnarkPoolAvailableJobsGetAction { rpc_id });
+                    store.dispatch(RpcAction::SnarkPoolAvailableJobsGet { rpc_id });
                 }
                 RpcRequest::SnarkPoolJobGet { job_id } => {
-                    store.dispatch(RpcSnarkPoolJobGetAction { rpc_id, job_id });
+                    store.dispatch(RpcAction::SnarkPoolJobGet { rpc_id, job_id });
                 }
                 RpcRequest::SnarkerConfig => {
-                    store.dispatch(RpcSnarkerConfigGetAction { rpc_id });
+                    store.dispatch(RpcAction::SnarkerConfigGet { rpc_id });
                 }
                 RpcRequest::SnarkerJobCommit { job_id } => {
-                    store.dispatch(RpcSnarkerJobCommitAction { rpc_id, job_id });
+                    store.dispatch(RpcAction::SnarkerJobCommit { rpc_id, job_id });
                 }
                 RpcRequest::SnarkerJobSpec { job_id } => {
-                    store.dispatch(RpcSnarkerJobSpecAction { rpc_id, job_id });
+                    store.dispatch(RpcAction::SnarkerJobSpec { rpc_id, job_id });
                 }
                 RpcRequest::SnarkerWorkers => {
-                    store.dispatch(RpcSnarkersWorkersGetAction { rpc_id });
+                    store.dispatch(RpcAction::SnarkerWorkersGet { rpc_id });
                 }
                 RpcRequest::HealthCheck => {
-                    store.dispatch(RpcHealthCheckAction { rpc_id });
+                    store.dispatch(RpcAction::HealthCheck { rpc_id });
                 }
                 RpcRequest::ReadinessCheck => {
-                    store.dispatch(RpcReadinessCheckAction { rpc_id });
+                    store.dispatch(RpcAction::ReadinessCheck { rpc_id });
                 }
             },
             Event::ExternalSnarkWorker(e) => match e {

--- a/node/src/event_source/event_source_effects.rs
+++ b/node/src/event_source/event_source_effects.rs
@@ -9,11 +9,7 @@ use crate::p2p::channels::best_tip::P2pChannelsBestTipAction;
 use crate::p2p::channels::rpc::P2pChannelsRpcAction;
 use crate::p2p::channels::snark_job_commitment::P2pChannelsSnarkJobCommitmentAction;
 use crate::p2p::channels::{ChannelId, P2pChannelsMessageReceivedAction};
-use crate::p2p::connection::incoming::{
-    P2pConnectionIncomingAnswerSdpCreateErrorAction,
-    P2pConnectionIncomingAnswerSdpCreateSuccessAction, P2pConnectionIncomingFinalizeErrorAction,
-    P2pConnectionIncomingFinalizeSuccessAction, P2pConnectionIncomingLibp2pReceivedAction,
-};
+use crate::p2p::connection::incoming::P2pConnectionIncomingAction;
 use crate::p2p::connection::outgoing::{
     P2pConnectionOutgoingAnswerRecvErrorAction, P2pConnectionOutgoingAnswerRecvSuccessAction,
     P2pConnectionOutgoingFinalizeErrorAction, P2pConnectionOutgoingFinalizeSuccessAction,
@@ -87,13 +83,13 @@ pub fn event_source_effects<S: Service>(store: &mut Store<S>, action: EventSourc
                     },
                     P2pConnectionEvent::AnswerSdpReady(peer_id, res) => match res {
                         Err(error) => {
-                            store.dispatch(P2pConnectionIncomingAnswerSdpCreateErrorAction {
+                            store.dispatch(P2pConnectionIncomingAction::AnswerSdpCreateError {
                                 peer_id,
                                 error,
                             });
                         }
                         Ok(sdp) => {
-                            store.dispatch(P2pConnectionIncomingAnswerSdpCreateSuccessAction {
+                            store.dispatch(P2pConnectionIncomingAction::AnswerSdpCreateSuccess {
                                 peer_id,
                                 sdp,
                             });
@@ -125,7 +121,7 @@ pub fn event_source_effects<S: Service>(store: &mut Store<S>, action: EventSourc
                                 peer_id,
                                 error: error.clone(),
                             });
-                            store.dispatch(P2pConnectionIncomingFinalizeErrorAction {
+                            store.dispatch(P2pConnectionIncomingAction::FinalizeError {
                                 peer_id,
                                 error,
                             });
@@ -133,10 +129,10 @@ pub fn event_source_effects<S: Service>(store: &mut Store<S>, action: EventSourc
                         Ok(_) => {
                             let _ = store
                                 .dispatch(P2pConnectionOutgoingFinalizeSuccessAction { peer_id })
-                                || store.dispatch(P2pConnectionIncomingFinalizeSuccessAction {
+                                || store.dispatch(P2pConnectionIncomingAction::FinalizeSuccess {
                                     peer_id,
                                 })
-                                || store.dispatch(P2pConnectionIncomingLibp2pReceivedAction {
+                                || store.dispatch(P2pConnectionIncomingAction::Libp2pReceived {
                                     peer_id,
                                 });
                         }

--- a/node/src/event_source/event_source_effects.rs
+++ b/node/src/event_source/event_source_effects.rs
@@ -24,10 +24,7 @@ use crate::p2p::connection::outgoing::{
 };
 use crate::p2p::connection::{P2pConnectionErrorResponse, P2pConnectionResponse};
 use crate::p2p::disconnection::{P2pDisconnectionAction, P2pDisconnectionReason};
-use crate::p2p::discovery::{
-    P2pDiscoveryKademliaAddRouteAction, P2pDiscoveryKademliaFailureAction,
-    P2pDiscoveryKademliaSuccessAction,
-};
+use crate::p2p::discovery::P2pDiscoveryAction;
 use crate::p2p::P2pChannelEvent;
 use crate::rpc::{
     RpcActionStatsGetAction, RpcGlobalStateGetAction, RpcHealthCheckAction,
@@ -215,13 +212,13 @@ pub fn event_source_effects<S: Service>(store: &mut Store<S>, action: EventSourc
                 P2pEvent::Libp2pIdentify(..) => {}
                 P2pEvent::Discovery(p2p::P2pDiscoveryEvent::Ready) => {}
                 P2pEvent::Discovery(p2p::P2pDiscoveryEvent::DidFindPeers(peers)) => {
-                    store.dispatch(P2pDiscoveryKademliaSuccessAction { peers });
+                    store.dispatch(P2pDiscoveryAction::KademliaSuccess { peers });
                 }
                 P2pEvent::Discovery(p2p::P2pDiscoveryEvent::DidFindPeersError(description)) => {
-                    store.dispatch(P2pDiscoveryKademliaFailureAction { description });
+                    store.dispatch(P2pDiscoveryAction::KademliaFailure { description });
                 }
                 P2pEvent::Discovery(p2p::P2pDiscoveryEvent::AddRoute(peer_id, addresses)) => {
-                    store.dispatch(P2pDiscoveryKademliaAddRouteAction { peer_id, addresses });
+                    store.dispatch(P2pDiscoveryAction::KademliaAddRoute { peer_id, addresses });
                 }
             },
             Event::Snark(event) => match event {

--- a/node/src/event_source/event_source_effects.rs
+++ b/node/src/event_source/event_source_effects.rs
@@ -5,7 +5,7 @@ use p2p::listen::{
 use p2p::P2pListenEvent;
 
 use crate::action::CheckTimeoutsAction;
-use crate::block_producer::vrf_evaluator::BlockProducerVrfEvaluatorEvaluationSuccessAction;
+use crate::block_producer::vrf_evaluator::BlockProducerVrfEvaluatorAction;
 use crate::external_snark_worker::ExternalSnarkWorkerEvent;
 use crate::p2p::channels::best_tip::P2pChannelsBestTipAction;
 use crate::p2p::channels::rpc::P2pChannelsRpcAction;
@@ -310,7 +310,7 @@ pub fn event_source_effects<S: Service>(store: &mut Store<S>, action: EventSourc
                     crate::block_producer::BlockProducerVrfEvaluatorEvent::Evaluated(
                         vrf_output_with_hash,
                     ) => {
-                        store.dispatch(BlockProducerVrfEvaluatorEvaluationSuccessAction {
+                        store.dispatch(BlockProducerVrfEvaluatorAction::EvaluationSuccess {
                             vrf_output: vrf_output_with_hash.evaluation_result,
                             staking_ledger_hash: vrf_output_with_hash.staking_ledger_hash,
                         });

--- a/node/src/logger/logger_effects.rs
+++ b/node/src/logger/logger_effects.rs
@@ -23,48 +23,48 @@ pub fn logger_effects<S: Service>(store: &Store<S>, action: ActionWithMetaRef<'_
     match action {
         Action::P2p(action) => match action {
             P2pAction::Listen(action) => match action {
-                p2p::listen::P2pListenAction::New(action) => {
+                p2p::listen::P2pListenAction::New { listener_id, addr } => {
                     openmina_core::log::info!(
                         meta.time();
                         kind = kind.to_string(),
-                        summary = format!("addr: {}", action.addr),
-                        addr = action.addr.to_string(),
-                        listener_id = action.listener_id.to_string(),
+                        summary = format!("addr: {addr}", ),
+                        addr = addr.to_string(),
+                        listener_id = listener_id.to_string(),
                     );
                 }
-                p2p::listen::P2pListenAction::Expired(action) => {
+                p2p::listen::P2pListenAction::Expired { listener_id, addr } => {
                     openmina_core::log::info!(
                         meta.time();
                         kind = kind.to_string(),
-                        summary = format!("addr: {}", action.addr),
-                        addr = action.addr.to_string(),
-                        listener_id = action.listener_id.to_string(),
+                        summary = format!("addr: {addr}", ),
+                        addr = addr.to_string(),
+                        listener_id = listener_id.to_string(),
                     );
                 }
-                p2p::listen::P2pListenAction::Error(action) => {
+                p2p::listen::P2pListenAction::Error { listener_id, error } => {
                     openmina_core::log::warn!(
                         meta.time();
                         kind = kind.to_string(),
-                        summary = format!("id: {}, error: {}", action.listener_id, action.error),
-                        error = action.error,
-                        listener_id = action.listener_id.to_string(),
+                        summary = format!("id: {listener_id}, error: {error}", ),
+                        error = error,
+                        listener_id = listener_id.to_string(),
                     );
                 }
-                p2p::listen::P2pListenAction::Closed(action) => {
-                    if let Some(error) = &action.error {
+                p2p::listen::P2pListenAction::Closed { listener_id, error } => {
+                    if let Some(error) = error {
                         openmina_core::log::warn!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("id: {}, error: {error}", action.listener_id),
+                            summary = format!("id: {listener_id}, error: {error}", ),
                             error = error,
-                            listener_id = action.listener_id.to_string(),
+                            listener_id = listener_id.to_string(),
                         );
                     } else {
                         openmina_core::log::info!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("id: {},", action.listener_id),
-                            listener_id = action.listener_id.to_string(),
+                            summary = format!("id: {listener_id},", ),
+                            listener_id = listener_id.to_string(),
                         );
                     }
                 }

--- a/node/src/logger/logger_effects.rs
+++ b/node/src/logger/logger_effects.rs
@@ -579,50 +579,58 @@ pub fn logger_effects<S: Service>(store: &Store<S>, action: ActionWithMetaRef<'_
         },
         Action::TransitionFrontier(a) => match a {
             TransitionFrontierAction::Sync(action) => match action {
-                TransitionFrontierSyncAction::Init(action) => openmina_core::log::info!(
+                TransitionFrontierSyncAction::Init {
+                    best_tip,
+                    root_block,
+                    ..
+                } => openmina_core::log::info!(
                     meta.time();
                     kind = kind.to_string(),
                     summary = "Transition frontier sync init".to_string(),
-                    block_hash = action.best_tip.hash.to_string(),
-                    root_block_hash = action.root_block.hash.to_string(),
+                    block_hash = best_tip.hash.to_string(),
+                    root_block_hash = root_block.hash.to_string(),
                 ),
-                TransitionFrontierSyncAction::BestTipUpdate(action) => openmina_core::log::info!(
+                TransitionFrontierSyncAction::BestTipUpdate {
+                    best_tip,
+                    root_block,
+                    ..
+                } => openmina_core::log::info!(
                     meta.time();
                     kind = kind.to_string(),
                     summary = "New best tip received".to_string(),
-                    block_hash = action.best_tip.hash.to_string(),
-                    root_block_hash = action.root_block.hash.to_string(),
+                    block_hash = best_tip.hash.to_string(),
+                    root_block_hash = root_block.hash.to_string(),
                 ),
-                TransitionFrontierSyncAction::LedgerStakingPending(_) => openmina_core::log::info!(
+                TransitionFrontierSyncAction::LedgerStakingPending => openmina_core::log::info!(
                     meta.time();
                     kind = kind.to_string(),
                     summary = "Staking ledger sync pending".to_string(),
                 ),
-                TransitionFrontierSyncAction::LedgerStakingSuccess(_) => openmina_core::log::info!(
+                TransitionFrontierSyncAction::LedgerStakingSuccess => openmina_core::log::info!(
                     meta.time();
                     kind = kind.to_string(),
                     summary = "Staking ledger sync success".to_string(),
                 ),
-                TransitionFrontierSyncAction::LedgerNextEpochPending(_) => {
+                TransitionFrontierSyncAction::LedgerNextEpochPending => {
                     openmina_core::log::info!(
                         meta.time();
                         kind = kind.to_string(),
                         summary = "Next epoch ledger sync pending".to_string(),
                     )
                 }
-                TransitionFrontierSyncAction::LedgerNextEpochSuccess(_) => {
+                TransitionFrontierSyncAction::LedgerNextEpochSuccess => {
                     openmina_core::log::info!(
                         meta.time();
                         kind = kind.to_string(),
                         summary = "Next epoch ledger sync pending".to_string(),
                     )
                 }
-                TransitionFrontierSyncAction::LedgerRootPending(_) => openmina_core::log::info!(
+                TransitionFrontierSyncAction::LedgerRootPending => openmina_core::log::info!(
                     meta.time();
                     kind = kind.to_string(),
                     summary = "Transition frontier root ledger sync pending".to_string(),
                 ),
-                TransitionFrontierSyncAction::LedgerRootSuccess(_) => openmina_core::log::info!(
+                TransitionFrontierSyncAction::LedgerRootSuccess => openmina_core::log::info!(
                     meta.time();
                     kind = kind.to_string(),
                     summary = "Transition frontier root ledger sync success".to_string(),

--- a/node/src/logger/logger_effects.rs
+++ b/node/src/logger/logger_effects.rs
@@ -696,7 +696,7 @@ pub fn logger_effects<S: Service>(store: &Store<S>, action: ActionWithMetaRef<'_
                     )
                 }
             },
-            BlockProducerAction::BestTipUpdate(_) => {}
+            BlockProducerAction::BestTipUpdate { .. } => {}
             _ => {}
         },
         _ => {}

--- a/node/src/logger/logger_effects.rs
+++ b/node/src/logger/logger_effects.rs
@@ -71,121 +71,123 @@ pub fn logger_effects<S: Service>(store: &Store<S>, action: ActionWithMetaRef<'_
             },
             P2pAction::Connection(action) => match action {
                 P2pConnectionAction::Outgoing(action) => match action {
-                    P2pConnectionOutgoingAction::RandomInit(_) => {}
-                    P2pConnectionOutgoingAction::Init(action) => {
+                    P2pConnectionOutgoingAction::RandomInit => {}
+                    P2pConnectionOutgoingAction::Init { opts, .. } => {
+                        let peer_id = opts.peer_id();
                         openmina_core::log::info!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {}", action.opts.peer_id()),
-                            peer_id = action.opts.peer_id().to_string(),
-                            transport = action.opts.kind(),
+                            summary = format!("peer_id: {peer_id}"),
+                            peer_id = peer_id.to_string(),
+                            transport = opts.kind(),
                         );
                     }
-                    P2pConnectionOutgoingAction::Reconnect(action) => {
+                    P2pConnectionOutgoingAction::Reconnect { opts, .. } => {
+                        let peer_id = opts.peer_id();
                         openmina_core::log::info!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {}", action.opts.peer_id()),
-                            peer_id = action.opts.peer_id().to_string(),
-                            transport = action.opts.kind(),
+                            summary = format!("peer_id: {peer_id}"),
+                            peer_id = peer_id.to_string(),
+                            transport = opts.kind(),
                         );
                     }
-                    P2pConnectionOutgoingAction::OfferSdpCreatePending(_) => {}
-                    P2pConnectionOutgoingAction::OfferSdpCreateError(action) => {
+                    P2pConnectionOutgoingAction::OfferSdpCreatePending { .. } => {}
+                    P2pConnectionOutgoingAction::OfferSdpCreateError { peer_id, error } => {
                         openmina_core::log::warn!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {}", action.peer_id),
-                            peer_id = action.peer_id.to_string(),
-                            error = action.error.clone(),
+                            summary = format!("peer_id: {peer_id}"),
+                            peer_id = peer_id.to_string(),
+                            error = error.clone(),
                         );
                     }
-                    P2pConnectionOutgoingAction::OfferSdpCreateSuccess(action) => {
+                    P2pConnectionOutgoingAction::OfferSdpCreateSuccess { peer_id, sdp } => {
                         openmina_core::log::debug!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {}", action.peer_id),
-                            peer_id = action.peer_id.to_string(),
-                            sdp = action.sdp.clone(),
+                            summary = format!("peer_id: {peer_id}"),
+                            peer_id = peer_id.to_string(),
+                            sdp = sdp.clone(),
                         );
                     }
-                    P2pConnectionOutgoingAction::OfferReady(action) => {
+                    P2pConnectionOutgoingAction::OfferReady { peer_id, offer } => {
                         openmina_core::log::debug!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {}", action.peer_id),
-                            peer_id = action.peer_id.to_string(),
-                            offer = serde_json::to_string(&action.offer).ok()
+                            summary = format!("peer_id: {peer_id}"),
+                            peer_id = peer_id.to_string(),
+                            offer = serde_json::to_string(offer).ok()
                         );
                     }
-                    P2pConnectionOutgoingAction::OfferSendSuccess(action) => {
+                    P2pConnectionOutgoingAction::OfferSendSuccess { peer_id } => {
                         openmina_core::log::debug!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {}", action.peer_id),
-                            peer_id = action.peer_id.to_string(),
+                            summary = format!("peer_id: {peer_id}"),
+                            peer_id = peer_id.to_string(),
                         );
                     }
-                    P2pConnectionOutgoingAction::AnswerRecvPending(_) => {}
-                    P2pConnectionOutgoingAction::AnswerRecvError(action) => {
+                    P2pConnectionOutgoingAction::AnswerRecvPending { .. } => {}
+                    P2pConnectionOutgoingAction::AnswerRecvError { peer_id, error } => {
                         openmina_core::log::warn!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {}", action.peer_id),
-                            peer_id = action.peer_id.to_string(),
-                            error = format!("{:?}", action.error),
+                            summary = format!("peer_id: {peer_id}"),
+                            peer_id = peer_id.to_string(),
+                            error = format!("{:?}", error),
                         );
                     }
-                    P2pConnectionOutgoingAction::AnswerRecvSuccess(action) => {
+                    P2pConnectionOutgoingAction::AnswerRecvSuccess { peer_id, answer } => {
                         openmina_core::log::debug!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {}", action.peer_id),
-                            peer_id = action.peer_id.to_string(),
-                            trace_answer = serde_json::to_string(&action.answer).ok()
+                            summary = format!("peer_id: {peer_id}"),
+                            peer_id = peer_id.to_string(),
+                            trace_answer = serde_json::to_string(answer).ok()
                         );
                     }
-                    P2pConnectionOutgoingAction::FinalizePending(_) => {}
-                    P2pConnectionOutgoingAction::FinalizeError(action) => {
+                    P2pConnectionOutgoingAction::FinalizePending { .. } => {}
+                    P2pConnectionOutgoingAction::FinalizeError { peer_id, error } => {
                         openmina_core::log::warn!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {}", action.peer_id),
-                            peer_id = action.peer_id.to_string(),
-                            error = action.error.clone(),
+                            summary = format!("peer_id: {peer_id}"),
+                            peer_id = peer_id.to_string(),
+                            error = error.clone(),
                         );
                     }
-                    P2pConnectionOutgoingAction::FinalizeSuccess(action) => {
+                    P2pConnectionOutgoingAction::FinalizeSuccess { peer_id } => {
                         openmina_core::log::info!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {}", action.peer_id),
-                            peer_id = action.peer_id.to_string()
+                            summary = format!("peer_id: {peer_id}"),
+                            peer_id = peer_id.to_string()
                         );
                     }
-                    P2pConnectionOutgoingAction::Timeout(action) => {
+                    P2pConnectionOutgoingAction::Timeout { peer_id } => {
                         openmina_core::log::warn!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {}", action.peer_id),
-                            peer_id = action.peer_id.to_string()
+                            summary = format!("peer_id: {peer_id}"),
+                            peer_id = peer_id.to_string()
                         );
                     }
-                    P2pConnectionOutgoingAction::Error(action) => {
+                    P2pConnectionOutgoingAction::Error { peer_id, error } => {
                         openmina_core::log::warn!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {}", action.peer_id),
-                            peer_id = action.peer_id.to_string(),
-                            error = format!("{:?}", action.error),
+                            summary = format!("peer_id: {peer_id}"),
+                            peer_id = peer_id.to_string(),
+                            error = format!("{:?}", error),
                         );
                     }
-                    P2pConnectionOutgoingAction::Success(action) => {
+                    P2pConnectionOutgoingAction::Success { peer_id } => {
                         openmina_core::log::info!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {}", action.peer_id),
-                            peer_id = action.peer_id.to_string()
+                            summary = format!("peer_id: {peer_id}"),
+                            peer_id = peer_id.to_string()
                         );
                     }
                 },

--- a/node/src/logger/logger_effects.rs
+++ b/node/src/logger/logger_effects.rs
@@ -289,21 +289,21 @@ pub fn logger_effects<S: Service>(store: &Store<S>, action: ActionWithMetaRef<'_
                 },
             },
             P2pAction::Disconnection(action) => match action {
-                P2pDisconnectionAction::Init(action) => {
+                P2pDisconnectionAction::Init { peer_id, reason } => {
                     openmina_core::log::info!(
                         meta.time();
                         kind = kind.to_string(),
-                        summary = format!("peer_id: {}", action.peer_id),
-                        peer_id = action.peer_id.to_string(),
-                        reason = format!("{:?}", action.reason)
+                        summary = format!("peer_id: {peer_id}", ),
+                        peer_id = peer_id.to_string(),
+                        reason = format!("{:?}", reason)
                     );
                 }
-                P2pDisconnectionAction::Finish(action) => {
+                P2pDisconnectionAction::Finish { peer_id } => {
                     openmina_core::log::info!(
                         meta.time();
                         kind = kind.to_string(),
-                        summary = format!("peer_id: {}", action.peer_id),
-                        peer_id = action.peer_id.to_string()
+                        summary = format!("peer_id: {peer_id}", ),
+                        peer_id = peer_id.to_string()
                     );
                 }
             },

--- a/node/src/logger/logger_effects.rs
+++ b/node/src/logger/logger_effects.rs
@@ -27,7 +27,7 @@ pub fn logger_effects<S: Service>(store: &Store<S>, action: ActionWithMetaRef<'_
                     openmina_core::log::info!(
                         meta.time();
                         kind = kind.to_string(),
-                        summary = format!("addr: {addr}", ),
+                        summary = format!("addr: {addr}"),
                         addr = addr.to_string(),
                         listener_id = listener_id.to_string(),
                     );
@@ -36,7 +36,7 @@ pub fn logger_effects<S: Service>(store: &Store<S>, action: ActionWithMetaRef<'_
                     openmina_core::log::info!(
                         meta.time();
                         kind = kind.to_string(),
-                        summary = format!("addr: {addr}", ),
+                        summary = format!("addr: {addr}"),
                         addr = addr.to_string(),
                         listener_id = listener_id.to_string(),
                     );
@@ -45,7 +45,7 @@ pub fn logger_effects<S: Service>(store: &Store<S>, action: ActionWithMetaRef<'_
                     openmina_core::log::warn!(
                         meta.time();
                         kind = kind.to_string(),
-                        summary = format!("id: {listener_id}, error: {error}", ),
+                        summary = format!("id: {listener_id}, error: {error}"),
                         error = error,
                         listener_id = listener_id.to_string(),
                     );
@@ -55,7 +55,7 @@ pub fn logger_effects<S: Service>(store: &Store<S>, action: ActionWithMetaRef<'_
                         openmina_core::log::warn!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("id: {listener_id}, error: {error}", ),
+                            summary = format!("id: {listener_id}, error: {error}"),
                             error = error,
                             listener_id = listener_id.to_string(),
                         );
@@ -63,7 +63,7 @@ pub fn logger_effects<S: Service>(store: &Store<S>, action: ActionWithMetaRef<'_
                         openmina_core::log::info!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("id: {listener_id},", ),
+                            summary = format!("id: {listener_id},"),
                             listener_id = listener_id.to_string(),
                         );
                     }
@@ -190,100 +190,101 @@ pub fn logger_effects<S: Service>(store: &Store<S>, action: ActionWithMetaRef<'_
                     }
                 },
                 P2pConnectionAction::Incoming(action) => match action {
-                    P2pConnectionIncomingAction::Init(action) => {
+                    P2pConnectionIncomingAction::Init { opts, .. } => {
+                        let peer_id = opts.peer_id;
                         openmina_core::log::info!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {}", action.opts.peer_id),
-                            peer_id = action.opts.peer_id.to_string(),
-                            trace_signaling = format!("{:?}", action.opts.signaling),
+                            summary = format!("peer_id: {peer_id}"),
+                            peer_id = peer_id.to_string(),
+                            trace_signaling = format!("{:?}", opts.signaling),
                         );
                     }
-                    P2pConnectionIncomingAction::AnswerSdpCreatePending(_) => {}
-                    P2pConnectionIncomingAction::AnswerSdpCreateError(action) => {
+                    P2pConnectionIncomingAction::AnswerSdpCreatePending { .. } => {}
+                    P2pConnectionIncomingAction::AnswerSdpCreateError { peer_id, error } => {
                         openmina_core::log::warn!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {}", action.peer_id),
-                            peer_id = action.peer_id.to_string(),
-                            error = format!("{:?}", action.error),
+                            summary = format!("peer_id: {peer_id}"),
+                            peer_id = peer_id.to_string(),
+                            error = format!("{:?}", error),
                         );
                     }
-                    P2pConnectionIncomingAction::AnswerSdpCreateSuccess(action) => {
+                    P2pConnectionIncomingAction::AnswerSdpCreateSuccess { peer_id, sdp } => {
                         openmina_core::log::info!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {}", action.peer_id),
-                            peer_id = action.peer_id.to_string(),
-                            trace_sdp = action.sdp.clone(),
+                            summary = format!("peer_id: {peer_id}"),
+                            peer_id = peer_id.to_string(),
+                            trace_sdp = sdp.clone(),
                         );
                     }
-                    P2pConnectionIncomingAction::AnswerReady(action) => {
+                    P2pConnectionIncomingAction::AnswerReady { peer_id, answer } => {
                         openmina_core::log::info!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {}", action.peer_id),
-                            peer_id = action.peer_id.to_string(),
-                            trace_answer = serde_json::to_string(&action.answer).ok()
+                            summary = format!("peer_id: {peer_id}"),
+                            peer_id = peer_id.to_string(),
+                            trace_answer = serde_json::to_string(answer).ok()
                         );
                     }
-                    P2pConnectionIncomingAction::AnswerSendSuccess(action) => {
+                    P2pConnectionIncomingAction::AnswerSendSuccess { peer_id } => {
                         openmina_core::log::info!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {}", action.peer_id),
-                            peer_id = action.peer_id.to_string()
+                            summary = format!("peer_id: {peer_id}"),
+                            peer_id = peer_id.to_string(),
                         );
                     }
-                    P2pConnectionIncomingAction::FinalizePending(_) => {}
-                    P2pConnectionIncomingAction::FinalizeError(action) => {
+                    P2pConnectionIncomingAction::FinalizePending { .. } => {}
+                    P2pConnectionIncomingAction::FinalizeError { peer_id, error } => {
                         openmina_core::log::warn!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {}", action.peer_id),
-                            peer_id = action.peer_id.to_string(),
-                            error = format!("{:?}", action.error),
+                            summary = format!("peer_id: {peer_id}"),
+                            peer_id = peer_id.to_string(),
+                            error = format!("{:?}", error),
                         );
                     }
-                    P2pConnectionIncomingAction::FinalizeSuccess(action) => {
+                    P2pConnectionIncomingAction::FinalizeSuccess { peer_id } => {
                         openmina_core::log::info!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {}", action.peer_id),
-                            peer_id = action.peer_id.to_string()
+                            summary = format!("peer_id: {peer_id}"),
+                            peer_id = peer_id.to_string(),
                         );
                     }
-                    P2pConnectionIncomingAction::Timeout(action) => {
+                    P2pConnectionIncomingAction::Timeout { peer_id } => {
                         openmina_core::log::warn!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {}", action.peer_id),
-                            peer_id = action.peer_id.to_string()
+                            summary = format!("peer_id: {peer_id}"),
+                            peer_id = peer_id.to_string(),
                         );
                     }
-                    P2pConnectionIncomingAction::Error(action) => {
+                    P2pConnectionIncomingAction::Error { peer_id, error } => {
                         openmina_core::log::warn!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {}", action.peer_id),
-                            peer_id = action.peer_id.to_string(),
-                            error = format!("{:?}", action.error),
+                            summary = format!("peer_id: {peer_id}"),
+                            peer_id = peer_id.to_string(),
+                            error = format!("{:?}", error),
                         );
                     }
-                    P2pConnectionIncomingAction::Success(action) => {
+                    P2pConnectionIncomingAction::Success { peer_id } => {
                         openmina_core::log::info!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {}", action.peer_id),
-                            peer_id = action.peer_id.to_string()
+                            summary = format!("peer_id: {peer_id}"),
+                            peer_id = peer_id.to_string(),
                         );
                     }
-                    P2pConnectionIncomingAction::Libp2pReceived(action) => {
+                    P2pConnectionIncomingAction::Libp2pReceived { peer_id } => {
                         openmina_core::log::info!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {}", action.peer_id),
-                            peer_id = action.peer_id.to_string(),
+                            summary = format!("peer_id: {peer_id}"),
+                            peer_id = peer_id.to_string(),
                         );
                     }
                 },
@@ -293,7 +294,7 @@ pub fn logger_effects<S: Service>(store: &Store<S>, action: ActionWithMetaRef<'_
                     openmina_core::log::info!(
                         meta.time();
                         kind = kind.to_string(),
-                        summary = format!("peer_id: {peer_id}", ),
+                        summary = format!("peer_id: {peer_id}"),
                         peer_id = peer_id.to_string(),
                         reason = format!("{:?}", reason)
                     );
@@ -302,7 +303,7 @@ pub fn logger_effects<S: Service>(store: &Store<S>, action: ActionWithMetaRef<'_
                     openmina_core::log::info!(
                         meta.time();
                         kind = kind.to_string(),
-                        summary = format!("peer_id: {peer_id}", ),
+                        summary = format!("peer_id: {peer_id}"),
                         peer_id = peer_id.to_string()
                     );
                 }
@@ -312,7 +313,7 @@ pub fn logger_effects<S: Service>(store: &Store<S>, action: ActionWithMetaRef<'_
                     openmina_core::log::debug!(
                         meta.time();
                         kind = kind.to_string(),
-                        summary = format!("peer_id: {peer_id}", ),
+                        summary = format!("peer_id: {peer_id}"),
                         peer_id = peer_id.to_string()
                     );
                 }
@@ -320,7 +321,7 @@ pub fn logger_effects<S: Service>(store: &Store<S>, action: ActionWithMetaRef<'_
                     openmina_core::log::debug!(
                         meta.time();
                         kind = kind.to_string(),
-                        summary = format!("peer_id: {peer_id}", ),
+                        summary = format!("peer_id: {peer_id}"),
                         peer_id = peer_id.to_string()
                     );
                 }
@@ -386,7 +387,7 @@ pub fn logger_effects<S: Service>(store: &Store<S>, action: ActionWithMetaRef<'_
                         openmina_core::log::debug!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {peer_id}", ),
+                            summary = format!("peer_id: {peer_id}"),
                             peer_id = peer_id.to_string()
                         );
                     }
@@ -394,7 +395,7 @@ pub fn logger_effects<S: Service>(store: &Store<S>, action: ActionWithMetaRef<'_
                         openmina_core::log::debug!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {peer_id}", ),
+                            summary = format!("peer_id: {peer_id}"),
                             peer_id = peer_id.to_string()
                         );
                     }
@@ -424,7 +425,7 @@ pub fn logger_effects<S: Service>(store: &Store<S>, action: ActionWithMetaRef<'_
                         openmina_core::log::debug!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {peer_id}", ),
+                            summary = format!("peer_id: {peer_id}"),
                             peer_id = peer_id.to_string()
                         );
                     }
@@ -432,7 +433,7 @@ pub fn logger_effects<S: Service>(store: &Store<S>, action: ActionWithMetaRef<'_
                         openmina_core::log::debug!(
                             meta.time();
                             kind = kind.to_string(),
-                            summary = format!("peer_id: {peer_id}", ),
+                            summary = format!("peer_id: {peer_id}"),
                             peer_id = peer_id.to_string()
                         );
                     }

--- a/node/src/logger/logger_effects.rs
+++ b/node/src/logger/logger_effects.rs
@@ -308,55 +308,55 @@ pub fn logger_effects<S: Service>(store: &Store<S>, action: ActionWithMetaRef<'_
                 }
             },
             P2pAction::Discovery(action) => match action {
-                P2pDiscoveryAction::Init(action) => {
+                P2pDiscoveryAction::Init { peer_id } => {
                     openmina_core::log::debug!(
                         meta.time();
                         kind = kind.to_string(),
-                        summary = format!("peer_id: {}", action.peer_id),
-                        peer_id = action.peer_id.to_string()
+                        summary = format!("peer_id: {peer_id}", ),
+                        peer_id = peer_id.to_string()
                     );
                 }
-                P2pDiscoveryAction::Success(action) => {
+                P2pDiscoveryAction::Success { peer_id, .. } => {
                     openmina_core::log::debug!(
                         meta.time();
                         kind = kind.to_string(),
-                        summary = format!("peer_id: {}", action.peer_id),
-                        peer_id = action.peer_id.to_string()
+                        summary = format!("peer_id: {peer_id}", ),
+                        peer_id = peer_id.to_string()
                     );
                 }
-                P2pDiscoveryAction::KademliaBootstrap(..) => {
+                P2pDiscoveryAction::KademliaBootstrap => {
                     openmina_core::log::debug!(
                         meta.time();
                         kind = kind.to_string(),
                         summary = format!("bootstrap kademlia"),
                     );
                 }
-                P2pDiscoveryAction::KademliaInit(..) => {
+                P2pDiscoveryAction::KademliaInit => {
                     openmina_core::log::info!(
                         meta.time();
                         kind = kind.to_string(),
                         summary = format!("find node"),
                     );
                 }
-                P2pDiscoveryAction::KademliaAddRoute(action) => {
+                P2pDiscoveryAction::KademliaAddRoute { peer_id, addresses } => {
                     openmina_core::log::info!(
                         meta.time();
                         kind = kind.to_string(),
-                        summary = format!("add route {} {:?}", action.peer_id, action.addresses.first()),
+                        summary = format!("add route {peer_id} {:?}", addresses.first()),
                     );
                 }
-                P2pDiscoveryAction::KademliaSuccess(action) => {
+                P2pDiscoveryAction::KademliaSuccess { peers } => {
                     openmina_core::log::info!(
                         meta.time();
                         kind = kind.to_string(),
-                        summary = format!("peers: {:?}", action.peers),
+                        summary = format!("peers: {:?}", peers),
                     );
                 }
-                P2pDiscoveryAction::KademliaFailure(action) => {
+                P2pDiscoveryAction::KademliaFailure { description } => {
                     openmina_core::log::info!(
                         meta.time();
                         kind = kind.to_string(),
-                        summary = format!("{:?}", action.description),
+                        summary = format!("{:?}", description),
                     );
                 }
             },

--- a/node/src/p2p/connection/incoming/p2p_connection_incoming_actions.rs
+++ b/node/src/p2p/connection/incoming/p2p_connection_incoming_actions.rs
@@ -1,83 +1,16 @@
 use super::*;
 
-impl redux::EnablingCondition<crate::State> for P2pConnectionIncomingInitAction {
+impl redux::EnablingCondition<crate::State> for P2pConnectionIncomingAction {
     fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pConnectionIncomingAnswerSdpCreatePendingAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pConnectionIncomingAnswerSdpCreateErrorAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pConnectionIncomingAnswerSdpCreateSuccessAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pConnectionIncomingAnswerReadyAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pConnectionIncomingAnswerSendSuccessAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pConnectionIncomingFinalizePendingAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pConnectionIncomingFinalizeErrorAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pConnectionIncomingFinalizeSuccessAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pConnectionIncomingTimeoutAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        let peer = state.p2p.peers.get(&self.peer_id);
-        let timed_out = peer
-            .and_then(|peer| peer.status.as_connecting()?.as_incoming())
-            .map_or(false, |s| s.is_timed_out(state.time()));
-        timed_out && self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pConnectionIncomingErrorAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pConnectionIncomingSuccessAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pConnectionIncomingLibp2pReceivedAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+        match self {
+            Self::Timeout { peer_id } => {
+                let peer = state.p2p.peers.get(peer_id);
+                let timed_out = peer
+                    .and_then(|peer| peer.status.as_connecting()?.as_incoming())
+                    .map_or(false, |s| s.is_timed_out(state.time()));
+                timed_out && self.is_enabled(&state.p2p)
+            }
+            _ => self.is_enabled(&state.p2p),
+        }
     }
 }

--- a/node/src/p2p/connection/outgoing/p2p_connection_outgoing_actions.rs
+++ b/node/src/p2p/connection/outgoing/p2p_connection_outgoing_actions.rs
@@ -5,124 +5,36 @@ use crate::p2p::P2pPeerStatus;
 
 use super::*;
 
-impl redux::EnablingCondition<crate::State> for P2pConnectionOutgoingRandomInitAction {
+impl redux::EnablingCondition<crate::State> for P2pConnectionOutgoingAction {
     fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
+        match self {
+            P2pConnectionOutgoingAction::Reconnect { opts, .. } => {
+                if !self.is_enabled(&state.p2p) {
+                    return false;
+                }
 
-impl redux::EnablingCondition<crate::State> for P2pConnectionOutgoingInitAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pConnectionOutgoingReconnectAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        if !self.is_enabled(&state.p2p) {
-            return false;
-        }
-
-        let Some(peer) = state.p2p.peers.get(self.opts.peer_id()) else {
-            return false;
-        };
-        let delay_passed = match &peer.status {
-            P2pPeerStatus::Connecting(P2pConnectionState::Outgoing(
-                P2pConnectionOutgoingState::Error { time, .. },
-            ))
-            | P2pPeerStatus::Disconnected { time, .. } => {
-                state.time().checked_sub(*time) >= Some(Duration::from_secs(30))
+                let Some(peer) = state.p2p.peers.get(opts.peer_id()) else {
+                    return false;
+                };
+                let delay_passed = match &peer.status {
+                    P2pPeerStatus::Connecting(P2pConnectionState::Outgoing(
+                        P2pConnectionOutgoingState::Error { time, .. },
+                    ))
+                    | P2pPeerStatus::Disconnected { time, .. } => {
+                        state.time().checked_sub(*time) >= Some(Duration::from_secs(30))
+                    }
+                    _ => true,
+                };
+                delay_passed
             }
-            _ => true,
-        };
-        delay_passed
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pConnectionOutgoingOfferSdpCreatePendingAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pConnectionOutgoingOfferSdpCreateErrorAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pConnectionOutgoingOfferSdpCreateSuccessAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pConnectionOutgoingOfferReadyAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pConnectionOutgoingOfferSendSuccessAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pConnectionOutgoingAnswerRecvPendingAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pConnectionOutgoingAnswerRecvErrorAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pConnectionOutgoingAnswerRecvSuccessAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pConnectionOutgoingFinalizePendingAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pConnectionOutgoingFinalizeErrorAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pConnectionOutgoingFinalizeSuccessAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pConnectionOutgoingTimeoutAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        let peer = state.p2p.peers.get(&self.peer_id);
-        let timed_out = peer
-            .and_then(|peer| peer.status.as_connecting()?.as_outgoing())
-            .map_or(false, |s| s.is_timed_out(state.time()));
-        timed_out && self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pConnectionOutgoingErrorAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pConnectionOutgoingSuccessAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+            P2pConnectionOutgoingAction::Timeout { peer_id } => {
+                let peer = state.p2p.peers.get(peer_id);
+                let timed_out = peer
+                    .and_then(|peer| peer.status.as_connecting()?.as_outgoing())
+                    .map_or(false, |s| s.is_timed_out(state.time()));
+                timed_out && self.is_enabled(&state.p2p)
+            }
+            _ => self.is_enabled(&state.p2p),
+        }
     }
 }

--- a/node/src/p2p/disconnection/p2p_disconnection_actions.rs
+++ b/node/src/p2p/disconnection/p2p_disconnection_actions.rs
@@ -1,12 +1,6 @@
 use super::*;
 
-impl redux::EnablingCondition<crate::State> for P2pDisconnectionInitAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pDisconnectionFinishAction {
+impl redux::EnablingCondition<crate::State> for P2pDisconnectionAction {
     fn is_enabled(&self, state: &crate::State) -> bool {
         self.is_enabled(&state.p2p)
     }

--- a/node/src/p2p/discovery/mod.rs
+++ b/node/src/p2p/discovery/mod.rs
@@ -1,42 +1,6 @@
 pub use ::p2p::discovery::*;
 
-impl redux::EnablingCondition<crate::State> for P2pDiscoveryInitAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pDiscoverySuccessAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pDiscoveryKademliaBootstrapAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pDiscoveryKademliaInitAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state.p2p.enough_time_elapsed(state.time()) && self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pDiscoveryKademliaAddRouteAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pDiscoveryKademliaSuccessAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pDiscoveryKademliaFailureAction {
+impl redux::EnablingCondition<crate::State> for P2pDiscoveryAction {
     fn is_enabled(&self, state: &crate::State) -> bool {
         self.is_enabled(&state.p2p)
     }

--- a/node/src/p2p/listen/p2p_listen_actions.rs
+++ b/node/src/p2p/listen/p2p_listen_actions.rs
@@ -1,29 +1,9 @@
-use p2p::listen::{
-    P2pListenClosedAction, P2pListenErrorAction, P2pListenExpiredAction, P2pListenNewAction,
-};
+use p2p::listen::P2pListenAction;
 use redux::EnablingCondition;
 
 use crate::State;
 
-impl EnablingCondition<State> for P2pListenNewAction {
-    fn is_enabled(&self, state: &State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl EnablingCondition<State> for P2pListenExpiredAction {
-    fn is_enabled(&self, state: &State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl EnablingCondition<State> for P2pListenErrorAction {
-    fn is_enabled(&self, state: &State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl EnablingCondition<State> for P2pListenClosedAction {
+impl EnablingCondition<State> for P2pListenAction {
     fn is_enabled(&self, state: &State) -> bool {
         self.is_enabled(&state.p2p)
     }

--- a/node/src/p2p/mod.rs
+++ b/node/src/p2p/mod.rs
@@ -84,8 +84,7 @@ impl_into_global_action!(connection::incoming::P2pConnectionIncomingErrorAction)
 impl_into_global_action!(connection::incoming::P2pConnectionIncomingSuccessAction);
 impl_into_global_action!(connection::incoming::P2pConnectionIncomingLibp2pReceivedAction);
 
-impl_into_global_action!(disconnection::P2pDisconnectionInitAction);
-impl_into_global_action!(disconnection::P2pDisconnectionFinishAction);
+impl_into_global_action!(disconnection::P2pDisconnectionAction);
 
 impl_into_global_action!(discovery::P2pDiscoveryInitAction);
 impl_into_global_action!(discovery::P2pDiscoverySuccessAction);

--- a/node/src/p2p/mod.rs
+++ b/node/src/p2p/mod.rs
@@ -67,19 +67,7 @@ impl_into_global_action!(connection::outgoing::P2pConnectionOutgoingTimeoutActio
 impl_into_global_action!(connection::outgoing::P2pConnectionOutgoingErrorAction);
 impl_into_global_action!(connection::outgoing::P2pConnectionOutgoingSuccessAction);
 
-impl_into_global_action!(connection::incoming::P2pConnectionIncomingInitAction);
-impl_into_global_action!(connection::incoming::P2pConnectionIncomingAnswerSdpCreatePendingAction);
-impl_into_global_action!(connection::incoming::P2pConnectionIncomingAnswerSdpCreateErrorAction);
-impl_into_global_action!(connection::incoming::P2pConnectionIncomingAnswerSdpCreateSuccessAction);
-impl_into_global_action!(connection::incoming::P2pConnectionIncomingAnswerReadyAction);
-impl_into_global_action!(connection::incoming::P2pConnectionIncomingAnswerSendSuccessAction);
-impl_into_global_action!(connection::incoming::P2pConnectionIncomingFinalizePendingAction);
-impl_into_global_action!(connection::incoming::P2pConnectionIncomingFinalizeErrorAction);
-impl_into_global_action!(connection::incoming::P2pConnectionIncomingFinalizeSuccessAction);
-impl_into_global_action!(connection::incoming::P2pConnectionIncomingTimeoutAction);
-impl_into_global_action!(connection::incoming::P2pConnectionIncomingErrorAction);
-impl_into_global_action!(connection::incoming::P2pConnectionIncomingSuccessAction);
-impl_into_global_action!(connection::incoming::P2pConnectionIncomingLibp2pReceivedAction);
+impl_into_global_action!(connection::incoming::P2pConnectionIncomingAction);
 
 impl_into_global_action!(disconnection::P2pDisconnectionAction);
 

--- a/node/src/p2p/mod.rs
+++ b/node/src/p2p/mod.rs
@@ -47,10 +47,7 @@ macro_rules! impl_into_global_action {
     };
 }
 
-impl_into_global_action!(listen::P2pListenNewAction);
-impl_into_global_action!(listen::P2pListenExpiredAction);
-impl_into_global_action!(listen::P2pListenErrorAction);
-impl_into_global_action!(listen::P2pListenClosedAction);
+impl_into_global_action!(listen::P2pListenAction);
 
 impl_into_global_action!(connection::outgoing::P2pConnectionOutgoingRandomInitAction);
 impl_into_global_action!(connection::outgoing::P2pConnectionOutgoingInitAction);

--- a/node/src/p2p/mod.rs
+++ b/node/src/p2p/mod.rs
@@ -49,23 +49,7 @@ macro_rules! impl_into_global_action {
 
 impl_into_global_action!(listen::P2pListenAction);
 
-impl_into_global_action!(connection::outgoing::P2pConnectionOutgoingRandomInitAction);
-impl_into_global_action!(connection::outgoing::P2pConnectionOutgoingInitAction);
-impl_into_global_action!(connection::outgoing::P2pConnectionOutgoingReconnectAction);
-impl_into_global_action!(connection::outgoing::P2pConnectionOutgoingOfferSdpCreatePendingAction);
-impl_into_global_action!(connection::outgoing::P2pConnectionOutgoingOfferSdpCreateErrorAction);
-impl_into_global_action!(connection::outgoing::P2pConnectionOutgoingOfferSdpCreateSuccessAction);
-impl_into_global_action!(connection::outgoing::P2pConnectionOutgoingOfferReadyAction);
-impl_into_global_action!(connection::outgoing::P2pConnectionOutgoingOfferSendSuccessAction);
-impl_into_global_action!(connection::outgoing::P2pConnectionOutgoingAnswerRecvPendingAction);
-impl_into_global_action!(connection::outgoing::P2pConnectionOutgoingAnswerRecvErrorAction);
-impl_into_global_action!(connection::outgoing::P2pConnectionOutgoingAnswerRecvSuccessAction);
-impl_into_global_action!(connection::outgoing::P2pConnectionOutgoingFinalizePendingAction);
-impl_into_global_action!(connection::outgoing::P2pConnectionOutgoingFinalizeErrorAction);
-impl_into_global_action!(connection::outgoing::P2pConnectionOutgoingFinalizeSuccessAction);
-impl_into_global_action!(connection::outgoing::P2pConnectionOutgoingTimeoutAction);
-impl_into_global_action!(connection::outgoing::P2pConnectionOutgoingErrorAction);
-impl_into_global_action!(connection::outgoing::P2pConnectionOutgoingSuccessAction);
+impl_into_global_action!(connection::outgoing::P2pConnectionOutgoingAction);
 
 impl_into_global_action!(connection::incoming::P2pConnectionIncomingAction);
 

--- a/node/src/p2p/mod.rs
+++ b/node/src/p2p/mod.rs
@@ -86,13 +86,7 @@ impl_into_global_action!(connection::incoming::P2pConnectionIncomingLibp2pReceiv
 
 impl_into_global_action!(disconnection::P2pDisconnectionAction);
 
-impl_into_global_action!(discovery::P2pDiscoveryInitAction);
-impl_into_global_action!(discovery::P2pDiscoverySuccessAction);
-impl_into_global_action!(discovery::P2pDiscoveryKademliaBootstrapAction);
-impl_into_global_action!(discovery::P2pDiscoveryKademliaInitAction);
-impl_into_global_action!(discovery::P2pDiscoveryKademliaSuccessAction);
-impl_into_global_action!(discovery::P2pDiscoveryKademliaFailureAction);
-impl_into_global_action!(discovery::P2pDiscoveryKademliaAddRouteAction);
+impl_into_global_action!(discovery::P2pDiscoveryAction);
 
 impl_into_global_action!(channels::P2pChannelsMessageReceivedAction);
 

--- a/node/src/p2p/p2p_effects.rs
+++ b/node/src/p2p/p2p_effects.rs
@@ -2,11 +2,7 @@ use mina_p2p_messages::v2::{MinaLedgerSyncLedgerAnswerStableV2, StateHash};
 use openmina_core::block::BlockWithHash;
 
 use crate::consensus::ConsensusAction;
-use crate::rpc::{
-    RpcP2pConnectionIncomingErrorAction, RpcP2pConnectionIncomingRespondAction,
-    RpcP2pConnectionIncomingSuccessAction, RpcP2pConnectionOutgoingErrorAction,
-    RpcP2pConnectionOutgoingSuccessAction,
-};
+use crate::rpc::RpcAction;
 use crate::snark_pool::candidate::SnarkPoolCandidateAction;
 use crate::snark_pool::SnarkPoolAction;
 use crate::transition_frontier::sync::ledger::snarked::{
@@ -105,7 +101,7 @@ pub fn p2p_effects<S: Service>(store: &mut Store<S>, action: P2pActionWithMeta) 
                 P2pConnectionOutgoingAction::Error(action) => {
                     let p2p = &store.state().p2p;
                     if let Some(rpc_id) = p2p.peer_connection_rpc_id(&action.peer_id) {
-                        store.dispatch(RpcP2pConnectionOutgoingErrorAction {
+                        store.dispatch(RpcAction::P2pConnectionOutgoingError {
                             rpc_id,
                             error: action.error.clone(),
                         });
@@ -115,7 +111,7 @@ pub fn p2p_effects<S: Service>(store: &mut Store<S>, action: P2pActionWithMeta) 
                 P2pConnectionOutgoingAction::Success(action) => {
                     let p2p = &store.state().p2p;
                     if let Some(rpc_id) = p2p.peer_connection_rpc_id(&action.peer_id) {
-                        store.dispatch(RpcP2pConnectionOutgoingSuccessAction { rpc_id });
+                        store.dispatch(RpcAction::P2pConnectionOutgoingSuccess { rpc_id });
                     }
                     action.effects(&meta, store);
                 }
@@ -134,7 +130,7 @@ pub fn p2p_effects<S: Service>(store: &mut Store<S>, action: P2pActionWithMeta) 
                 P2pConnectionIncomingAction::AnswerReady(action) => {
                     let p2p = &store.state().p2p;
                     if let Some(rpc_id) = p2p.peer_connection_rpc_id(&action.peer_id) {
-                        store.dispatch(RpcP2pConnectionIncomingRespondAction {
+                        store.dispatch(RpcAction::P2pConnectionIncomingRespond {
                             rpc_id,
                             response: P2pConnectionResponse::Accepted(action.answer.clone()),
                         });
@@ -160,7 +156,7 @@ pub fn p2p_effects<S: Service>(store: &mut Store<S>, action: P2pActionWithMeta) 
                 P2pConnectionIncomingAction::Error(action) => {
                     let p2p = &store.state().p2p;
                     if let Some(rpc_id) = p2p.peer_connection_rpc_id(&action.peer_id) {
-                        store.dispatch(RpcP2pConnectionIncomingErrorAction {
+                        store.dispatch(RpcAction::P2pConnectionIncomingError {
                             rpc_id,
                             error: format!("{:?}", action.error),
                         });
@@ -170,7 +166,7 @@ pub fn p2p_effects<S: Service>(store: &mut Store<S>, action: P2pActionWithMeta) 
                 P2pConnectionIncomingAction::Success(action) => {
                     let p2p = &store.state().p2p;
                     if let Some(rpc_id) = p2p.peer_connection_rpc_id(&action.peer_id) {
-                        store.dispatch(RpcP2pConnectionIncomingSuccessAction { rpc_id });
+                        store.dispatch(RpcAction::P2pConnectionIncomingSuccess { rpc_id });
                     }
                     action.effects(&meta, store);
                 }

--- a/node/src/p2p/p2p_effects.rs
+++ b/node/src/p2p/p2p_effects.rs
@@ -654,13 +654,13 @@ pub fn p2p_effects<S: Service>(store: &mut Store<S>, action: P2pActionWithMeta) 
             }
         },
         P2pAction::Peer(action) => match action {
-            P2pPeerAction::Ready(action) => {
+            P2pPeerAction::Ready { .. } => {
                 action.effects(&meta, store);
             }
-            P2pPeerAction::BestTipUpdate(action) => {
+            P2pPeerAction::BestTipUpdate { best_tip, .. } => {
                 store.dispatch(ConsensusAction::BlockReceived {
-                    hash: action.best_tip.hash,
-                    block: action.best_tip.block,
+                    hash: best_tip.hash,
+                    block: best_tip.block,
                     chain_proof: None,
                 });
                 store.dispatch(TransitionFrontierSyncLedgerSnarkedPeersQueryAction {});

--- a/node/src/p2p/p2p_effects.rs
+++ b/node/src/p2p/p2p_effects.rs
@@ -41,64 +41,30 @@ pub fn p2p_effects<S: Service>(store: &mut Store<S>, action: P2pActionWithMeta) 
             action.effects(&meta, store);
         }
         P2pAction::Connection(action) => match action {
-            P2pConnectionAction::Outgoing(action) => match action {
-                P2pConnectionOutgoingAction::RandomInit(action) => {
-                    action.effects(&meta, store);
-                }
-                P2pConnectionOutgoingAction::Init(action) => {
-                    action.effects(&meta, store);
-                }
-                P2pConnectionOutgoingAction::Reconnect(action) => {
-                    action.effects(&meta, store);
-                }
-                P2pConnectionOutgoingAction::OfferSdpCreatePending(_) => {}
-                P2pConnectionOutgoingAction::OfferSdpCreateError(action) => {
-                    action.effects(&meta, store);
-                }
-                P2pConnectionOutgoingAction::OfferSdpCreateSuccess(action) => {
-                    action.effects(&meta, store);
-                }
-                P2pConnectionOutgoingAction::OfferReady(action) => {
-                    action.effects(&meta, store);
-                }
-                P2pConnectionOutgoingAction::OfferSendSuccess(action) => {
-                    action.effects(&meta, store);
-                }
-                P2pConnectionOutgoingAction::AnswerRecvPending(_) => {}
-                P2pConnectionOutgoingAction::AnswerRecvError(action) => {
-                    action.effects(&meta, store);
-                }
-                P2pConnectionOutgoingAction::AnswerRecvSuccess(action) => {
-                    action.effects(&meta, store);
-                }
-                P2pConnectionOutgoingAction::FinalizePending(_) => {}
-                P2pConnectionOutgoingAction::FinalizeError(action) => {
-                    action.effects(&meta, store);
-                }
-                P2pConnectionOutgoingAction::FinalizeSuccess(action) => {
-                    action.effects(&meta, store);
-                }
-                P2pConnectionOutgoingAction::Timeout(action) => {
-                    action.effects(&meta, store);
-                }
-                P2pConnectionOutgoingAction::Error(action) => {
-                    let p2p = &store.state().p2p;
-                    if let Some(rpc_id) = p2p.peer_connection_rpc_id(&action.peer_id) {
-                        store.dispatch(RpcAction::P2pConnectionOutgoingError {
-                            rpc_id,
-                            error: action.error.clone(),
-                        });
+            P2pConnectionAction::Outgoing(action) => {
+                match action {
+                    P2pConnectionOutgoingAction::Error {
+                        ref peer_id,
+                        ref error,
+                    } => {
+                        let p2p = &store.state().p2p;
+                        if let Some(rpc_id) = p2p.peer_connection_rpc_id(peer_id) {
+                            store.dispatch(RpcAction::P2pConnectionOutgoingError {
+                                rpc_id,
+                                error: error.clone(),
+                            });
+                        }
                     }
-                    // action.effects(&meta, store);
-                }
-                P2pConnectionOutgoingAction::Success(action) => {
-                    let p2p = &store.state().p2p;
-                    if let Some(rpc_id) = p2p.peer_connection_rpc_id(&action.peer_id) {
-                        store.dispatch(RpcAction::P2pConnectionOutgoingSuccess { rpc_id });
+                    P2pConnectionOutgoingAction::Success { ref peer_id } => {
+                        let p2p = &store.state().p2p;
+                        if let Some(rpc_id) = p2p.peer_connection_rpc_id(peer_id) {
+                            store.dispatch(RpcAction::P2pConnectionOutgoingSuccess { rpc_id });
+                        }
                     }
-                    action.effects(&meta, store);
+                    _ => {}
                 }
-            },
+                action.effects(&meta, store);
+            }
             P2pConnectionAction::Incoming(action) => {
                 match &action {
                     P2pConnectionIncomingAction::AnswerReady { peer_id, answer } => {

--- a/node/src/p2p/p2p_effects.rs
+++ b/node/src/p2p/p2p_effects.rs
@@ -43,20 +43,9 @@ pub fn p2p_effects<S: Service>(store: &mut Store<S>, action: P2pActionWithMeta) 
     let (action, meta) = action.split();
 
     match action {
-        P2pAction::Listen(action) => match action {
-            p2p::listen::P2pListenAction::New(action) => {
-                action.effects(&meta, store);
-            }
-            p2p::listen::P2pListenAction::Expired(action) => {
-                action.effects(&meta, store);
-            }
-            p2p::listen::P2pListenAction::Error(action) => {
-                action.effects(&meta, store);
-            }
-            p2p::listen::P2pListenAction::Closed(action) => {
-                action.effects(&meta, store);
-            }
-        },
+        P2pAction::Listen(action) => {
+            action.effects(&meta, store);
+        }
         P2pAction::Connection(action) => match action {
             P2pConnectionAction::Outgoing(action) => match action {
                 P2pConnectionOutgoingAction::RandomInit(action) => {

--- a/node/src/p2p/p2p_effects.rs
+++ b/node/src/p2p/p2p_effects.rs
@@ -26,8 +26,8 @@ use crate::transition_frontier::sync::{
     TransitionFrontierSyncBlocksPeersQueryAction,
 };
 use crate::watched_accounts::{
-    WatchedAccountLedgerInitialState, WatchedAccountsLedgerInitialStateGetError,
-    WatchedAccountsLedgerInitialStateGetErrorAction,
+    WatchedAccountLedgerInitialState, WatchedAccountsAction,
+    WatchedAccountsLedgerInitialStateGetError,
 };
 use crate::{Service, Store};
 
@@ -244,7 +244,7 @@ pub fn p2p_effects<S: Service>(store: &mut Store<S>, action: P2pActionWithMeta) 
                                 ..
                             } => {
                                 if account_peer_id == &peer_id {
-                                    Some(WatchedAccountsLedgerInitialStateGetErrorAction {
+                                    Some(WatchedAccountsAction::LedgerInitialStateGetError {
                                     pub_key: pub_key.clone(),
                                     error:
                                         WatchedAccountsLedgerInitialStateGetError::PeerDisconnected,

--- a/node/src/p2p/peer/p2p_peer_actions.rs
+++ b/node/src/p2p/peer/p2p_peer_actions.rs
@@ -1,12 +1,6 @@
 use super::*;
 
-impl redux::EnablingCondition<crate::State> for P2pPeerReadyAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
-    }
-}
-
-impl redux::EnablingCondition<crate::State> for P2pPeerBestTipUpdateAction {
+impl redux::EnablingCondition<crate::State> for P2pPeerAction {
     fn is_enabled(&self, state: &crate::State) -> bool {
         self.is_enabled(&state.p2p)
     }

--- a/node/src/recorder/recorder.rs
+++ b/node/src/recorder/recorder.rs
@@ -70,7 +70,7 @@ impl Recorder {
                 let is_input = match action.action() {
                     Action::CheckTimeouts(_) => true,
                     Action::EventSource(e) => match e {
-                        EventSourceAction::NewEvent(_) => true,
+                        EventSourceAction::NewEvent { .. } => true,
                         _ => return,
                     },
                     _ => false,

--- a/node/src/reducer.rs
+++ b/node/src/reducer.rs
@@ -6,7 +6,7 @@ pub fn reducer(state: &mut State, action: &ActionWithMeta) {
     let meta = action.meta().clone();
     match action.action() {
         Action::CheckTimeouts(_) => {}
-        Action::EventSource(EventSourceAction::NewEvent(content)) => match &content.event {
+        Action::EventSource(EventSourceAction::NewEvent { event }) => match event {
             #[cfg(not(target_arch = "wasm32"))]
             Event::P2p(P2pEvent::Libp2pIdentify(peer_id, maddr)) => {
                 if let Some(peer) = state.p2p.peers.get_mut(peer_id) {

--- a/node/src/rpc/rpc_actions.rs
+++ b/node/src/rpc/rpc_actions.rs
@@ -11,321 +11,163 @@ use super::{ActionStatsQuery, RpcId, RpcScanStateSummaryGetQuery, SyncStatsQuery
 pub type RpcActionWithMeta = redux::ActionWithMeta<RpcAction>;
 pub type RpcActionWithMetaRef<'a> = redux::ActionWithMeta<&'a RpcAction>;
 
-#[derive(derive_more::From, Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum RpcAction {
-    GlobalStateGet(RpcGlobalStateGetAction),
+    GlobalStateGet {
+        rpc_id: RpcId,
+    },
 
     // Stats
-    ActionStatsGet(RpcActionStatsGetAction),
-    SyncStatsGet(RpcSyncStatsGetAction),
+    ActionStatsGet {
+        rpc_id: RpcId,
+        query: ActionStatsQuery,
+    },
+    SyncStatsGet {
+        rpc_id: RpcId,
+        query: SyncStatsQuery,
+    },
 
-    PeersGet(RpcPeersGetAction),
+    PeersGet {
+        rpc_id: RpcId,
+    },
 
-    P2pConnectionOutgoingInit(RpcP2pConnectionOutgoingInitAction),
-    P2pConnectionOutgoingPending(RpcP2pConnectionOutgoingPendingAction),
-    P2pConnectionOutgoingError(RpcP2pConnectionOutgoingErrorAction),
-    P2pConnectionOutgoingSuccess(RpcP2pConnectionOutgoingSuccessAction),
+    P2pConnectionOutgoingInit {
+        rpc_id: RpcId,
+        opts: P2pConnectionOutgoingInitOpts,
+    },
+    P2pConnectionOutgoingPending {
+        rpc_id: RpcId,
+    },
+    P2pConnectionOutgoingError {
+        rpc_id: RpcId,
+        error: P2pConnectionOutgoingError,
+    },
+    P2pConnectionOutgoingSuccess {
+        rpc_id: RpcId,
+    },
 
-    P2pConnectionIncomingInit(RpcP2pConnectionIncomingInitAction),
-    P2pConnectionIncomingPending(RpcP2pConnectionIncomingPendingAction),
-    P2pConnectionIncomingRespond(RpcP2pConnectionIncomingRespondAction),
-    P2pConnectionIncomingError(RpcP2pConnectionIncomingErrorAction),
-    P2pConnectionIncomingSuccess(RpcP2pConnectionIncomingSuccessAction),
+    P2pConnectionIncomingInit {
+        rpc_id: RpcId,
+        opts: P2pConnectionIncomingInitOpts,
+    },
+    P2pConnectionIncomingPending {
+        rpc_id: RpcId,
+    },
+    P2pConnectionIncomingRespond {
+        rpc_id: RpcId,
+        response: P2pConnectionResponse,
+    },
+    P2pConnectionIncomingError {
+        rpc_id: RpcId,
+        error: String,
+    },
+    P2pConnectionIncomingSuccess {
+        rpc_id: RpcId,
+    },
 
-    ScanStateSummaryGet(RpcScanStateSummaryGetAction),
+    ScanStateSummaryGet {
+        rpc_id: RpcId,
+        query: RpcScanStateSummaryGetQuery,
+    },
 
-    SnarkPoolAvailableJobsGet(RpcSnarkPoolAvailableJobsGetAction),
-    SnarkPoolJobGet(RpcSnarkPoolJobGetAction),
+    SnarkPoolAvailableJobsGet {
+        rpc_id: RpcId,
+    },
+    SnarkPoolJobGet {
+        job_id: SnarkWorkId,
+        rpc_id: RpcId,
+    },
 
-    SnarkerConfigGet(RpcSnarkerConfigGetAction),
-    SnarkerJobCommit(RpcSnarkerJobCommitAction),
-    SnarkerJobSpec(RpcSnarkerJobSpecAction),
+    SnarkerConfigGet {
+        rpc_id: RpcId,
+    },
+    SnarkerJobCommit {
+        rpc_id: RpcId,
+        job_id: SnarkJobId,
+    },
+    SnarkerJobSpec {
+        rpc_id: RpcId,
+        job_id: SnarkJobId,
+    },
 
-    SnarkerWorkersGet(RpcSnarkersWorkersGetAction),
+    SnarkerWorkersGet {
+        rpc_id: RpcId,
+    },
 
-    HealthCheck(RpcHealthCheckAction),
-    ReadinessCheck(RpcReadinessCheckAction),
+    HealthCheck {
+        rpc_id: RpcId,
+    },
+    ReadinessCheck {
+        rpc_id: RpcId,
+    },
 
-    Finish(RpcFinishAction),
+    Finish {
+        rpc_id: RpcId,
+    },
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct RpcGlobalStateGetAction {
-    pub rpc_id: RpcId,
-}
-
-impl redux::EnablingCondition<crate::State> for RpcGlobalStateGetAction {}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct RpcActionStatsGetAction {
-    pub rpc_id: RpcId,
-    pub query: ActionStatsQuery,
-}
-
-impl redux::EnablingCondition<crate::State> for RpcActionStatsGetAction {}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct RpcSyncStatsGetAction {
-    pub rpc_id: RpcId,
-    pub query: SyncStatsQuery,
-}
-
-impl redux::EnablingCondition<crate::State> for RpcSyncStatsGetAction {}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct RpcPeersGetAction {
-    pub rpc_id: RpcId,
-}
-
-impl redux::EnablingCondition<crate::State> for RpcPeersGetAction {}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct RpcP2pConnectionOutgoingInitAction {
-    pub rpc_id: RpcId,
-    pub opts: P2pConnectionOutgoingInitOpts,
-}
-
-impl redux::EnablingCondition<crate::State> for RpcP2pConnectionOutgoingInitAction {
+impl redux::EnablingCondition<crate::State> for RpcAction {
     fn is_enabled(&self, state: &crate::State) -> bool {
-        !state.rpc.requests.contains_key(&self.rpc_id)
+        match self {
+            RpcAction::GlobalStateGet { .. } => true,
+            RpcAction::ActionStatsGet { .. } => true,
+            RpcAction::SyncStatsGet { .. } => true,
+            RpcAction::PeersGet { .. } => true,
+            RpcAction::P2pConnectionOutgoingInit { rpc_id, .. } => {
+                !state.rpc.requests.contains_key(rpc_id)
+            }
+            RpcAction::P2pConnectionOutgoingPending { rpc_id } => state
+                .rpc
+                .requests
+                .get(rpc_id)
+                .map_or(false, |v| v.status.is_init()),
+            RpcAction::P2pConnectionOutgoingError { rpc_id, .. } => state
+                .rpc
+                .requests
+                .get(rpc_id)
+                .map_or(false, |v| v.status.is_pending()),
+            RpcAction::P2pConnectionOutgoingSuccess { rpc_id } => state
+                .rpc
+                .requests
+                .get(rpc_id)
+                .map_or(false, |v| v.status.is_pending()),
+            RpcAction::P2pConnectionIncomingInit { rpc_id, .. } => {
+                !state.rpc.requests.contains_key(rpc_id)
+            }
+            RpcAction::P2pConnectionIncomingPending { rpc_id } => state
+                .rpc
+                .requests
+                .get(rpc_id)
+                .map_or(false, |v| v.status.is_init()),
+            RpcAction::P2pConnectionIncomingRespond { rpc_id, .. } => state
+                .rpc
+                .requests
+                .get(rpc_id)
+                .map_or(false, |v| v.status.is_init() || v.status.is_pending()),
+            RpcAction::P2pConnectionIncomingError { rpc_id, .. } => state
+                .rpc
+                .requests
+                .get(rpc_id)
+                .map_or(false, |v| v.status.is_init() || v.status.is_pending()),
+            RpcAction::P2pConnectionIncomingSuccess { rpc_id } => state
+                .rpc
+                .requests
+                .get(rpc_id)
+                .map_or(false, |v| v.status.is_pending()),
+            RpcAction::ScanStateSummaryGet { .. } => true,
+            RpcAction::SnarkPoolAvailableJobsGet { .. } => true,
+            RpcAction::SnarkPoolJobGet { .. } => true,
+            RpcAction::SnarkerConfigGet { .. } => true,
+            RpcAction::SnarkerJobCommit { .. } => true,
+            RpcAction::SnarkerJobSpec { .. } => true,
+            RpcAction::SnarkerWorkersGet { .. } => true,
+            RpcAction::HealthCheck { .. } => true,
+            RpcAction::ReadinessCheck { .. } => true,
+            RpcAction::Finish { rpc_id } => state
+                .rpc
+                .requests
+                .get(rpc_id)
+                .map_or(false, |v| v.status.is_finished()),
+        }
     }
 }
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct RpcP2pConnectionOutgoingPendingAction {
-    pub rpc_id: RpcId,
-}
-
-impl redux::EnablingCondition<crate::State> for RpcP2pConnectionOutgoingPendingAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state
-            .rpc
-            .requests
-            .get(&self.rpc_id)
-            .map_or(false, |v| v.status.is_init())
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct RpcP2pConnectionOutgoingErrorAction {
-    pub rpc_id: RpcId,
-    pub error: P2pConnectionOutgoingError,
-}
-
-impl redux::EnablingCondition<crate::State> for RpcP2pConnectionOutgoingErrorAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state
-            .rpc
-            .requests
-            .get(&self.rpc_id)
-            .map_or(false, |v| v.status.is_pending())
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct RpcP2pConnectionOutgoingSuccessAction {
-    pub rpc_id: RpcId,
-}
-
-impl redux::EnablingCondition<crate::State> for RpcP2pConnectionOutgoingSuccessAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state
-            .rpc
-            .requests
-            .get(&self.rpc_id)
-            .map_or(false, |v| v.status.is_pending())
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct RpcP2pConnectionIncomingInitAction {
-    pub rpc_id: RpcId,
-    pub opts: P2pConnectionIncomingInitOpts,
-}
-
-impl redux::EnablingCondition<crate::State> for RpcP2pConnectionIncomingInitAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        !state.rpc.requests.contains_key(&self.rpc_id)
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct RpcP2pConnectionIncomingPendingAction {
-    pub rpc_id: RpcId,
-}
-
-impl redux::EnablingCondition<crate::State> for RpcP2pConnectionIncomingPendingAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state
-            .rpc
-            .requests
-            .get(&self.rpc_id)
-            .map_or(false, |v| v.status.is_init())
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct RpcP2pConnectionIncomingRespondAction {
-    pub rpc_id: RpcId,
-    pub response: P2pConnectionResponse,
-}
-
-impl redux::EnablingCondition<crate::State> for RpcP2pConnectionIncomingRespondAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state
-            .rpc
-            .requests
-            .get(&self.rpc_id)
-            .map_or(false, |v| v.status.is_init() || v.status.is_pending())
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct RpcP2pConnectionIncomingErrorAction {
-    pub rpc_id: RpcId,
-    pub error: String,
-}
-
-impl redux::EnablingCondition<crate::State> for RpcP2pConnectionIncomingErrorAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state
-            .rpc
-            .requests
-            .get(&self.rpc_id)
-            .map_or(false, |v| v.status.is_init() || v.status.is_pending())
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct RpcP2pConnectionIncomingSuccessAction {
-    pub rpc_id: RpcId,
-}
-
-impl redux::EnablingCondition<crate::State> for RpcP2pConnectionIncomingSuccessAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state
-            .rpc
-            .requests
-            .get(&self.rpc_id)
-            .map_or(false, |v| v.status.is_pending())
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct RpcScanStateSummaryGetAction {
-    pub rpc_id: RpcId,
-    pub query: RpcScanStateSummaryGetQuery,
-}
-
-impl redux::EnablingCondition<crate::State> for RpcScanStateSummaryGetAction {}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct RpcSnarkPoolAvailableJobsGetAction {
-    pub rpc_id: RpcId,
-}
-
-impl redux::EnablingCondition<crate::State> for RpcSnarkPoolAvailableJobsGetAction {}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct RpcSnarkPoolJobGetAction {
-    pub job_id: SnarkWorkId,
-    pub rpc_id: RpcId,
-}
-
-impl redux::EnablingCondition<crate::State> for RpcSnarkPoolJobGetAction {}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct RpcSnarkerConfigGetAction {
-    pub rpc_id: RpcId,
-}
-
-impl redux::EnablingCondition<crate::State> for RpcSnarkerConfigGetAction {}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct RpcSnarkerJobCommitAction {
-    pub rpc_id: RpcId,
-    pub job_id: SnarkJobId,
-}
-
-impl redux::EnablingCondition<crate::State> for RpcSnarkerJobCommitAction {}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct RpcSnarkerJobSpecAction {
-    pub rpc_id: RpcId,
-    pub job_id: SnarkJobId,
-}
-
-impl redux::EnablingCondition<crate::State> for RpcSnarkerJobSpecAction {}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct RpcSnarkersWorkersGetAction {
-    pub rpc_id: RpcId,
-}
-
-impl redux::EnablingCondition<crate::State> for RpcSnarkersWorkersGetAction {}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct RpcHealthCheckAction {
-    pub rpc_id: RpcId,
-}
-
-impl redux::EnablingCondition<crate::State> for RpcHealthCheckAction {}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct RpcReadinessCheckAction {
-    pub rpc_id: RpcId,
-}
-
-impl redux::EnablingCondition<crate::State> for RpcReadinessCheckAction {}
-
-/// Finish/Cleanup rpc request.
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct RpcFinishAction {
-    pub rpc_id: RpcId,
-}
-
-impl redux::EnablingCondition<crate::State> for RpcFinishAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state
-            .rpc
-            .requests
-            .get(&self.rpc_id)
-            .map_or(false, |v| v.status.is_finished())
-    }
-}
-
-impl_into_global_action!(
-    Rpc:
-    RpcGlobalStateGetAction,
-    RpcActionStatsGetAction,
-    RpcSyncStatsGetAction,
-
-    RpcPeersGetAction,
-
-    RpcP2pConnectionOutgoingInitAction,
-    RpcP2pConnectionOutgoingPendingAction,
-    RpcP2pConnectionOutgoingErrorAction,
-    RpcP2pConnectionOutgoingSuccessAction,
-
-    RpcP2pConnectionIncomingInitAction,
-    RpcP2pConnectionIncomingPendingAction,
-    RpcP2pConnectionIncomingRespondAction,
-    RpcP2pConnectionIncomingErrorAction,
-    RpcP2pConnectionIncomingSuccessAction,
-
-    RpcScanStateSummaryGetAction,
-
-    RpcSnarkPoolAvailableJobsGetAction,
-    RpcSnarkPoolJobGetAction,
-
-    RpcSnarkerConfigGetAction,
-    RpcSnarkerJobCommitAction,
-    RpcSnarkerJobSpecAction,
-
-    RpcSnarkersWorkersGetAction,
-
-    RpcHealthCheckAction,
-    RpcReadinessCheckAction,
-
-    RpcFinishAction,
-);

--- a/node/src/rpc/rpc_effects.rs
+++ b/node/src/rpc/rpc_effects.rs
@@ -4,7 +4,7 @@ use mina_p2p_messages::v2::MinaBaseTransactionStatusStableV2;
 
 use crate::external_snark_worker::available_job_to_snark_worker_spec;
 use crate::p2p::connection::incoming::P2pConnectionIncomingAction;
-use crate::p2p::connection::outgoing::P2pConnectionOutgoingInitAction;
+use crate::p2p::connection::outgoing::P2pConnectionOutgoingAction;
 use crate::p2p::connection::P2pConnectionResponse;
 use crate::rpc::{PeerConnectionStatus, RpcPeerInfo};
 use crate::snark_pool::SnarkPoolAction;
@@ -118,7 +118,7 @@ pub fn rpc_effects<S: Service>(store: &mut Store<S>, action: RpcActionWithMeta) 
             );
         }
         RpcAction::P2pConnectionOutgoingInit { rpc_id, opts } => {
-            store.dispatch(P2pConnectionOutgoingInitAction {
+            store.dispatch(P2pConnectionOutgoingAction::Init {
                 opts,
                 rpc_id: Some(rpc_id),
             });

--- a/node/src/rpc/rpc_effects.rs
+++ b/node/src/rpc/rpc_effects.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use mina_p2p_messages::v2::MinaBaseTransactionStatusStableV2;
 
 use crate::external_snark_worker::available_job_to_snark_worker_spec;
-use crate::p2p::connection::incoming::P2pConnectionIncomingInitAction;
+use crate::p2p::connection::incoming::P2pConnectionIncomingAction;
 use crate::p2p::connection::outgoing::P2pConnectionOutgoingInitAction;
 use crate::p2p::connection::P2pConnectionResponse;
 use crate::rpc::{PeerConnectionStatus, RpcPeerInfo};
@@ -140,7 +140,7 @@ pub fn rpc_effects<S: Service>(store: &mut Store<S>, action: RpcActionWithMeta) 
             let rpc_id = rpc_id;
             match store.state().p2p.incoming_accept(opts.peer_id, &opts.offer) {
                 Ok(_) => {
-                    store.dispatch(P2pConnectionIncomingInitAction {
+                    store.dispatch(P2pConnectionIncomingAction::Init {
                         opts,
                         rpc_id: Some(rpc_id),
                     });

--- a/node/src/rpc/rpc_effects.rs
+++ b/node/src/rpc/rpc_effects.rs
@@ -11,10 +11,8 @@ use crate::snark_pool::SnarkPoolAction;
 use crate::{Service, Store};
 
 use super::{
-    ActionStatsQuery, ActionStatsResponse, RpcAction, RpcActionWithMeta, RpcFinishAction,
-    RpcP2pConnectionIncomingErrorAction, RpcP2pConnectionIncomingPendingAction,
-    RpcP2pConnectionIncomingRespondAction, RpcP2pConnectionOutgoingPendingAction,
-    RpcScanStateSummary, RpcScanStateSummaryBlock, RpcScanStateSummaryBlockTransaction,
+    ActionStatsQuery, ActionStatsResponse, RpcAction, RpcActionWithMeta, RpcScanStateSummary,
+    RpcScanStateSummaryBlock, RpcScanStateSummaryBlockTransaction,
     RpcScanStateSummaryBlockTransactionKind, RpcScanStateSummaryGetQuery,
     RpcScanStateSummaryScanStateJob, RpcSnarkPoolJobFull, RpcSnarkPoolJobSnarkWork,
     RpcSnarkPoolJobSummary, RpcSnarkerJobCommitResponse, RpcSnarkerJobSpecResponse,
@@ -32,19 +30,17 @@ pub fn rpc_effects<S: Service>(store: &mut Store<S>, action: RpcActionWithMeta) 
     let (action, meta) = action.split();
 
     match action {
-        RpcAction::GlobalStateGet(action) => {
-            let _ = store
-                .service
-                .respond_state_get(action.rpc_id, store.state.get());
+        RpcAction::GlobalStateGet { rpc_id } => {
+            let _ = store.service.respond_state_get(rpc_id, store.state.get());
         }
-        RpcAction::ActionStatsGet(action) => match action.query {
+        RpcAction::ActionStatsGet { rpc_id, query } => match query {
             ActionStatsQuery::SinceStart => {
                 let resp = store
                     .service
                     .stats()
                     .map(|s| s.collect_action_stats_since_start())
                     .map(|stats| ActionStatsResponse::SinceStart { stats });
-                let _ = store.service.respond_action_stats_get(action.rpc_id, resp);
+                let _ = store.service.respond_action_stats_get(rpc_id, resp);
             }
             ActionStatsQuery::ForLatestBlock => {
                 let resp = store
@@ -52,7 +48,7 @@ pub fn rpc_effects<S: Service>(store: &mut Store<S>, action: RpcActionWithMeta) 
                     .stats()
                     .and_then(|s| s.collect_action_stats_for_block_with_id(None))
                     .map(ActionStatsResponse::ForBlock);
-                let _ = store.service.respond_action_stats_get(action.rpc_id, resp);
+                let _ = store.service.respond_action_stats_get(rpc_id, resp);
             }
             ActionStatsQuery::ForBlockWithId(id) => {
                 let resp = store
@@ -60,17 +56,17 @@ pub fn rpc_effects<S: Service>(store: &mut Store<S>, action: RpcActionWithMeta) 
                     .stats()
                     .and_then(|s| s.collect_action_stats_for_block_with_id(Some(id)))
                     .map(ActionStatsResponse::ForBlock);
-                let _ = store.service.respond_action_stats_get(action.rpc_id, resp);
+                let _ = store.service.respond_action_stats_get(rpc_id, resp);
             }
         },
-        RpcAction::SyncStatsGet(action) => {
+        RpcAction::SyncStatsGet { rpc_id, query } => {
             let resp = store
                 .service
                 .stats()
-                .map(|s| s.collect_sync_stats(action.query.limit));
-            let _ = store.service.respond_sync_stats_get(action.rpc_id, resp);
+                .map(|s| s.collect_sync_stats(query.limit));
+            let _ = store.service.respond_sync_stats_get(rpc_id, resp);
         }
-        RpcAction::PeersGet(action) => {
+        RpcAction::PeersGet { rpc_id } => {
             let peers = store
                 .state()
                 .p2p
@@ -117,95 +113,79 @@ pub fn rpc_effects<S: Service>(store: &mut Store<S>, action: RpcActionWithMeta) 
                 })
                 .collect();
             respond_or_log!(
-                store.service().respond_peers_get(action.rpc_id, peers),
+                store.service().respond_peers_get(rpc_id, peers),
                 meta.time()
             );
         }
-        RpcAction::P2pConnectionOutgoingInit(action) => {
-            let (rpc_id, opts) = (action.rpc_id, action.opts);
+        RpcAction::P2pConnectionOutgoingInit { rpc_id, opts } => {
             store.dispatch(P2pConnectionOutgoingInitAction {
                 opts,
                 rpc_id: Some(rpc_id),
             });
-            store.dispatch(RpcP2pConnectionOutgoingPendingAction { rpc_id });
+            store.dispatch(RpcAction::P2pConnectionOutgoingPending { rpc_id });
         }
-        RpcAction::P2pConnectionOutgoingPending(_) => {}
-        RpcAction::P2pConnectionOutgoingError(action) => {
-            let error = Err(format!("{:?}", action.error));
+        RpcAction::P2pConnectionOutgoingPending { .. } => {}
+        RpcAction::P2pConnectionOutgoingError { rpc_id, error } => {
+            let error = Err(format!("{:?}", error));
+            let _ = store.service.respond_p2p_connection_outgoing(rpc_id, error);
+            store.dispatch(RpcAction::Finish { rpc_id: rpc_id });
+        }
+        RpcAction::P2pConnectionOutgoingSuccess { rpc_id } => {
             let _ = store
                 .service
-                .respond_p2p_connection_outgoing(action.rpc_id, error);
-            store.dispatch(RpcFinishAction {
-                rpc_id: action.rpc_id,
-            });
+                .respond_p2p_connection_outgoing(rpc_id, Ok(()));
+            store.dispatch(RpcAction::Finish { rpc_id });
         }
-        RpcAction::P2pConnectionOutgoingSuccess(action) => {
-            let _ = store
-                .service
-                .respond_p2p_connection_outgoing(action.rpc_id, Ok(()));
-            store.dispatch(RpcFinishAction {
-                rpc_id: action.rpc_id,
-            });
-        }
-        RpcAction::P2pConnectionIncomingInit(action) => {
-            let rpc_id = action.rpc_id;
-            match store
-                .state()
-                .p2p
-                .incoming_accept(action.opts.peer_id, &action.opts.offer)
-            {
+        RpcAction::P2pConnectionIncomingInit { rpc_id, opts } => {
+            let rpc_id = rpc_id;
+            match store.state().p2p.incoming_accept(opts.peer_id, &opts.offer) {
                 Ok(_) => {
                     store.dispatch(P2pConnectionIncomingInitAction {
-                        opts: action.opts,
+                        opts,
                         rpc_id: Some(rpc_id),
                     });
-                    store.dispatch(RpcP2pConnectionIncomingPendingAction { rpc_id });
+                    store.dispatch(RpcAction::P2pConnectionIncomingPending { rpc_id });
                 }
                 Err(reason) => {
                     let response = P2pConnectionResponse::Rejected(reason);
-                    store.dispatch(RpcP2pConnectionIncomingRespondAction { rpc_id, response });
+                    store.dispatch(RpcAction::P2pConnectionIncomingRespond { rpc_id, response });
                 }
             }
         }
-        RpcAction::P2pConnectionIncomingPending(_) => {}
-        RpcAction::P2pConnectionIncomingRespond(action) => {
-            let rpc_id = action.rpc_id;
-            let error = match &action.response {
+        RpcAction::P2pConnectionIncomingPending { .. } => {}
+        RpcAction::P2pConnectionIncomingRespond { rpc_id, response } => {
+            let error = match &response {
                 P2pConnectionResponse::Accepted(_) => None,
                 P2pConnectionResponse::InternalError => Some("RemoteInternalError".to_owned()),
                 P2pConnectionResponse::Rejected(reason) => Some(format!("Rejected({:?})", reason)),
             };
             let _ = store
                 .service
-                .respond_p2p_connection_incoming_answer(rpc_id, action.response);
+                .respond_p2p_connection_incoming_answer(rpc_id, response);
             if let Some(error) = error {
-                store.dispatch(RpcP2pConnectionIncomingErrorAction { rpc_id, error });
+                store.dispatch(RpcAction::P2pConnectionIncomingError { rpc_id, error });
             }
         }
-        RpcAction::P2pConnectionIncomingError(action) => {
+        RpcAction::P2pConnectionIncomingError { rpc_id, error } => {
             let _ = store
                 .service
-                .respond_p2p_connection_incoming(action.rpc_id, Err(action.error));
-            store.dispatch(RpcFinishAction {
-                rpc_id: action.rpc_id,
-            });
+                .respond_p2p_connection_incoming(rpc_id, Err(error));
+            store.dispatch(RpcAction::Finish { rpc_id });
         }
-        RpcAction::P2pConnectionIncomingSuccess(action) => {
+        RpcAction::P2pConnectionIncomingSuccess { rpc_id } => {
             let _ = store
                 .service
-                .respond_p2p_connection_incoming(action.rpc_id, Ok(()));
-            store.dispatch(RpcFinishAction {
-                rpc_id: action.rpc_id,
-            });
+                .respond_p2p_connection_incoming(rpc_id, Ok(()));
+            store.dispatch(RpcAction::Finish { rpc_id });
         }
-        RpcAction::ScanStateSummaryGet(action) => {
+        RpcAction::ScanStateSummaryGet { rpc_id, query } => {
             let state = store.state.get();
             let transition_frontier = &state.transition_frontier;
             let snark_pool = &state.snark_pool;
 
             let service = &store.service;
             let res = None.or_else(|| {
-                let block = match action.query {
+                let block = match query {
                     RpcScanStateSummaryGetQuery::ForBestTip => transition_frontier.best_tip(),
                     RpcScanStateSummaryGetQuery::ForBlockWithHash(hash) => transition_frontier
                         .best_chain
@@ -283,11 +263,9 @@ pub fn rpc_effects<S: Service>(store: &mut Store<S>, action: RpcActionWithMeta) 
                     scan_state,
                 })
             });
-            let _ = store
-                .service
-                .respond_scan_state_summary_get(action.rpc_id, res);
+            let _ = store.service.respond_scan_state_summary_get(rpc_id, res);
         }
-        RpcAction::SnarkPoolAvailableJobsGet(action) => {
+        RpcAction::SnarkPoolAvailableJobsGet { rpc_id } => {
             let resp = store
                 .state()
                 .snark_pool
@@ -304,11 +282,11 @@ pub fn rpc_effects<S: Service>(store: &mut Store<S>, action: RpcActionWithMeta) 
                     }),
                 })
                 .collect::<Vec<_>>();
-            let _ = store.service().respond_snark_pool_get(action.rpc_id, resp);
+            let _ = store.service().respond_snark_pool_get(rpc_id, resp);
         }
-        RpcAction::SnarkPoolJobGet(action) => {
+        RpcAction::SnarkPoolJobGet { job_id, rpc_id } => {
             let resp = store.state().snark_pool.range(..).find_map(|(_, job)| {
-                if &job.id == &action.job_id {
+                if job.id == job_id {
                     Some(RpcSnarkPoolJobFull {
                         time: job.time,
                         id: job.id.clone(),
@@ -325,11 +303,9 @@ pub fn rpc_effects<S: Service>(store: &mut Store<S>, action: RpcActionWithMeta) 
                     None
                 }
             });
-            let _ = store
-                .service()
-                .respond_snark_pool_job_get(action.rpc_id, resp);
+            let _ = store.service().respond_snark_pool_job_get(rpc_id, resp);
         }
-        RpcAction::SnarkerConfigGet(action) => {
+        RpcAction::SnarkerConfigGet { rpc_id } => {
             let config =
                 store
                     .state
@@ -341,42 +317,37 @@ pub fn rpc_effects<S: Service>(store: &mut Store<S>, action: RpcActionWithMeta) 
                         public_key: config.public_key.as_ref().clone(),
                         fee: config.fee.clone(),
                     });
-            let _ = store
-                .service()
-                .respond_snarker_config_get(action.rpc_id, config);
+            let _ = store.service().respond_snarker_config_get(rpc_id, config);
         }
-        RpcAction::SnarkerJobCommit(action) => {
-            let job_id = action.job_id;
+        RpcAction::SnarkerJobCommit { rpc_id, job_id } => {
             if !store.state().snark_pool.should_create_commitment(&job_id) {
-                let _ = store.service().respond_snarker_job_commit(
-                    action.rpc_id,
-                    RpcSnarkerJobCommitResponse::JobNotFound,
-                );
+                let _ = store
+                    .service()
+                    .respond_snarker_job_commit(rpc_id, RpcSnarkerJobCommitResponse::JobNotFound);
                 // TODO(binier): differentiate between job not found and job already taken.
                 return;
             }
             if !store.state().external_snark_worker.has_idle() {
-                let _ = store.service().respond_snarker_job_commit(
-                    action.rpc_id,
-                    RpcSnarkerJobCommitResponse::SnarkerBusy,
-                );
+                let _ = store
+                    .service()
+                    .respond_snarker_job_commit(rpc_id, RpcSnarkerJobCommitResponse::SnarkerBusy);
                 return;
             }
             if store
                 .service()
-                .respond_snarker_job_commit(action.rpc_id, RpcSnarkerJobCommitResponse::Ok)
+                .respond_snarker_job_commit(rpc_id, RpcSnarkerJobCommitResponse::Ok)
                 .is_err()
             {
                 return;
             }
             store.dispatch(SnarkPoolAction::CommitmentCreate { job_id });
         }
-        RpcAction::SnarkerJobSpec(action) => {
-            let job_id = action.job_id;
+        RpcAction::SnarkerJobSpec { rpc_id, job_id } => {
+            let job_id = job_id;
             let Some(job) = store.state().snark_pool.get(&job_id) else {
                 if store
                     .service()
-                    .respond_snarker_job_spec(action.rpc_id, RpcSnarkerJobSpecResponse::JobNotFound)
+                    .respond_snarker_job_spec(rpc_id, RpcSnarkerJobSpecResponse::JobNotFound)
                     .is_err()
                 {
                     return;
@@ -407,23 +378,23 @@ pub fn rpc_effects<S: Service>(store: &mut Store<S>, action: RpcActionWithMeta) 
             };
             if store
                 .service()
-                .respond_snarker_job_spec(action.rpc_id, input)
+                .respond_snarker_job_spec(rpc_id, input)
                 .is_err()
             {
                 return;
             }
         }
-        RpcAction::SnarkerWorkersGet(action) => {
+        RpcAction::SnarkerWorkersGet { rpc_id } => {
             let the_only = store.state().external_snark_worker.0.clone();
             if store
                 .service()
-                .respond_snarker_workers(action.rpc_id, vec![the_only.into()])
+                .respond_snarker_workers(rpc_id, vec![the_only.into()])
                 .is_err()
             {
                 return;
             }
         }
-        RpcAction::HealthCheck(action) => {
+        RpcAction::HealthCheck { rpc_id } => {
             let some_peers = store
                 .state()
                 .p2p
@@ -436,13 +407,11 @@ pub fn rpc_effects<S: Service>(store: &mut Store<S>, action: RpcActionWithMeta) 
                     openmina_core::log::warn!(openmina_core::log::system_time(); "no ready peers");
                     String::from("no ready peers") });
             respond_or_log!(
-                store
-                    .service()
-                    .respond_health_check(action.rpc_id, some_peers),
+                store.service().respond_health_check(rpc_id, some_peers),
                 meta.time()
             );
         }
-        RpcAction::ReadinessCheck(action) => {
+        RpcAction::ReadinessCheck { rpc_id } => {
             let synced = store
                 .service()
                 .stats()
@@ -466,10 +435,10 @@ pub fn rpc_effects<S: Service>(store: &mut Store<S>, action: RpcActionWithMeta) 
                 });
             openmina_core::log::debug!(meta.time(); summary = "readiness check", result = format!("{synced:?}"));
             respond_or_log!(
-                store.service().respond_health_check(action.rpc_id, synced),
+                store.service().respond_health_check(rpc_id, synced),
                 meta.time()
             );
         }
-        RpcAction::Finish(_) => {}
+        RpcAction::Finish { .. } => {}
     }
 }

--- a/node/src/rpc/rpc_reducer.rs
+++ b/node/src/rpc/rpc_reducer.rs
@@ -6,78 +6,78 @@ impl RpcState {
     pub fn reducer(&mut self, action: RpcActionWithMetaRef<'_>) {
         let (action, meta) = action.split();
         match action {
-            RpcAction::GlobalStateGet(_) => {}
-            RpcAction::ActionStatsGet(_) => {}
-            RpcAction::SyncStatsGet(_) => {}
-            RpcAction::PeersGet(_) => {}
-            RpcAction::P2pConnectionOutgoingInit(content) => {
+            RpcAction::GlobalStateGet { .. } => {}
+            RpcAction::ActionStatsGet { .. } => {}
+            RpcAction::SyncStatsGet { .. } => {}
+            RpcAction::PeersGet { .. } => {}
+            RpcAction::P2pConnectionOutgoingInit { rpc_id, opts } => {
                 let rpc_state = RpcRequestState {
-                    req: RpcRequest::P2pConnectionOutgoing(content.opts.clone()),
+                    req: RpcRequest::P2pConnectionOutgoing(opts.clone()),
                     status: RpcRequestStatus::Init { time: meta.time() },
                 };
-                self.requests.insert(content.rpc_id, rpc_state);
+                self.requests.insert(*rpc_id, rpc_state);
             }
-            RpcAction::P2pConnectionOutgoingPending(content) => {
-                let Some(rpc) = self.requests.get_mut(&content.rpc_id) else {
+            RpcAction::P2pConnectionOutgoingPending { rpc_id } => {
+                let Some(rpc) = self.requests.get_mut(rpc_id) else {
                     return;
                 };
                 rpc.status = RpcRequestStatus::Pending { time: meta.time() };
             }
-            RpcAction::P2pConnectionOutgoingError(content) => {
-                let Some(rpc) = self.requests.get_mut(&content.rpc_id) else {
+            RpcAction::P2pConnectionOutgoingError { rpc_id, error } => {
+                let Some(rpc) = self.requests.get_mut(rpc_id) else {
                     return;
                 };
                 rpc.status = RpcRequestStatus::Error {
                     time: meta.time(),
-                    error: format!("{:?}", content.error),
+                    error: format!("{:?}", error),
                 };
             }
-            RpcAction::P2pConnectionOutgoingSuccess(content) => {
-                let Some(rpc) = self.requests.get_mut(&content.rpc_id) else {
+            RpcAction::P2pConnectionOutgoingSuccess { rpc_id } => {
+                let Some(rpc) = self.requests.get_mut(rpc_id) else {
                     return;
                 };
                 rpc.status = RpcRequestStatus::Success { time: meta.time() };
             }
-            RpcAction::P2pConnectionIncomingInit(content) => {
+            RpcAction::P2pConnectionIncomingInit { rpc_id, opts } => {
                 let rpc_state = RpcRequestState {
-                    req: RpcRequest::P2pConnectionIncoming(content.opts.clone()),
+                    req: RpcRequest::P2pConnectionIncoming(opts.clone()),
                     status: RpcRequestStatus::Init { time: meta.time() },
                 };
-                self.requests.insert(content.rpc_id, rpc_state);
+                self.requests.insert(*rpc_id, rpc_state);
             }
-            RpcAction::P2pConnectionIncomingPending(content) => {
-                let Some(rpc) = self.requests.get_mut(&content.rpc_id) else {
+            RpcAction::P2pConnectionIncomingPending { rpc_id } => {
+                let Some(rpc) = self.requests.get_mut(rpc_id) else {
                     return;
                 };
                 rpc.status = RpcRequestStatus::Pending { time: meta.time() };
             }
-            RpcAction::P2pConnectionIncomingRespond(_) => {}
-            RpcAction::P2pConnectionIncomingError(content) => {
-                let Some(rpc) = self.requests.get_mut(&content.rpc_id) else {
+            RpcAction::P2pConnectionIncomingRespond { .. } => {}
+            RpcAction::P2pConnectionIncomingError { rpc_id, error } => {
+                let Some(rpc) = self.requests.get_mut(rpc_id) else {
                     return;
                 };
                 rpc.status = RpcRequestStatus::Error {
                     time: meta.time(),
-                    error: format!("{:?}", content.error),
+                    error: format!("{:?}", error),
                 };
             }
-            RpcAction::P2pConnectionIncomingSuccess(content) => {
-                let Some(rpc) = self.requests.get_mut(&content.rpc_id) else {
+            RpcAction::P2pConnectionIncomingSuccess { rpc_id } => {
+                let Some(rpc) = self.requests.get_mut(rpc_id) else {
                     return;
                 };
                 rpc.status = RpcRequestStatus::Success { time: meta.time() };
             }
-            RpcAction::ScanStateSummaryGet(_) => {}
-            RpcAction::SnarkPoolAvailableJobsGet(_) => {}
-            RpcAction::SnarkPoolJobGet(_) => {}
-            RpcAction::SnarkerConfigGet(_) => {}
-            RpcAction::SnarkerJobCommit(_) => {}
-            RpcAction::SnarkerJobSpec(_) => {}
-            RpcAction::SnarkerWorkersGet(_) => {}
-            RpcAction::HealthCheck(_) => {}
-            RpcAction::ReadinessCheck(_) => {}
-            RpcAction::Finish(action) => {
-                self.requests.remove(&action.rpc_id);
+            RpcAction::ScanStateSummaryGet { .. } => {}
+            RpcAction::SnarkPoolAvailableJobsGet { .. } => {}
+            RpcAction::SnarkPoolJobGet { .. } => {}
+            RpcAction::SnarkerConfigGet { .. } => {}
+            RpcAction::SnarkerJobCommit { .. } => {}
+            RpcAction::SnarkerJobSpec { .. } => {}
+            RpcAction::SnarkerWorkersGet { .. } => {}
+            RpcAction::HealthCheck { .. } => {}
+            RpcAction::ReadinessCheck { .. } => {}
+            RpcAction::Finish { rpc_id } => {
+                self.requests.remove(rpc_id);
             }
         }
     }

--- a/node/src/snark_pool/candidate/snark_pool_candidate_effects.rs
+++ b/node/src/snark_pool/candidate/snark_pool_candidate_effects.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use snark::work_verify::SnarkWorkVerifyAction;
 
 use crate::p2p::channels::rpc::{P2pChannelsRpcAction, P2pRpcRequest};
-use crate::p2p::disconnection::{P2pDisconnectionInitAction, P2pDisconnectionReason};
+use crate::p2p::disconnection::{P2pDisconnectionAction, P2pDisconnectionReason};
 use crate::Store;
 
 use super::{SnarkPoolCandidateAction, SnarkPoolCandidateActionWithMeta};
@@ -85,7 +85,7 @@ pub fn snark_pool_candidate_effects<S: redux::Service>(
         SnarkPoolCandidateAction::WorkVerifyPending { .. } => {}
         SnarkPoolCandidateAction::WorkVerifyError { peer_id, .. } => {
             // TODO(binier): blacklist peer
-            store.dispatch(P2pDisconnectionInitAction {
+            store.dispatch(P2pDisconnectionAction::Init {
                 peer_id,
                 reason: P2pDisconnectionReason::SnarkPoolVerifyError,
             });

--- a/node/src/transition_frontier/sync/ledger/mod.rs
+++ b/node/src/transition_frontier/sync/ledger/mod.rs
@@ -9,8 +9,8 @@ pub use transition_frontier_sync_ledger_actions::*;
 
 mod transition_frontier_sync_ledger_reducer;
 
-
 mod transition_frontier_sync_ledger_effects;
+pub use transition_frontier_sync_ledger_effects::*;
 
 
 use mina_p2p_messages::v2::{LedgerHash, MinaBaseStagedLedgerHashStableV1, StateHash};

--- a/node/src/transition_frontier/sync/ledger/snarked/transition_frontier_sync_ledger_snarked_actions.rs
+++ b/node/src/transition_frontier/sync/ledger/snarked/transition_frontier_sync_ledger_snarked_actions.rs
@@ -16,285 +16,230 @@ pub type TransitionFrontierSyncLedgerSnarkedActionWithMeta =
 pub type TransitionFrontierSyncLedgerSnarkedActionWithMetaRef<'a> =
     redux::ActionWithMeta<&'a TransitionFrontierSyncLedgerSnarkedAction>;
 
-#[derive(derive_more::From, Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum TransitionFrontierSyncLedgerSnarkedAction {
-    Pending(TransitionFrontierSyncLedgerSnarkedPendingAction),
-    PeersQuery(TransitionFrontierSyncLedgerSnarkedPeersQueryAction),
-    PeerQueryInit(TransitionFrontierSyncLedgerSnarkedPeerQueryInitAction),
-    PeerQueryPending(TransitionFrontierSyncLedgerSnarkedPeerQueryPendingAction),
-    PeerQueryRetry(TransitionFrontierSyncLedgerSnarkedPeerQueryRetryAction),
-    PeerQueryError(TransitionFrontierSyncLedgerSnarkedPeerQueryErrorAction),
-    PeerQuerySuccess(TransitionFrontierSyncLedgerSnarkedPeerQuerySuccessAction),
-    ChildHashesReceived(TransitionFrontierSyncLedgerSnarkedChildHashesReceivedAction),
-    ChildAccountsReceived(TransitionFrontierSyncLedgerSnarkedChildAccountsReceivedAction),
-    Success(TransitionFrontierSyncLedgerSnarkedSuccessAction),
+    Pending,
+    PeersQuery,
+    PeerQueryInit {
+        address: LedgerAddress,
+        peer_id: PeerId,
+    },
+    PeerQueryPending {
+        address: LedgerAddress,
+        peer_id: PeerId,
+        rpc_id: P2pRpcId,
+    },
+    PeerQueryRetry {
+        address: LedgerAddress,
+        peer_id: PeerId,
+    },
+    PeerQueryError {
+        peer_id: PeerId,
+        rpc_id: P2pRpcId,
+        error: PeerLedgerQueryError,
+    },
+    PeerQuerySuccess {
+        peer_id: PeerId,
+        rpc_id: P2pRpcId,
+        response: PeerLedgerQueryResponse,
+    },
+    ChildHashesReceived {
+        address: LedgerAddress,
+        hashes: (LedgerHash, LedgerHash),
+        sender: PeerId,
+    },
+    ChildAccountsReceived {
+        address: LedgerAddress,
+        accounts: Vec<MinaBaseAccountBinableArgStableV2>,
+        sender: PeerId,
+    },
+    Success,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TransitionFrontierSyncLedgerSnarkedPendingAction {}
-
-impl redux::EnablingCondition<crate::State> for TransitionFrontierSyncLedgerSnarkedPendingAction {
+impl redux::EnablingCondition<crate::State> for TransitionFrontierSyncLedgerSnarkedAction {
     fn is_enabled(&self, state: &crate::State) -> bool {
-        state.transition_frontier.sync.ledger().map_or(false, |s| {
-            matches!(s, TransitionFrontierSyncLedgerState::Init { .. })
-        })
-    }
-}
+        match self {
+            TransitionFrontierSyncLedgerSnarkedAction::Pending => {
+                state.transition_frontier.sync.ledger().map_or(false, |s| {
+                    matches!(s, TransitionFrontierSyncLedgerState::Init { .. })
+                })
+            }
+            TransitionFrontierSyncLedgerSnarkedAction::PeersQuery => {
+                let peers_available = state
+                    .p2p
+                    .ready_peers_iter()
+                    .any(|(_, p)| p.channels.rpc.can_send_request());
+                peers_available
+                    && state
+                        .transition_frontier
+                        .sync
+                        .ledger()
+                        .and_then(|s| s.snarked())
+                        .map_or(false, |s| {
+                            s.sync_next().is_some() || s.sync_retry_iter().next().is_some()
+                        })
+            }
+            TransitionFrontierSyncLedgerSnarkedAction::PeerQueryInit { address, peer_id } => {
+                None.or_else(|| {
+                    let target_best_tip = state.transition_frontier.sync.best_tip()?;
+                    let ledger = state.transition_frontier.sync.ledger()?.snarked()?;
+                    let target = ledger.target();
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TransitionFrontierSyncLedgerSnarkedPeersQueryAction {}
+                    // This is true if there is a next address that needs to be queried
+                    // from a peer and it matches the one requested by this action.
+                    let check_next_addr = match ledger {
+                        TransitionFrontierSyncLedgerSnarkedState::Pending {
+                            pending,
+                            next_addr,
+                            ..
+                        } => next_addr.as_ref().map_or(false, |next_addr| {
+                            next_addr == address
+                                && (next_addr.to_index().0 != 0 || pending.is_empty())
+                        }),
+                        _ => false,
+                    };
 
-impl redux::EnablingCondition<crate::State>
-    for TransitionFrontierSyncLedgerSnarkedPeersQueryAction
-{
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        let peers_available = state
-            .p2p
-            .ready_peers_iter()
-            .any(|(_, p)| p.channels.rpc.can_send_request());
-        peers_available
-            && state
+                    let peer = state.p2p.get_ready_peer(peer_id)?;
+                    let check_peer_available = {
+                        let peer_best_tip = peer.best_tip.as_ref()?;
+                        if !peer.channels.rpc.can_send_request() {
+                            false
+                        } else if target.staged.is_some() {
+                            // if peer has same best tip, then he has same root
+                            // so we can sync root snarked+staged ledger from that peer.
+                            target_best_tip.hash() == peer_best_tip.hash()
+                        } else {
+                            &target.snarked_ledger_hash == peer_best_tip.snarked_ledger_hash()
+                                || &target.snarked_ledger_hash
+                                    == peer_best_tip.staking_epoch_ledger_hash()
+                                || &target.snarked_ledger_hash
+                                    == peer_best_tip.next_epoch_ledger_hash()
+                        }
+                    };
+
+                    Some(check_next_addr && check_peer_available)
+                })
+                .unwrap_or(false)
+            }
+            TransitionFrontierSyncLedgerSnarkedAction::PeerQueryRetry { address, peer_id } => {
+                None.or_else(|| {
+                    let target_best_tip = state.transition_frontier.sync.best_tip()?;
+                    let ledger = state.transition_frontier.sync.ledger()?.snarked()?;
+                    let target = ledger.target();
+
+                    // This is true if there is next retry address and it
+                    // matches the one requested in this action.
+                    let check_next_addr = state
+                        .transition_frontier
+                        .sync
+                        .ledger()
+                        .and_then(|s| s.snarked()?.sync_retry_iter().next())
+                        .map_or(false, |addr| &addr == address);
+
+                    let peer = state.p2p.get_ready_peer(peer_id)?;
+                    let check_peer_available = {
+                        let peer_best_tip = peer.best_tip.as_ref()?;
+                        if !peer.channels.rpc.can_send_request() {
+                            false
+                        } else if target.staged.is_some() {
+                            // if peer has same best tip, then he has same root
+                            // so we can sync root snarked+staged ledger from that peer.
+                            target_best_tip.hash() == peer_best_tip.hash()
+                        } else {
+                            &target.snarked_ledger_hash == peer_best_tip.snarked_ledger_hash()
+                                || &target.snarked_ledger_hash
+                                    == peer_best_tip.staking_epoch_ledger_hash()
+                                || &target.snarked_ledger_hash
+                                    == peer_best_tip.next_epoch_ledger_hash()
+                        }
+                    };
+
+                    Some(check_next_addr && check_peer_available)
+                })
+                .unwrap_or(false)
+            }
+            TransitionFrontierSyncLedgerSnarkedAction::PeerQueryPending { peer_id, .. } => state
+                .transition_frontier
+                .sync
+                .ledger()
+                .and_then(|s| s.snarked()?.fetch_pending())
+                .map_or(false, |pending| {
+                    pending
+                        .iter()
+                        .filter_map(|(_, query_state)| query_state.attempts.get(peer_id))
+                        .any(|peer_rpc_state| matches!(peer_rpc_state, PeerRpcState::Init { .. }))
+                }),
+            TransitionFrontierSyncLedgerSnarkedAction::PeerQueryError {
+                peer_id, rpc_id, ..
+            } => state
                 .transition_frontier
                 .sync
                 .ledger()
                 .and_then(|s| s.snarked())
                 .map_or(false, |s| {
-                    s.sync_next().is_some() || s.sync_retry_iter().next().is_some()
-                })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TransitionFrontierSyncLedgerSnarkedPeerQueryInitAction {
-    pub address: LedgerAddress,
-    pub peer_id: PeerId,
-}
-
-impl redux::EnablingCondition<crate::State>
-    for TransitionFrontierSyncLedgerSnarkedPeerQueryInitAction
-{
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        None.or_else(|| {
-            let target_best_tip = state.transition_frontier.sync.best_tip()?;
-            let ledger = state.transition_frontier.sync.ledger()?.snarked()?;
-            let target = ledger.target();
-
-            // This is true if there is a next address that needs to be queried
-            // from a peer and it matches the one requested by this action.
-            let check_next_addr = match ledger {
-                TransitionFrontierSyncLedgerSnarkedState::Pending {
-                    pending, next_addr, ..
-                } => next_addr.as_ref().map_or(false, |next_addr| {
-                    next_addr == &self.address
-                        && (next_addr.to_index().0 != 0 || pending.is_empty())
+                    s.peer_query_get(peer_id, *rpc_id)
+                        .and_then(|(_, s)| s.attempts.get(peer_id))
+                        .map_or(false, |s| matches!(s, PeerRpcState::Pending { .. }))
                 }),
-                _ => false,
-            };
-
-            let peer = state.p2p.get_ready_peer(&self.peer_id)?;
-            let check_peer_available = {
-                let peer_best_tip = peer.best_tip.as_ref()?;
-                if !peer.channels.rpc.can_send_request() {
-                    false
-                } else if target.staged.is_some() {
-                    // if peer has same best tip, then he has same root
-                    // so we can sync root snarked+staged ledger from that peer.
-                    target_best_tip.hash() == peer_best_tip.hash()
-                } else {
-                    &target.snarked_ledger_hash == peer_best_tip.snarked_ledger_hash()
-                        || &target.snarked_ledger_hash == peer_best_tip.staking_epoch_ledger_hash()
-                        || &target.snarked_ledger_hash == peer_best_tip.next_epoch_ledger_hash()
-                }
-            };
-
-            Some(check_next_addr && check_peer_available)
-        })
-        .unwrap_or(false)
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TransitionFrontierSyncLedgerSnarkedPeerQueryRetryAction {
-    pub address: LedgerAddress,
-    pub peer_id: PeerId,
-}
-
-impl redux::EnablingCondition<crate::State>
-    for TransitionFrontierSyncLedgerSnarkedPeerQueryRetryAction
-{
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        None.or_else(|| {
-            let target_best_tip = state.transition_frontier.sync.best_tip()?;
-            let ledger = state.transition_frontier.sync.ledger()?.snarked()?;
-            let target = ledger.target();
-
-            // This is true if there is next retry address and it
-            // matches the one requested in this action.
-            let check_next_addr = state
+            TransitionFrontierSyncLedgerSnarkedAction::PeerQuerySuccess {
+                peer_id, rpc_id, ..
+            } => {
+                state
+                    .transition_frontier
+                    .sync
+                    .ledger()
+                    .and_then(|s| s.snarked())
+                    .map_or(false, |s| {
+                        // TODO(binier): check if expected response
+                        // kind is correct.
+                        s.peer_query_get(peer_id, *rpc_id)
+                            .and_then(|(_, s)| s.attempts.get(peer_id))
+                            .map_or(false, |s| matches!(s, PeerRpcState::Pending { .. }))
+                    })
+            }
+            TransitionFrontierSyncLedgerSnarkedAction::ChildHashesReceived {
+                address,
+                sender,
+                ..
+            } => {
+                address.length() < LEDGER_DEPTH - 1
+                    && state
+                        .transition_frontier
+                        .sync
+                        .ledger()
+                        .and_then(|s| s.snarked()?.fetch_pending()?.get(address))
+                        .and_then(|s| s.attempts.get(sender))
+                        .map_or(false, |s| s.is_success())
+            }
+            TransitionFrontierSyncLedgerSnarkedAction::ChildAccountsReceived {
+                address,
+                sender,
+                ..
+            } => {
+                state
+                    .transition_frontier
+                    .sync
+                    .ledger()
+                    .and_then(|s| s.snarked()?.fetch_pending()?.get(address))
+                    .and_then(|s| s.attempts.get(sender))
+                    // TODO(binier): check if expected response
+                    // kind is correct.
+                    .map_or(false, |s| s.is_success())
+            }
+            TransitionFrontierSyncLedgerSnarkedAction::Success => state
                 .transition_frontier
                 .sync
                 .ledger()
-                .and_then(|s| s.snarked()?.sync_retry_iter().next())
-                .map_or(false, |addr| addr == self.address);
-
-            let peer = state.p2p.get_ready_peer(&self.peer_id)?;
-            let check_peer_available = {
-                let peer_best_tip = peer.best_tip.as_ref()?;
-                if !peer.channels.rpc.can_send_request() {
-                    false
-                } else if target.staged.is_some() {
-                    // if peer has same best tip, then he has same root
-                    // so we can sync root snarked+staged ledger from that peer.
-                    target_best_tip.hash() == peer_best_tip.hash()
-                } else {
-                    &target.snarked_ledger_hash == peer_best_tip.snarked_ledger_hash()
-                        || &target.snarked_ledger_hash == peer_best_tip.staking_epoch_ledger_hash()
-                        || &target.snarked_ledger_hash == peer_best_tip.next_epoch_ledger_hash()
-                }
-            };
-
-            Some(check_next_addr && check_peer_available)
-        })
-        .unwrap_or(false)
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TransitionFrontierSyncLedgerSnarkedPeerQueryPendingAction {
-    pub address: LedgerAddress,
-    pub peer_id: PeerId,
-    pub rpc_id: P2pRpcId,
-}
-
-impl redux::EnablingCondition<crate::State>
-    for TransitionFrontierSyncLedgerSnarkedPeerQueryPendingAction
-{
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state
-            .transition_frontier
-            .sync
-            .ledger()
-            .and_then(|s| s.snarked()?.fetch_pending())
-            .map_or(false, |pending| {
-                pending
-                    .iter()
-                    .filter_map(|(_, query_state)| query_state.attempts.get(&self.peer_id))
-                    .any(|peer_rpc_state| matches!(peer_rpc_state, PeerRpcState::Init { .. }))
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TransitionFrontierSyncLedgerSnarkedPeerQueryErrorAction {
-    pub peer_id: PeerId,
-    pub rpc_id: P2pRpcId,
-    pub error: PeerLedgerQueryError,
-}
-
-impl redux::EnablingCondition<crate::State>
-    for TransitionFrontierSyncLedgerSnarkedPeerQueryErrorAction
-{
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state
-            .transition_frontier
-            .sync
-            .ledger()
-            .and_then(|s| s.snarked())
-            .map_or(false, |s| {
-                s.peer_query_get(&self.peer_id, self.rpc_id)
-                    .and_then(|(_, s)| s.attempts.get(&self.peer_id))
-                    .map_or(false, |s| matches!(s, PeerRpcState::Pending { .. }))
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TransitionFrontierSyncLedgerSnarkedPeerQuerySuccessAction {
-    pub peer_id: PeerId,
-    pub rpc_id: P2pRpcId,
-    pub response: PeerLedgerQueryResponse,
-}
-
-impl redux::EnablingCondition<crate::State>
-    for TransitionFrontierSyncLedgerSnarkedPeerQuerySuccessAction
-{
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state
-            .transition_frontier
-            .sync
-            .ledger()
-            .and_then(|s| s.snarked())
-            .map_or(false, |s| {
-                // TODO(binier): check if expected response
-                // kind is correct.
-                s.peer_query_get(&self.peer_id, self.rpc_id)
-                    .and_then(|(_, s)| s.attempts.get(&self.peer_id))
-                    .map_or(false, |s| matches!(s, PeerRpcState::Pending { .. }))
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TransitionFrontierSyncLedgerSnarkedChildHashesReceivedAction {
-    pub address: LedgerAddress,
-    pub hashes: (LedgerHash, LedgerHash),
-    pub sender: PeerId,
-}
-
-impl redux::EnablingCondition<crate::State>
-    for TransitionFrontierSyncLedgerSnarkedChildHashesReceivedAction
-{
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.address.length() < LEDGER_DEPTH - 1
-            && state
-                .transition_frontier
-                .sync
-                .ledger()
-                .and_then(|s| s.snarked()?.fetch_pending()?.get(&self.address))
-                .and_then(|s| s.attempts.get(&self.sender))
-                .map_or(false, |s| s.is_success())
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TransitionFrontierSyncLedgerSnarkedChildAccountsReceivedAction {
-    pub address: LedgerAddress,
-    pub accounts: Vec<MinaBaseAccountBinableArgStableV2>,
-    pub sender: PeerId,
-}
-
-impl redux::EnablingCondition<crate::State>
-    for TransitionFrontierSyncLedgerSnarkedChildAccountsReceivedAction
-{
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state
-            .transition_frontier
-            .sync
-            .ledger()
-            .and_then(|s| s.snarked()?.fetch_pending()?.get(&self.address))
-            .and_then(|s| s.attempts.get(&self.sender))
-            // TODO(binier): check if expected response
-            // kind is correct.
-            .map_or(false, |s| s.is_success())
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TransitionFrontierSyncLedgerSnarkedSuccessAction {}
-
-impl redux::EnablingCondition<crate::State> for TransitionFrontierSyncLedgerSnarkedSuccessAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state
-            .transition_frontier
-            .sync
-            .ledger()
-            .and_then(|s| s.snarked())
-            .map_or(false, |s| match s {
-                TransitionFrontierSyncLedgerSnarkedState::Pending {
-                    pending, next_addr, ..
-                } => next_addr.is_none() && pending.is_empty(),
-                _ => false,
-            })
+                .and_then(|s| s.snarked())
+                .map_or(false, |s| match s {
+                    TransitionFrontierSyncLedgerSnarkedState::Pending {
+                        pending,
+                        next_addr,
+                        ..
+                    } => next_addr.is_none() && pending.is_empty(),
+                    _ => false,
+                }),
+        }
     }
 }
 
@@ -303,27 +248,12 @@ use crate::transition_frontier::{
     TransitionFrontierAction,
 };
 
-macro_rules! impl_into_global_action {
-    ($a:ty) => {
-        impl From<$a> for crate::Action {
-            fn from(value: $a) -> Self {
-                Self::TransitionFrontier(TransitionFrontierAction::Sync(
-                    TransitionFrontierSyncAction::Ledger(
-                        TransitionFrontierSyncLedgerAction::Snarked(value.into()),
-                    ),
-                ))
-            }
-        }
-    };
+impl From<TransitionFrontierSyncLedgerSnarkedAction> for crate::Action {
+    fn from(value: TransitionFrontierSyncLedgerSnarkedAction) -> Self {
+        Self::TransitionFrontier(TransitionFrontierAction::Sync(
+            TransitionFrontierSyncAction::Ledger(TransitionFrontierSyncLedgerAction::Snarked(
+                value,
+            )),
+        ))
+    }
 }
-
-impl_into_global_action!(TransitionFrontierSyncLedgerSnarkedPendingAction);
-impl_into_global_action!(TransitionFrontierSyncLedgerSnarkedPeersQueryAction);
-impl_into_global_action!(TransitionFrontierSyncLedgerSnarkedPeerQueryInitAction);
-impl_into_global_action!(TransitionFrontierSyncLedgerSnarkedPeerQueryPendingAction);
-impl_into_global_action!(TransitionFrontierSyncLedgerSnarkedPeerQueryErrorAction);
-impl_into_global_action!(TransitionFrontierSyncLedgerSnarkedPeerQueryRetryAction);
-impl_into_global_action!(TransitionFrontierSyncLedgerSnarkedPeerQuerySuccessAction);
-impl_into_global_action!(TransitionFrontierSyncLedgerSnarkedChildHashesReceivedAction);
-impl_into_global_action!(TransitionFrontierSyncLedgerSnarkedChildAccountsReceivedAction);
-impl_into_global_action!(TransitionFrontierSyncLedgerSnarkedSuccessAction);

--- a/node/src/transition_frontier/sync/ledger/staged/transition_frontier_sync_ledger_staged_actions.rs
+++ b/node/src/transition_frontier/sync/ledger/staged/transition_frontier_sync_ledger_staged_actions.rs
@@ -16,325 +16,202 @@ pub type TransitionFrontierSyncLedgerStagedActionWithMeta =
 pub type TransitionFrontierSyncLedgerStagedActionWithMetaRef<'a> =
     redux::ActionWithMeta<&'a TransitionFrontierSyncLedgerStagedAction>;
 
-#[derive(derive_more::From, Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum TransitionFrontierSyncLedgerStagedAction {
-    PartsFetchPending(TransitionFrontierSyncLedgerStagedPartsFetchPendingAction),
-    PartsPeerFetchInit(TransitionFrontierSyncLedgerStagedPartsPeerFetchInitAction),
-    PartsPeerFetchPending(TransitionFrontierSyncLedgerStagedPartsPeerFetchPendingAction),
-    PartsPeerFetchError(TransitionFrontierSyncLedgerStagedPartsPeerFetchErrorAction),
-    PartsPeerFetchSuccess(TransitionFrontierSyncLedgerStagedPartsPeerFetchSuccessAction),
-    PartsPeerInvalid(TransitionFrontierSyncLedgerStagedPartsPeerInvalidAction),
-    PartsPeerValid(TransitionFrontierSyncLedgerStagedPartsPeerValidAction),
-    PartsFetchSuccess(TransitionFrontierSyncLedgerStagedPartsFetchSuccessAction),
-    ReconstructEmpty(TransitionFrontierSyncLedgerStagedReconstructEmptyAction),
-    ReconstructInit(TransitionFrontierSyncLedgerStagedReconstructInitAction),
-    ReconstructPending(TransitionFrontierSyncLedgerStagedReconstructPendingAction),
-    ReconstructError(TransitionFrontierSyncLedgerStagedReconstructErrorAction),
-    ReconstructSuccess(TransitionFrontierSyncLedgerStagedReconstructSuccessAction),
-    Success(TransitionFrontierSyncLedgerStagedSuccessAction),
+    PartsFetchPending,
+    PartsPeerFetchInit,
+    PartsPeerFetchPending {
+        peer_id: PeerId,
+        rpc_id: P2pRpcId,
+    },
+    PartsPeerFetchError {
+        peer_id: PeerId,
+        rpc_id: P2pRpcId,
+        error: PeerStagedLedgerPartsFetchError,
+    },
+    PartsPeerFetchSuccess {
+        peer_id: PeerId,
+        rpc_id: P2pRpcId,
+        parts: Arc<StagedLedgerAuxAndPendingCoinbases>,
+    },
+    PartsPeerInvalid {
+        sender: PeerId,
+        parts: Arc<StagedLedgerAuxAndPendingCoinbases>,
+    },
+    PartsPeerValid {
+        sender: PeerId,
+    },
+    PartsFetchSuccess {
+        sender: PeerId,
+    },
+    ReconstructEmpty,
+    ReconstructInit,
+    ReconstructPending,
+    ReconstructError {
+        error: String,
+    },
+    ReconstructSuccess,
+    Success,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TransitionFrontierSyncLedgerStagedPartsFetchPendingAction {}
-
-impl redux::EnablingCondition<crate::State>
-    for TransitionFrontierSyncLedgerStagedPartsFetchPendingAction
-{
+impl redux::EnablingCondition<crate::State> for TransitionFrontierSyncLedgerStagedAction {
     fn is_enabled(&self, state: &crate::State) -> bool {
-        state
-            .transition_frontier
-            .sync
-            .ledger()
-            .and_then(|s| s.snarked())
-            .map_or(false, |s| match s {
-                TransitionFrontierSyncLedgerSnarkedState::Success { target, .. } => {
-                    target.staged.is_some()
-                }
-                _ => false,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TransitionFrontierSyncLedgerStagedPartsPeerFetchInitAction {}
-
-impl redux::EnablingCondition<crate::State>
-    for TransitionFrontierSyncLedgerStagedPartsPeerFetchInitAction
-{
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state
-            .transition_frontier
-            .sync
-            .ledger()
-            .and_then(|s| s.staged())
-            .map_or(false, |staged| {
-                let iter = state.p2p.ready_rpc_peers_iter();
-                staged.filter_available_peers(iter).next().is_some()
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TransitionFrontierSyncLedgerStagedPartsPeerFetchPendingAction {
-    pub peer_id: PeerId,
-    pub rpc_id: P2pRpcId,
-}
-
-impl redux::EnablingCondition<crate::State>
-    for TransitionFrontierSyncLedgerStagedPartsPeerFetchPendingAction
-{
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state
-            .transition_frontier
-            .sync
-            .ledger()
-            .and_then(|s| s.staged())
-            .map_or(false, |s| {
-                matches!(
-                    s,
-                    TransitionFrontierSyncLedgerStagedState::PartsFetchPending { .. }
-                )
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TransitionFrontierSyncLedgerStagedPartsPeerFetchErrorAction {
-    pub peer_id: PeerId,
-    pub rpc_id: P2pRpcId,
-    pub error: PeerStagedLedgerPartsFetchError,
-}
-
-impl redux::EnablingCondition<crate::State>
-    for TransitionFrontierSyncLedgerStagedPartsPeerFetchErrorAction
-{
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state
-            .transition_frontier
-            .sync
-            .ledger()
-            .and_then(|s| s.staged()?.fetch_attempts()?.get(&self.peer_id))
-            .and_then(|s| s.fetch_pending_rpc_id())
-            .map_or(false, |rpc_id| rpc_id == self.rpc_id)
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TransitionFrontierSyncLedgerStagedPartsPeerFetchSuccessAction {
-    pub peer_id: PeerId,
-    pub rpc_id: P2pRpcId,
-    pub parts: Arc<StagedLedgerAuxAndPendingCoinbases>,
-}
-
-impl redux::EnablingCondition<crate::State>
-    for TransitionFrontierSyncLedgerStagedPartsPeerFetchSuccessAction
-{
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state
-            .transition_frontier
-            .sync
-            .ledger()
-            .and_then(|s| s.staged()?.fetch_attempts()?.get(&self.peer_id))
-            .and_then(|s| s.fetch_pending_rpc_id())
-            .map_or(false, |rpc_id| rpc_id == self.rpc_id)
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TransitionFrontierSyncLedgerStagedPartsPeerInvalidAction {
-    pub sender: PeerId,
-    pub parts: Arc<StagedLedgerAuxAndPendingCoinbases>,
-}
-
-impl redux::EnablingCondition<crate::State>
-    for TransitionFrontierSyncLedgerStagedPartsPeerInvalidAction
-{
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state
-            .transition_frontier
-            .sync
-            .ledger()
-            .and_then(|s| s.staged()?.fetch_attempts()?.get(&self.sender))
-            .map_or(false, |s| match s {
-                PeerStagedLedgerPartsFetchState::Success { parts, .. } => !parts.is_valid(),
-                _ => false,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TransitionFrontierSyncLedgerStagedPartsPeerValidAction {
-    pub sender: PeerId,
-}
-
-impl redux::EnablingCondition<crate::State>
-    for TransitionFrontierSyncLedgerStagedPartsPeerValidAction
-{
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state
-            .transition_frontier
-            .sync
-            .ledger()
-            .and_then(|s| s.staged()?.fetch_attempts()?.get(&self.sender))
-            .map_or(false, |s| match s {
-                PeerStagedLedgerPartsFetchState::Success { parts, .. } => parts.is_valid(),
-                _ => false,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TransitionFrontierSyncLedgerStagedPartsFetchSuccessAction {
-    pub sender: PeerId,
-}
-
-impl redux::EnablingCondition<crate::State>
-    for TransitionFrontierSyncLedgerStagedPartsFetchSuccessAction
-{
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state
-            .transition_frontier
-            .sync
-            .ledger()
-            .and_then(|s| s.staged()?.fetch_attempts()?.get(&self.sender))
-            .map_or(false, |s| s.is_valid())
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TransitionFrontierSyncLedgerStagedReconstructEmptyAction {}
-
-impl redux::EnablingCondition<crate::State>
-    for TransitionFrontierSyncLedgerStagedReconstructEmptyAction
-{
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state
-            .transition_frontier
-            .sync
-            .ledger()
-            .and_then(|s| s.snarked())
-            .and_then(|s| match s {
-                TransitionFrontierSyncLedgerSnarkedState::Success { target, .. } => {
-                    target.clone().with_staged()
-                }
-                _ => None,
-            })
-            .map_or(false, |target| {
-                let hashes = &target.staged.hashes;
-                let empty_hash = &[0; 32];
-                target.snarked_ledger_hash == hashes.non_snark.ledger_hash
-                    && hashes.non_snark.aux_hash.as_ref() == empty_hash
-                    && hashes.non_snark.pending_coinbase_aux.as_ref() == empty_hash
-                // TODO(binier): `pending_coinbase_hash` isn't empty hash.
-                // Do we need to check it?
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TransitionFrontierSyncLedgerStagedReconstructInitAction {}
-
-impl redux::EnablingCondition<crate::State>
-    for TransitionFrontierSyncLedgerStagedReconstructInitAction
-{
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state
-            .transition_frontier
-            .sync
-            .ledger()
-            .and_then(|s| s.staged())
-            .map_or(false, |s| {
-                matches!(
-                    s,
-                    TransitionFrontierSyncLedgerStagedState::PartsFetchSuccess { .. }
-                        | TransitionFrontierSyncLedgerStagedState::ReconstructEmpty { .. }
-                )
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TransitionFrontierSyncLedgerStagedReconstructPendingAction {}
-
-impl redux::EnablingCondition<crate::State>
-    for TransitionFrontierSyncLedgerStagedReconstructPendingAction
-{
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state
-            .transition_frontier
-            .sync
-            .ledger()
-            .and_then(|s| s.staged())
-            .map_or(false, |s| {
-                matches!(
-                    s,
-                    TransitionFrontierSyncLedgerStagedState::PartsFetchSuccess { .. }
-                        | TransitionFrontierSyncLedgerStagedState::ReconstructEmpty { .. }
-                )
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TransitionFrontierSyncLedgerStagedReconstructErrorAction {
-    pub error: String,
-}
-
-impl redux::EnablingCondition<crate::State>
-    for TransitionFrontierSyncLedgerStagedReconstructErrorAction
-{
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state
-            .transition_frontier
-            .sync
-            .ledger()
-            .and_then(|s| s.staged())
-            .map_or(false, |s| {
-                matches!(
-                    s,
-                    TransitionFrontierSyncLedgerStagedState::ReconstructPending { .. }
-                )
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TransitionFrontierSyncLedgerStagedReconstructSuccessAction {}
-
-impl redux::EnablingCondition<crate::State>
-    for TransitionFrontierSyncLedgerStagedReconstructSuccessAction
-{
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state
-            .transition_frontier
-            .sync
-            .ledger()
-            .and_then(|s| s.staged())
-            .map_or(false, |s| {
-                matches!(
-                    s,
-                    TransitionFrontierSyncLedgerStagedState::ReconstructPending { .. }
-                )
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct TransitionFrontierSyncLedgerStagedSuccessAction {}
-
-impl redux::EnablingCondition<crate::State> for TransitionFrontierSyncLedgerStagedSuccessAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        state
-            .transition_frontier
-            .sync
-            .ledger()
-            .and_then(|s| s.staged())
-            .map_or(false, |s| {
-                matches!(
-                    s,
-                    TransitionFrontierSyncLedgerStagedState::ReconstructSuccess { .. }
-                )
-            })
+        match self {
+            TransitionFrontierSyncLedgerStagedAction::PartsFetchPending => state
+                .transition_frontier
+                .sync
+                .ledger()
+                .and_then(|s| s.snarked())
+                .map_or(false, |s| match s {
+                    TransitionFrontierSyncLedgerSnarkedState::Success { target, .. } => {
+                        target.staged.is_some()
+                    }
+                    _ => false,
+                }),
+            TransitionFrontierSyncLedgerStagedAction::PartsPeerFetchInit => state
+                .transition_frontier
+                .sync
+                .ledger()
+                .and_then(|s| s.staged())
+                .map_or(false, |staged| {
+                    let iter = state.p2p.ready_rpc_peers_iter();
+                    staged.filter_available_peers(iter).next().is_some()
+                }),
+            TransitionFrontierSyncLedgerStagedAction::PartsPeerFetchPending { .. } => state
+                .transition_frontier
+                .sync
+                .ledger()
+                .and_then(|s| s.staged())
+                .map_or(false, |s| {
+                    matches!(
+                        s,
+                        TransitionFrontierSyncLedgerStagedState::PartsFetchPending { .. }
+                    )
+                }),
+            TransitionFrontierSyncLedgerStagedAction::PartsPeerFetchError {
+                peer_id,
+                rpc_id,
+                ..
+            } => state
+                .transition_frontier
+                .sync
+                .ledger()
+                .and_then(|s| s.staged()?.fetch_attempts()?.get(peer_id))
+                .and_then(|s| s.fetch_pending_rpc_id())
+                .map_or(false, |fetch_rpc_id| fetch_rpc_id == *rpc_id),
+            TransitionFrontierSyncLedgerStagedAction::PartsPeerFetchSuccess {
+                peer_id,
+                rpc_id,
+                ..
+            } => state
+                .transition_frontier
+                .sync
+                .ledger()
+                .and_then(|s| s.staged()?.fetch_attempts()?.get(peer_id))
+                .and_then(|s| s.fetch_pending_rpc_id())
+                .map_or(false, |fetch_rpc_id| fetch_rpc_id == *rpc_id),
+            TransitionFrontierSyncLedgerStagedAction::PartsPeerInvalid { sender, .. } => state
+                .transition_frontier
+                .sync
+                .ledger()
+                .and_then(|s| s.staged()?.fetch_attempts()?.get(sender))
+                .map_or(false, |s| match s {
+                    PeerStagedLedgerPartsFetchState::Success { parts, .. } => !parts.is_valid(),
+                    _ => false,
+                }),
+            TransitionFrontierSyncLedgerStagedAction::PartsPeerValid { sender } => state
+                .transition_frontier
+                .sync
+                .ledger()
+                .and_then(|s| s.staged()?.fetch_attempts()?.get(sender))
+                .map_or(false, |s| match s {
+                    PeerStagedLedgerPartsFetchState::Success { parts, .. } => parts.is_valid(),
+                    _ => false,
+                }),
+            TransitionFrontierSyncLedgerStagedAction::PartsFetchSuccess { sender } => state
+                .transition_frontier
+                .sync
+                .ledger()
+                .and_then(|s| s.staged()?.fetch_attempts()?.get(sender))
+                .map_or(false, |s| s.is_valid()),
+            TransitionFrontierSyncLedgerStagedAction::ReconstructEmpty => state
+                .transition_frontier
+                .sync
+                .ledger()
+                .and_then(|s| s.snarked())
+                .and_then(|s| match s {
+                    TransitionFrontierSyncLedgerSnarkedState::Success { target, .. } => {
+                        target.clone().with_staged()
+                    }
+                    _ => None,
+                })
+                .map_or(false, |target| {
+                    let hashes = &target.staged.hashes;
+                    let empty_hash = &[0; 32];
+                    target.snarked_ledger_hash == hashes.non_snark.ledger_hash
+                        && hashes.non_snark.aux_hash.as_ref() == empty_hash
+                        && hashes.non_snark.pending_coinbase_aux.as_ref() == empty_hash
+                    // TODO(binier): `pending_coinbase_hash` isn't empty hash.
+                    // Do we need to check it?
+                }),
+            TransitionFrontierSyncLedgerStagedAction::ReconstructInit => state
+                .transition_frontier
+                .sync
+                .ledger()
+                .and_then(|s| s.staged())
+                .map_or(false, |s| {
+                    matches!(
+                        s,
+                        TransitionFrontierSyncLedgerStagedState::PartsFetchSuccess { .. }
+                            | TransitionFrontierSyncLedgerStagedState::ReconstructEmpty { .. }
+                    )
+                }),
+            TransitionFrontierSyncLedgerStagedAction::ReconstructPending => state
+                .transition_frontier
+                .sync
+                .ledger()
+                .and_then(|s| s.staged())
+                .map_or(false, |s| {
+                    matches!(
+                        s,
+                        TransitionFrontierSyncLedgerStagedState::PartsFetchSuccess { .. }
+                            | TransitionFrontierSyncLedgerStagedState::ReconstructEmpty { .. }
+                    )
+                }),
+            TransitionFrontierSyncLedgerStagedAction::ReconstructError { .. } => state
+                .transition_frontier
+                .sync
+                .ledger()
+                .and_then(|s| s.staged())
+                .map_or(false, |s| {
+                    matches!(
+                        s,
+                        TransitionFrontierSyncLedgerStagedState::ReconstructPending { .. }
+                    )
+                }),
+            TransitionFrontierSyncLedgerStagedAction::ReconstructSuccess => state
+                .transition_frontier
+                .sync
+                .ledger()
+                .and_then(|s| s.staged())
+                .map_or(false, |s| {
+                    matches!(
+                        s,
+                        TransitionFrontierSyncLedgerStagedState::ReconstructPending { .. }
+                    )
+                }),
+            TransitionFrontierSyncLedgerStagedAction::Success => state
+                .transition_frontier
+                .sync
+                .ledger()
+                .and_then(|s| s.staged())
+                .map_or(false, |s| {
+                    matches!(
+                        s,
+                        TransitionFrontierSyncLedgerStagedState::ReconstructSuccess { .. }
+                    )
+                }),
+        }
     }
 }
 
@@ -343,31 +220,10 @@ use crate::transition_frontier::{
     TransitionFrontierAction,
 };
 
-macro_rules! impl_into_global_action {
-    ($a:ty) => {
-        impl From<$a> for crate::Action {
-            fn from(value: $a) -> Self {
-                Self::TransitionFrontier(TransitionFrontierAction::Sync(
-                    TransitionFrontierSyncAction::Ledger(
-                        TransitionFrontierSyncLedgerAction::Staged(value.into()),
-                    ),
-                ))
-            }
-        }
-    };
+impl From<TransitionFrontierSyncLedgerStagedAction> for crate::Action {
+    fn from(value: TransitionFrontierSyncLedgerStagedAction) -> Self {
+        Self::TransitionFrontier(TransitionFrontierAction::Sync(
+            TransitionFrontierSyncAction::Ledger(TransitionFrontierSyncLedgerAction::Staged(value)),
+        ))
+    }
 }
-
-impl_into_global_action!(TransitionFrontierSyncLedgerStagedPartsFetchPendingAction);
-impl_into_global_action!(TransitionFrontierSyncLedgerStagedPartsPeerFetchInitAction);
-impl_into_global_action!(TransitionFrontierSyncLedgerStagedPartsPeerFetchPendingAction);
-impl_into_global_action!(TransitionFrontierSyncLedgerStagedPartsPeerFetchErrorAction);
-impl_into_global_action!(TransitionFrontierSyncLedgerStagedPartsPeerFetchSuccessAction);
-impl_into_global_action!(TransitionFrontierSyncLedgerStagedPartsPeerInvalidAction);
-impl_into_global_action!(TransitionFrontierSyncLedgerStagedPartsPeerValidAction);
-impl_into_global_action!(TransitionFrontierSyncLedgerStagedPartsFetchSuccessAction);
-impl_into_global_action!(TransitionFrontierSyncLedgerStagedReconstructEmptyAction);
-impl_into_global_action!(TransitionFrontierSyncLedgerStagedReconstructInitAction);
-impl_into_global_action!(TransitionFrontierSyncLedgerStagedReconstructPendingAction);
-impl_into_global_action!(TransitionFrontierSyncLedgerStagedReconstructErrorAction);
-impl_into_global_action!(TransitionFrontierSyncLedgerStagedReconstructSuccessAction);
-impl_into_global_action!(TransitionFrontierSyncLedgerStagedSuccessAction);

--- a/node/src/transition_frontier/sync/ledger/staged/transition_frontier_sync_ledger_staged_effects.rs
+++ b/node/src/transition_frontier/sync/ledger/staged/transition_frontier_sync_ledger_staged_effects.rs
@@ -3,140 +3,111 @@ use redux::ActionMeta;
 use crate::p2p::channels::rpc::{P2pChannelsRpcAction, P2pRpcRequest};
 use crate::Store;
 
-use super::{
-    TransitionFrontierSyncLedgerStagedPartsFetchPendingAction,
-    TransitionFrontierSyncLedgerStagedPartsFetchSuccessAction,
-    TransitionFrontierSyncLedgerStagedPartsPeerFetchErrorAction,
-    TransitionFrontierSyncLedgerStagedPartsPeerFetchInitAction,
-    TransitionFrontierSyncLedgerStagedPartsPeerFetchPendingAction,
-    TransitionFrontierSyncLedgerStagedPartsPeerFetchSuccessAction,
-    TransitionFrontierSyncLedgerStagedPartsPeerInvalidAction,
-    TransitionFrontierSyncLedgerStagedPartsPeerValidAction,
-    TransitionFrontierSyncLedgerStagedReconstructEmptyAction,
-    TransitionFrontierSyncLedgerStagedReconstructErrorAction,
-    TransitionFrontierSyncLedgerStagedReconstructInitAction,
-    TransitionFrontierSyncLedgerStagedReconstructPendingAction,
-    TransitionFrontierSyncLedgerStagedReconstructSuccessAction,
-    TransitionFrontierSyncLedgerStagedService, TransitionFrontierSyncLedgerStagedSuccessAction,
-};
+use super::{TransitionFrontierSyncLedgerStagedAction, TransitionFrontierSyncLedgerStagedService};
 
-impl TransitionFrontierSyncLedgerStagedPartsFetchPendingAction {
-    pub fn effects<S: redux::Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        store.dispatch(TransitionFrontierSyncLedgerStagedPartsPeerFetchInitAction {});
-    }
-}
-
-impl TransitionFrontierSyncLedgerStagedPartsPeerFetchInitAction {
-    pub fn effects<S: redux::Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        let state = store.state();
-        let Some(staged_ledger) =
-            None.or_else(|| state.transition_frontier.sync.ledger()?.staged())
-        else {
-            return;
-        };
-        let block_hash = staged_ledger.target().staged.block_hash.clone();
-
-        let ready_peers = staged_ledger
-            .filter_available_peers(state.p2p.ready_rpc_peers_iter())
-            .collect::<Vec<_>>();
-
-        for (peer_id, rpc_id) in ready_peers {
-            // TODO(binier): maybe
-            if store.dispatch(P2pChannelsRpcAction::RequestSend {
-                peer_id,
-                id: rpc_id,
-                request: P2pRpcRequest::StagedLedgerAuxAndPendingCoinbasesAtBlock(
-                    block_hash.clone(),
-                ),
-            }) {
-                store.dispatch(
-                    TransitionFrontierSyncLedgerStagedPartsPeerFetchPendingAction {
-                        peer_id,
-                        rpc_id,
-                    },
-                );
-                break;
-            }
-        }
-    }
-}
-
-impl TransitionFrontierSyncLedgerStagedPartsPeerFetchErrorAction {
-    pub fn effects<S: redux::Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        store.dispatch(TransitionFrontierSyncLedgerStagedPartsPeerFetchInitAction {});
-    }
-}
-
-impl TransitionFrontierSyncLedgerStagedPartsPeerFetchSuccessAction {
-    pub fn effects<S: redux::Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        if !store.dispatch(TransitionFrontierSyncLedgerStagedPartsPeerValidAction {
-            sender: self.peer_id,
-        }) {
-            store.dispatch(TransitionFrontierSyncLedgerStagedPartsPeerInvalidAction {
-                sender: self.peer_id,
-                parts: self.parts,
-            });
-        }
-    }
-}
-
-impl TransitionFrontierSyncLedgerStagedPartsPeerInvalidAction {
-    pub fn effects<S: redux::Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        store.dispatch(TransitionFrontierSyncLedgerStagedPartsPeerFetchInitAction {});
-    }
-}
-
-impl TransitionFrontierSyncLedgerStagedPartsPeerValidAction {
-    pub fn effects<S: redux::Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        store.dispatch(TransitionFrontierSyncLedgerStagedPartsFetchSuccessAction {
-            sender: self.sender,
-        });
-    }
-}
-
-impl TransitionFrontierSyncLedgerStagedPartsFetchSuccessAction {
-    pub fn effects<S: redux::Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        store.dispatch(TransitionFrontierSyncLedgerStagedReconstructInitAction {});
-    }
-}
-
-impl TransitionFrontierSyncLedgerStagedReconstructEmptyAction {
-    pub fn effects<S: redux::Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        store.dispatch(TransitionFrontierSyncLedgerStagedReconstructInitAction {});
-    }
-}
-
-impl TransitionFrontierSyncLedgerStagedReconstructInitAction {
-    pub fn effects<S>(self, _: &ActionMeta, store: &mut Store<S>)
+impl TransitionFrontierSyncLedgerStagedAction {
+    pub fn effects<S: redux::Service>(self, _: &ActionMeta, store: &mut Store<S>)
     where
         S: TransitionFrontierSyncLedgerStagedService,
     {
-        let ledger_state = store.state().transition_frontier.sync.ledger();
-        let Some((target, parts)) = ledger_state.and_then(|s| s.staged()?.target_with_parts())
-        else {
-            return;
-        };
-        let snarked_ledger_hash = target.snarked_ledger_hash.clone();
-        let parts = parts.cloned();
-
-        store.dispatch(TransitionFrontierSyncLedgerStagedReconstructPendingAction {});
-
-        match store
-            .service
-            .staged_ledger_reconstruct(snarked_ledger_hash, parts)
-        {
-            Err(error) => {
-                store.dispatch(TransitionFrontierSyncLedgerStagedReconstructErrorAction { error });
+        match self {
+            TransitionFrontierSyncLedgerStagedAction::PartsFetchPending => {
+                store.dispatch(TransitionFrontierSyncLedgerStagedAction::PartsPeerFetchInit);
             }
-            Ok(_) => {
-                store.dispatch(TransitionFrontierSyncLedgerStagedReconstructSuccessAction {});
+            TransitionFrontierSyncLedgerStagedAction::PartsPeerFetchInit => {
+                let state = store.state();
+                let Some(staged_ledger) =
+                    None.or_else(|| state.transition_frontier.sync.ledger()?.staged())
+                else {
+                    return;
+                };
+                let block_hash = staged_ledger.target().staged.block_hash.clone();
+
+                let ready_peers = staged_ledger
+                    .filter_available_peers(state.p2p.ready_rpc_peers_iter())
+                    .collect::<Vec<_>>();
+
+                for (peer_id, rpc_id) in ready_peers {
+                    // TODO(binier): maybe
+                    if store.dispatch(P2pChannelsRpcAction::RequestSend {
+                        peer_id,
+                        id: rpc_id,
+                        request: P2pRpcRequest::StagedLedgerAuxAndPendingCoinbasesAtBlock(
+                            block_hash.clone(),
+                        ),
+                    }) {
+                        store.dispatch(
+                            TransitionFrontierSyncLedgerStagedAction::PartsPeerFetchPending {
+                                peer_id,
+                                rpc_id,
+                            },
+                        );
+                        break;
+                    }
+                }
             }
+            TransitionFrontierSyncLedgerStagedAction::PartsPeerFetchError { .. } => {
+                store.dispatch(TransitionFrontierSyncLedgerStagedAction::PartsPeerFetchInit);
+            }
+            TransitionFrontierSyncLedgerStagedAction::PartsPeerFetchSuccess {
+                peer_id,
+                parts,
+                ..
+            } => {
+                if !store.dispatch(TransitionFrontierSyncLedgerStagedAction::PartsPeerValid {
+                    sender: peer_id,
+                }) {
+                    store.dispatch(TransitionFrontierSyncLedgerStagedAction::PartsPeerInvalid {
+                        sender: peer_id,
+                        parts,
+                    });
+                }
+            }
+            TransitionFrontierSyncLedgerStagedAction::PartsPeerInvalid { .. } => {
+                store.dispatch(TransitionFrontierSyncLedgerStagedAction::PartsPeerFetchInit);
+            }
+            TransitionFrontierSyncLedgerStagedAction::PartsPeerValid { sender } => {
+                store.dispatch(
+                    TransitionFrontierSyncLedgerStagedAction::PartsFetchSuccess { sender },
+                );
+            }
+            TransitionFrontierSyncLedgerStagedAction::PartsFetchSuccess { .. } => {
+                store.dispatch(TransitionFrontierSyncLedgerStagedAction::ReconstructInit);
+            }
+            TransitionFrontierSyncLedgerStagedAction::ReconstructEmpty => {
+                store.dispatch(TransitionFrontierSyncLedgerStagedAction::ReconstructInit);
+            }
+            TransitionFrontierSyncLedgerStagedAction::ReconstructInit => {
+                let ledger_state = store.state().transition_frontier.sync.ledger();
+                let Some((target, parts)) =
+                    ledger_state.and_then(|s| s.staged()?.target_with_parts())
+                else {
+                    return;
+                };
+                let snarked_ledger_hash = target.snarked_ledger_hash.clone();
+                let parts = parts.cloned();
+
+                store.dispatch(TransitionFrontierSyncLedgerStagedAction::ReconstructPending);
+
+                match store
+                    .service
+                    .staged_ledger_reconstruct(snarked_ledger_hash, parts)
+                {
+                    Err(error) => {
+                        store.dispatch(
+                            TransitionFrontierSyncLedgerStagedAction::ReconstructError { error },
+                        );
+                    }
+                    Ok(_) => {
+                        store
+                            .dispatch(TransitionFrontierSyncLedgerStagedAction::ReconstructSuccess);
+                    }
+                }
+            }
+            TransitionFrontierSyncLedgerStagedAction::ReconstructSuccess => {
+                store.dispatch(TransitionFrontierSyncLedgerStagedAction::Success);
+            }
+            _ => {}
         }
-    }
-}
-
-impl TransitionFrontierSyncLedgerStagedReconstructSuccessAction {
-    pub fn effects<S: redux::Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        store.dispatch(TransitionFrontierSyncLedgerStagedSuccessAction {});
     }
 }

--- a/node/src/transition_frontier/sync/ledger/transition_frontier_sync_ledger_effects.rs
+++ b/node/src/transition_frontier/sync/ledger/transition_frontier_sync_ledger_effects.rs
@@ -2,34 +2,30 @@ use redux::ActionMeta;
 
 use crate::Store;
 
-use super::snarked::{
-    TransitionFrontierSyncLedgerSnarkedPendingAction,
-    TransitionFrontierSyncLedgerSnarkedSuccessAction,
-};
-use super::staged::{
-    TransitionFrontierSyncLedgerStagedPartsFetchPendingAction,
-    TransitionFrontierSyncLedgerStagedReconstructEmptyAction,
-    TransitionFrontierSyncLedgerStagedSuccessAction,
-};
-use super::{TransitionFrontierSyncLedgerInitAction, TransitionFrontierSyncLedgerSuccessAction};
+use super::snarked::TransitionFrontierSyncLedgerSnarkedAction;
+use super::staged::TransitionFrontierSyncLedgerStagedAction;
+use super::TransitionFrontierSyncLedgerAction;
 
-impl TransitionFrontierSyncLedgerInitAction {
-    pub fn effects<S: redux::Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        store.dispatch(TransitionFrontierSyncLedgerSnarkedPendingAction {});
+pub fn transition_frontier_sync_ledger_init_effects<S: redux::Service>(
+    _: &ActionMeta,
+    store: &mut Store<S>,
+) {
+    store.dispatch(TransitionFrontierSyncLedgerSnarkedAction::Pending);
+}
+
+pub fn transition_frontier_sync_ledger_snarked_success_effects<S: redux::Service>(
+    _: &ActionMeta,
+    store: &mut Store<S>,
+) {
+    if store.dispatch(TransitionFrontierSyncLedgerAction::Success) {
+    } else if store.dispatch(TransitionFrontierSyncLedgerStagedAction::ReconstructEmpty) {
+    } else if store.dispatch(TransitionFrontierSyncLedgerStagedAction::PartsFetchPending) {
     }
 }
 
-impl TransitionFrontierSyncLedgerSnarkedSuccessAction {
-    pub fn effects<S: redux::Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        if store.dispatch(TransitionFrontierSyncLedgerSuccessAction {}) {
-        } else if store.dispatch(TransitionFrontierSyncLedgerStagedReconstructEmptyAction {}) {
-        } else if store.dispatch(TransitionFrontierSyncLedgerStagedPartsFetchPendingAction {}) {
-        }
-    }
-}
-
-impl TransitionFrontierSyncLedgerStagedSuccessAction {
-    pub fn effects<S: redux::Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        store.dispatch(TransitionFrontierSyncLedgerSuccessAction {});
-    }
+pub fn transition_frontier_sync_ledger_staged_success_effects<S: redux::Service>(
+    _: &ActionMeta,
+    store: &mut Store<S>,
+) {
+    store.dispatch(TransitionFrontierSyncLedgerAction::Success);
 }

--- a/node/src/transition_frontier/sync/ledger/transition_frontier_sync_ledger_reducer.rs
+++ b/node/src/transition_frontier/sync/ledger/transition_frontier_sync_ledger_reducer.rs
@@ -13,9 +13,9 @@ impl TransitionFrontierSyncLedgerState {
     pub fn reducer(&mut self, action: TransitionFrontierSyncLedgerActionWithMetaRef<'_>) {
         let (action, meta) = action.split();
         match action {
-            TransitionFrontierSyncLedgerAction::Init(_) => {}
+            TransitionFrontierSyncLedgerAction::Init => {}
             TransitionFrontierSyncLedgerAction::Snarked(action) => {
-                if let TransitionFrontierSyncLedgerSnarkedAction::Pending(_) = action {
+                if let TransitionFrontierSyncLedgerSnarkedAction::Pending = action {
                     let Self::Init { target, .. } = self else {
                         return;
                     };
@@ -30,7 +30,7 @@ impl TransitionFrontierSyncLedgerState {
                 }
             }
             TransitionFrontierSyncLedgerAction::Staged(action) => {
-                if let TransitionFrontierSyncLedgerStagedAction::PartsFetchPending(_) = action {
+                if let TransitionFrontierSyncLedgerStagedAction::PartsFetchPending = action {
                     let Self::Snarked(TransitionFrontierSyncLedgerSnarkedState::Success {
                         target,
                         ..
@@ -50,7 +50,7 @@ impl TransitionFrontierSyncLedgerState {
                             ..
                         }) if matches!(
                             action,
-                            TransitionFrontierSyncLedgerStagedAction::ReconstructEmpty(_)
+                            TransitionFrontierSyncLedgerStagedAction::ReconstructEmpty
                         ) =>
                         {
                             let s = TransitionFrontierSyncLedgerStagedState::ReconstructEmpty {
@@ -64,7 +64,7 @@ impl TransitionFrontierSyncLedgerState {
                     }
                 }
             }
-            TransitionFrontierSyncLedgerAction::Success(_) => {
+            TransitionFrontierSyncLedgerAction::Success => {
                 match self {
                     Self::Staged(TransitionFrontierSyncLedgerStagedState::Success {
                         target,

--- a/node/src/transition_frontier/sync/transition_frontier_sync_effects.rs
+++ b/node/src/transition_frontier/sync/transition_frontier_sync_effects.rs
@@ -8,240 +8,185 @@ use crate::Store;
 use super::ledger::snarked::TransitionFrontierSyncLedgerSnarkedAction;
 use super::ledger::staged::TransitionFrontierSyncLedgerStagedAction;
 use super::ledger::TransitionFrontierSyncLedgerAction;
-use super::{
-    TransitionFrontierSyncBestTipUpdateAction, TransitionFrontierSyncBlocksFetchSuccessAction,
-    TransitionFrontierSyncBlocksNextApplyInitAction,
-    TransitionFrontierSyncBlocksNextApplyPendingAction,
-    TransitionFrontierSyncBlocksNextApplySuccessAction,
-    TransitionFrontierSyncBlocksPeerQueryErrorAction,
-    TransitionFrontierSyncBlocksPeerQueryInitAction,
-    TransitionFrontierSyncBlocksPeerQueryPendingAction,
-    TransitionFrontierSyncBlocksPeerQueryRetryAction,
-    TransitionFrontierSyncBlocksPeerQuerySuccessAction,
-    TransitionFrontierSyncBlocksPeersQueryAction, TransitionFrontierSyncBlocksPendingAction,
-    TransitionFrontierSyncBlocksSuccessAction, TransitionFrontierSyncInitAction,
-    TransitionFrontierSyncLedgerNextEpochPendingAction,
-    TransitionFrontierSyncLedgerNextEpochSuccessAction,
-    TransitionFrontierSyncLedgerRootPendingAction, TransitionFrontierSyncLedgerRootSuccessAction,
-    TransitionFrontierSyncLedgerStakingPendingAction,
-    TransitionFrontierSyncLedgerStakingSuccessAction,
-};
+use super::TransitionFrontierSyncAction;
 
-impl TransitionFrontierSyncInitAction {
-    pub fn effects<S: redux::Service>(&self, _: &ActionMeta, store: &mut Store<S>) {
-        store.dispatch(TransitionFrontierSyncLedgerStakingPendingAction {});
-    }
-}
-
-impl TransitionFrontierSyncBestTipUpdateAction {
-    pub fn effects<S: redux::Service>(&self, _: &ActionMeta, store: &mut Store<S>) {
-        // if root snarked ledger changed.
-        store.dispatch(TransitionFrontierSyncLedgerAction::Init);
-        // if root snarked ledger stayed same but root block changed
-        // while reconstructing staged ledger.
-        store.dispatch(TransitionFrontierSyncLedgerStagedAction::PartsFetchPending);
-        store.dispatch(TransitionFrontierSyncLedgerSnarkedAction::PeersQuery);
-        // if we don't need to sync root staged ledger.
-        store.dispatch(TransitionFrontierSyncBlocksPeersQueryAction {});
-        // if we already have a block ready to be applied.
-        store.dispatch(TransitionFrontierSyncBlocksNextApplyInitAction {});
-
-        // TODO(binier): cleanup ledgers
-    }
-}
-
-impl TransitionFrontierSyncLedgerStakingPendingAction {
-    pub fn effects<S: redux::Service>(&self, _: &ActionMeta, store: &mut Store<S>) {
-        store.dispatch(TransitionFrontierSyncLedgerAction::Init);
-    }
-}
-
-impl TransitionFrontierSyncLedgerStakingSuccessAction {
-    pub fn effects<S: redux::Service>(&self, _: &ActionMeta, store: &mut Store<S>) {
-        if store.dispatch(TransitionFrontierSyncLedgerNextEpochPendingAction {}) {
-        } else if store.dispatch(TransitionFrontierSyncLedgerRootPendingAction {}) {
-        }
-    }
-}
-
-impl TransitionFrontierSyncLedgerNextEpochPendingAction {
-    pub fn effects<S: redux::Service>(&self, _: &ActionMeta, store: &mut Store<S>) {
-        store.dispatch(TransitionFrontierSyncLedgerAction::Init);
-    }
-}
-
-impl TransitionFrontierSyncLedgerNextEpochSuccessAction {
-    pub fn effects<S: redux::Service>(&self, _: &ActionMeta, store: &mut Store<S>) {
-        store.dispatch(TransitionFrontierSyncLedgerRootPendingAction {});
-    }
-}
-
-impl TransitionFrontierSyncLedgerRootPendingAction {
-    pub fn effects<S: redux::Service>(&self, _: &ActionMeta, store: &mut Store<S>) {
-        store.dispatch(TransitionFrontierSyncLedgerAction::Init);
-    }
-}
-
-impl TransitionFrontierSyncLedgerRootSuccessAction {
-    pub fn effects<S: redux::Service>(&self, _: &ActionMeta, store: &mut Store<S>) {
-        store.dispatch(TransitionFrontierSyncBlocksPendingAction {});
-    }
-}
-
-impl TransitionFrontierSyncBlocksPendingAction {
-    pub fn effects<S: redux::Service>(&self, _: &ActionMeta, store: &mut Store<S>) {
-        if !store.dispatch(TransitionFrontierSyncBlocksSuccessAction {}) {
-            store.dispatch(TransitionFrontierSyncBlocksPeersQueryAction {});
-        }
-    }
-}
-
-impl TransitionFrontierSyncBlocksPeersQueryAction {
-    pub fn effects<S: redux::Service>(&self, _: &ActionMeta, store: &mut Store<S>) {
-        // TODO(binier): make sure they have the ledger we want to query.
-        let mut peer_ids = store
-            .state()
-            .p2p
-            .ready_peers_iter()
-            .filter(|(_, p)| p.channels.rpc.can_send_request())
-            .map(|(id, p)| (*id, p.connected_since))
-            .collect::<Vec<_>>();
-        peer_ids.sort_by(|(_, t1), (_, t2)| t2.cmp(t1));
-
-        let mut retry_hashes = store
-            .state()
-            .transition_frontier
-            .sync
-            .blocks_fetch_retry_iter()
-            .collect::<Vec<_>>();
-        retry_hashes.reverse();
-
-        for (peer_id, _) in peer_ids {
-            if let Some(hash) = retry_hashes.last() {
-                if store.dispatch(TransitionFrontierSyncBlocksPeerQueryRetryAction {
-                    peer_id,
-                    hash: hash.clone(),
-                }) {
-                    retry_hashes.pop();
-                    continue;
-                }
-            }
-
-            match store.state().transition_frontier.sync.blocks_fetch_next() {
-                Some(hash) => {
-                    store.dispatch(TransitionFrontierSyncBlocksPeerQueryInitAction {
-                        peer_id,
-                        hash,
-                    });
-                }
-                None if retry_hashes.is_empty() => break,
-                None => {}
-            }
-        }
-    }
-}
-
-impl TransitionFrontierSyncBlocksPeerQueryInitAction {
-    pub fn effects<S: redux::Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        let Some(rpc_id) = store
-            .state()
-            .p2p
-            .get_ready_peer(&self.peer_id)
-            .map(|v| v.channels.rpc.next_local_rpc_id())
-        else {
-            return;
-        };
-
-        if store.dispatch(P2pChannelsRpcAction::RequestSend {
-            peer_id: self.peer_id,
-            id: rpc_id,
-            request: P2pRpcRequest::Block(self.hash.clone()),
-        }) {
-            store.dispatch(TransitionFrontierSyncBlocksPeerQueryPendingAction {
-                hash: self.hash,
-                peer_id: self.peer_id,
-                rpc_id,
-            });
-        }
-    }
-}
-
-impl TransitionFrontierSyncBlocksPeerQueryRetryAction {
-    pub fn effects<S: redux::Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        let Some(rpc_id) = store
-            .state()
-            .p2p
-            .get_ready_peer(&self.peer_id)
-            .map(|v| v.channels.rpc.next_local_rpc_id())
-        else {
-            return;
-        };
-
-        if store.dispatch(P2pChannelsRpcAction::RequestSend {
-            peer_id: self.peer_id,
-            id: rpc_id,
-            request: P2pRpcRequest::Block(self.hash.clone()),
-        }) {
-            store.dispatch(TransitionFrontierSyncBlocksPeerQueryPendingAction {
-                hash: self.hash,
-                peer_id: self.peer_id,
-                rpc_id,
-            });
-        }
-    }
-}
-
-impl TransitionFrontierSyncBlocksPeerQueryErrorAction {
-    pub fn effects<S: redux::Service>(&self, _: &ActionMeta, store: &mut Store<S>) {
-        store.dispatch(TransitionFrontierSyncBlocksPeersQueryAction {});
-    }
-}
-
-impl TransitionFrontierSyncBlocksPeerQuerySuccessAction {
-    pub fn effects<S: redux::Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        store.dispatch(TransitionFrontierSyncBlocksPeersQueryAction {});
-        store.dispatch(TransitionFrontierSyncBlocksFetchSuccessAction {
-            hash: self.response.hash,
-        });
-    }
-}
-
-impl TransitionFrontierSyncBlocksFetchSuccessAction {
-    pub fn effects<S: redux::Service>(&self, _: &ActionMeta, store: &mut Store<S>) {
-        let _ = store;
-        // TODO(binier): uncomment once ledger communication is async.
-        // store.dispatch(TransitionFrontierSyncBlocksNextApplyInitAction {});
-    }
-}
-
-impl TransitionFrontierSyncBlocksNextApplyInitAction {
-    pub fn effects<S>(&self, _: &ActionMeta, store: &mut Store<S>)
+impl TransitionFrontierSyncAction {
+    pub fn effects<S: redux::Service>(&self, _: &ActionMeta, store: &mut Store<S>)
     where
         S: TransitionFrontierService,
     {
-        let Some((block, pred_block)) = store
-            .state()
-            .transition_frontier
-            .sync
-            .blocks_apply_next()
-            .map(|v| (v.0.clone(), v.1.clone()))
-        else {
-            return;
-        };
-        let hash = block.hash.clone();
+        match self {
+            TransitionFrontierSyncAction::Init { .. } => {
+                store.dispatch(TransitionFrontierSyncAction::LedgerStakingPending);
+            }
+            TransitionFrontierSyncAction::BestTipUpdate { .. } => {
+                // if root snarked ledger changed.
+                store.dispatch(TransitionFrontierSyncLedgerAction::Init);
+                // if root snarked ledger stayed same but root block changed
+                // while reconstructing staged ledger.
+                store.dispatch(TransitionFrontierSyncLedgerStagedAction::PartsFetchPending);
+                store.dispatch(TransitionFrontierSyncLedgerSnarkedAction::PeersQuery);
+                // if we don't need to sync root staged ledger.
+                store.dispatch(TransitionFrontierSyncAction::BlocksPeersQuery);
+                // if we already have a block ready to be applied.
+                store.dispatch(TransitionFrontierSyncAction::BlocksNextApplyInit);
 
-        store.dispatch(TransitionFrontierSyncBlocksNextApplyPendingAction { hash: hash.clone() });
-        store.service.block_apply(block, pred_block).unwrap();
+                // TODO(binier): cleanup ledgers
+            }
+            TransitionFrontierSyncAction::LedgerStakingPending => {
+                store.dispatch(TransitionFrontierSyncLedgerAction::Init);
+            }
+            TransitionFrontierSyncAction::LedgerStakingSuccess => {
+                if store.dispatch(TransitionFrontierSyncAction::LedgerNextEpochPending) {
+                } else if store.dispatch(TransitionFrontierSyncAction::LedgerRootPending) {
+                }
+            }
+            TransitionFrontierSyncAction::LedgerNextEpochPending => {
+                store.dispatch(TransitionFrontierSyncLedgerAction::Init);
+            }
+            TransitionFrontierSyncAction::LedgerNextEpochSuccess => {
+                store.dispatch(TransitionFrontierSyncAction::LedgerRootPending);
+            }
+            TransitionFrontierSyncAction::LedgerRootPending => {
+                store.dispatch(TransitionFrontierSyncLedgerAction::Init);
+            }
+            TransitionFrontierSyncAction::LedgerRootSuccess => {
+                store.dispatch(TransitionFrontierSyncAction::BlocksPending);
+            }
+            TransitionFrontierSyncAction::BlocksPending => {
+                if !store.dispatch(TransitionFrontierSyncAction::BlocksSuccess) {
+                    store.dispatch(TransitionFrontierSyncAction::BlocksPeersQuery);
+                }
+            }
+            TransitionFrontierSyncAction::BlocksPeersQuery => {
+                // TODO(binier): make sure they have the ledger we want to query.
+                let mut peer_ids = store
+                    .state()
+                    .p2p
+                    .ready_peers_iter()
+                    .filter(|(_, p)| p.channels.rpc.can_send_request())
+                    .map(|(id, p)| (*id, p.connected_since))
+                    .collect::<Vec<_>>();
+                peer_ids.sort_by(|(_, t1), (_, t2)| t2.cmp(t1));
 
-        store.dispatch(TransitionFrontierSyncBlocksNextApplySuccessAction { hash });
-    }
-}
+                let mut retry_hashes = store
+                    .state()
+                    .transition_frontier
+                    .sync
+                    .blocks_fetch_retry_iter()
+                    .collect::<Vec<_>>();
+                retry_hashes.reverse();
 
-impl TransitionFrontierSyncBlocksNextApplySuccessAction {
-    pub fn effects<S: redux::Service>(self, _: &ActionMeta, store: &mut Store<S>) {
-        // TODO(binier): uncomment once ledger communication is async.
-        // if !store.dispatch(TransitionFrontierSyncBlockNextApplyInitAction {}) {
-        store.dispatch(TransitionFrontierSyncBlocksSuccessAction {});
-        // }
+                for (peer_id, _) in peer_ids {
+                    if let Some(hash) = retry_hashes.last() {
+                        if store.dispatch(TransitionFrontierSyncAction::BlocksPeerQueryRetry {
+                            peer_id,
+                            hash: hash.clone(),
+                        }) {
+                            retry_hashes.pop();
+                            continue;
+                        }
+                    }
+
+                    match store.state().transition_frontier.sync.blocks_fetch_next() {
+                        Some(hash) => {
+                            store.dispatch(TransitionFrontierSyncAction::BlocksPeerQueryInit {
+                                peer_id,
+                                hash,
+                            });
+                        }
+                        None if retry_hashes.is_empty() => break,
+                        None => {}
+                    }
+                }
+            }
+            TransitionFrontierSyncAction::BlocksPeerQueryInit { hash, peer_id } => {
+                let Some(rpc_id) = store
+                    .state()
+                    .p2p
+                    .get_ready_peer(peer_id)
+                    .map(|v| v.channels.rpc.next_local_rpc_id())
+                else {
+                    return;
+                };
+
+                if store.dispatch(P2pChannelsRpcAction::RequestSend {
+                    peer_id: *peer_id,
+                    id: rpc_id,
+                    request: P2pRpcRequest::Block(hash.clone()),
+                }) {
+                    store.dispatch(TransitionFrontierSyncAction::BlocksPeerQueryPending {
+                        hash: hash.clone(),
+                        peer_id: *peer_id,
+                        rpc_id,
+                    });
+                }
+            }
+            TransitionFrontierSyncAction::BlocksPeerQueryRetry { hash, peer_id } => {
+                let Some(rpc_id) = store
+                    .state()
+                    .p2p
+                    .get_ready_peer(peer_id)
+                    .map(|v| v.channels.rpc.next_local_rpc_id())
+                else {
+                    return;
+                };
+
+                if store.dispatch(P2pChannelsRpcAction::RequestSend {
+                    peer_id: *peer_id,
+                    id: rpc_id,
+                    request: P2pRpcRequest::Block(hash.clone()),
+                }) {
+                    store.dispatch(TransitionFrontierSyncAction::BlocksPeerQueryPending {
+                        hash: hash.clone(),
+                        peer_id: *peer_id,
+                        rpc_id,
+                    });
+                }
+            }
+            TransitionFrontierSyncAction::BlocksPeerQueryPending { .. } => {}
+            TransitionFrontierSyncAction::BlocksPeerQueryError { .. } => {
+                store.dispatch(TransitionFrontierSyncAction::BlocksPeersQuery);
+            }
+            TransitionFrontierSyncAction::BlocksPeerQuerySuccess { response, .. } => {
+                store.dispatch(TransitionFrontierSyncAction::BlocksPeersQuery);
+                store.dispatch(TransitionFrontierSyncAction::BlocksFetchSuccess {
+                    hash: response.hash.clone(),
+                });
+            }
+            TransitionFrontierSyncAction::BlocksFetchSuccess { .. } => {
+                let _ = store;
+                // TODO(binier): uncomment once ledger communication is async.
+                // store.dispatch(TransitionFrontierSyncBlocksNextApplyInitAction {});
+            }
+            TransitionFrontierSyncAction::BlocksNextApplyInit => {
+                let Some((block, pred_block)) = store
+                    .state()
+                    .transition_frontier
+                    .sync
+                    .blocks_apply_next()
+                    .map(|v| (v.0.clone(), v.1.clone()))
+                else {
+                    return;
+                };
+                let hash = block.hash.clone();
+
+                store.dispatch(TransitionFrontierSyncAction::BlocksNextApplyPending {
+                    hash: hash.clone(),
+                });
+                store.service.block_apply(block, pred_block).unwrap();
+
+                store.dispatch(TransitionFrontierSyncAction::BlocksNextApplySuccess { hash });
+            }
+            TransitionFrontierSyncAction::BlocksNextApplyPending { .. } => {}
+            TransitionFrontierSyncAction::BlocksNextApplySuccess { .. } => {
+                // TODO(binier): uncomment once ledger communication is async.
+                // if !store.dispatch(TransitionFrontierSyncAction::BlockNextApplyInit) {
+                store.dispatch(TransitionFrontierSyncAction::BlocksSuccess);
+                // }
+            }
+            TransitionFrontierSyncAction::BlocksSuccess => {}
+            TransitionFrontierSyncAction::Ledger(_) => {}
+        }
     }
 }

--- a/node/src/transition_frontier/sync/transition_frontier_sync_effects.rs
+++ b/node/src/transition_frontier/sync/transition_frontier_sync_effects.rs
@@ -5,9 +5,9 @@ use crate::p2p::channels::rpc::P2pRpcRequest;
 use crate::transition_frontier::TransitionFrontierService;
 use crate::Store;
 
-use super::ledger::snarked::TransitionFrontierSyncLedgerSnarkedPeersQueryAction;
-use super::ledger::staged::TransitionFrontierSyncLedgerStagedPartsFetchPendingAction;
-use super::ledger::TransitionFrontierSyncLedgerInitAction;
+use super::ledger::snarked::TransitionFrontierSyncLedgerSnarkedAction;
+use super::ledger::staged::TransitionFrontierSyncLedgerStagedAction;
+use super::ledger::TransitionFrontierSyncLedgerAction;
 use super::{
     TransitionFrontierSyncBestTipUpdateAction, TransitionFrontierSyncBlocksFetchSuccessAction,
     TransitionFrontierSyncBlocksNextApplyInitAction,
@@ -36,11 +36,11 @@ impl TransitionFrontierSyncInitAction {
 impl TransitionFrontierSyncBestTipUpdateAction {
     pub fn effects<S: redux::Service>(&self, _: &ActionMeta, store: &mut Store<S>) {
         // if root snarked ledger changed.
-        store.dispatch(TransitionFrontierSyncLedgerInitAction {});
+        store.dispatch(TransitionFrontierSyncLedgerAction::Init);
         // if root snarked ledger stayed same but root block changed
         // while reconstructing staged ledger.
-        store.dispatch(TransitionFrontierSyncLedgerStagedPartsFetchPendingAction {});
-        store.dispatch(TransitionFrontierSyncLedgerSnarkedPeersQueryAction {});
+        store.dispatch(TransitionFrontierSyncLedgerStagedAction::PartsFetchPending);
+        store.dispatch(TransitionFrontierSyncLedgerSnarkedAction::PeersQuery);
         // if we don't need to sync root staged ledger.
         store.dispatch(TransitionFrontierSyncBlocksPeersQueryAction {});
         // if we already have a block ready to be applied.
@@ -52,7 +52,7 @@ impl TransitionFrontierSyncBestTipUpdateAction {
 
 impl TransitionFrontierSyncLedgerStakingPendingAction {
     pub fn effects<S: redux::Service>(&self, _: &ActionMeta, store: &mut Store<S>) {
-        store.dispatch(TransitionFrontierSyncLedgerInitAction {});
+        store.dispatch(TransitionFrontierSyncLedgerAction::Init);
     }
 }
 
@@ -66,7 +66,7 @@ impl TransitionFrontierSyncLedgerStakingSuccessAction {
 
 impl TransitionFrontierSyncLedgerNextEpochPendingAction {
     pub fn effects<S: redux::Service>(&self, _: &ActionMeta, store: &mut Store<S>) {
-        store.dispatch(TransitionFrontierSyncLedgerInitAction {});
+        store.dispatch(TransitionFrontierSyncLedgerAction::Init);
     }
 }
 
@@ -78,7 +78,7 @@ impl TransitionFrontierSyncLedgerNextEpochSuccessAction {
 
 impl TransitionFrontierSyncLedgerRootPendingAction {
     pub fn effects<S: redux::Service>(&self, _: &ActionMeta, store: &mut Store<S>) {
-        store.dispatch(TransitionFrontierSyncLedgerInitAction {});
+        store.dispatch(TransitionFrontierSyncLedgerAction::Init);
     }
 }
 

--- a/node/src/transition_frontier/sync/transition_frontier_sync_reducer.rs
+++ b/node/src/transition_frontier/sync/transition_frontier_sync_reducer.rs
@@ -24,27 +24,34 @@ impl TransitionFrontierSyncState {
     ) {
         let (action, meta) = action.split();
         match action {
-            TransitionFrontierSyncAction::Init(a) => {
+            TransitionFrontierSyncAction::Init {
+                best_tip,
+                root_block,
+                blocks_inbetween,
+            } => {
                 *self = Self::Init {
                     time: meta.time(),
-                    best_tip: a.best_tip.clone(),
-                    root_block: a.root_block.clone(),
-                    blocks_inbetween: a.blocks_inbetween.clone(),
+                    best_tip: best_tip.clone(),
+                    root_block: root_block.clone(),
+                    blocks_inbetween: blocks_inbetween.clone(),
                 };
             }
             // TODO(binier): refactor
-            TransitionFrontierSyncAction::BestTipUpdate(a) => match self {
+            TransitionFrontierSyncAction::BestTipUpdate {
+                best_tip,
+                root_block,
+                blocks_inbetween,
+            } => match self {
                 Self::StakingLedgerPending(state)
                 | Self::NextEpochLedgerPending(state)
                 | Self::RootLedgerPending(state) => {
                     state.time = meta.time();
-                    state.root_block = a.root_block.clone();
-                    state.blocks_inbetween = a.blocks_inbetween.clone();
-                    let old_best_tip = std::mem::replace(&mut state.best_tip, a.best_tip.clone());
+                    state.root_block = root_block.clone();
+                    state.blocks_inbetween = blocks_inbetween.clone();
+                    let old_best_tip = std::mem::replace(&mut state.best_tip, best_tip.clone());
 
-                    let staking_epoch_target = SyncLedgerTarget::staking_epoch(&a.best_tip);
-                    let next_epoch_target =
-                        SyncLedgerTarget::next_epoch(&a.best_tip, &a.root_block);
+                    let staking_epoch_target = SyncLedgerTarget::staking_epoch(best_tip);
+                    let next_epoch_target = SyncLedgerTarget::next_epoch(best_tip, root_block);
 
                     let new_target = if let Self::StakingLedgerPending(state) = self {
                         state
@@ -69,13 +76,13 @@ impl TransitionFrontierSyncState {
                             Some((state, staking_epoch_target))
                         } else if let Some(next_epoch_target) = next_epoch_target.filter(|_| {
                             old_best_tip.next_epoch_ledger_hash()
-                                != a.best_tip.next_epoch_ledger_hash()
+                                != best_tip.next_epoch_ledger_hash()
                         }) {
                             Some((state, next_epoch_target))
                         } else {
                             state
                                 .ledger
-                                .update_target(meta.time(), SyncLedgerTarget::root(&a.root_block));
+                                .update_target(meta.time(), SyncLedgerTarget::root(root_block));
                             None
                         }
                     } else {
@@ -111,8 +118,8 @@ impl TransitionFrontierSyncState {
                     let old_chain = VecDeque::from(std::mem::take(chain));
                     let old_root = old_chain.front().and_then(|b| b.block()).unwrap().clone();
                     let old_best_tip = old_chain.back().and_then(|b| b.block()).unwrap().clone();
-                    let new_root = &a.root_block;
-                    let new_best_tip = &a.best_tip;
+                    let new_root = root_block;
+                    let new_best_tip = best_tip;
 
                     let old_chain_has_new_root_applied = old_chain
                         .iter()
@@ -162,7 +169,7 @@ impl TransitionFrontierSyncState {
                         };
 
                         push_block(new_root.hash(), Some(new_root));
-                        for hash in &a.blocks_inbetween {
+                        for hash in blocks_inbetween {
                             push_block(hash, None);
                         }
                         push_block(new_best_tip.hash(), Some(new_best_tip));
@@ -183,7 +190,7 @@ impl TransitionFrontierSyncState {
                             &old_root,
                             new_best_tip,
                             new_root,
-                            &a.blocks_inbetween,
+                            blocks_inbetween,
                         );
                     }
                 }
@@ -193,12 +200,12 @@ impl TransitionFrontierSyncState {
 
                     let old_best_tip = best_chain.last().unwrap();
                     let old_root = best_chain.first().unwrap();
-                    let new_best_tip = &a.best_tip;
-                    let new_root = &a.root_block;
+                    let new_best_tip = best_tip;
+                    let new_root = root_block;
 
                     if applied_blocks.contains_key(&new_root.hash) {
-                        let chain = std::iter::once(a.root_block.hash())
-                            .chain(&a.blocks_inbetween)
+                        let chain = std::iter::once(root_block.hash())
+                            .chain(blocks_inbetween)
                             .chain(std::iter::once(new_best_tip.hash()))
                             .map(|hash| match applied_blocks.get(hash) {
                                 Some(&block) => TransitionFrontierSyncBlockState::ApplySuccess {
@@ -233,13 +240,13 @@ impl TransitionFrontierSyncState {
                             old_root,
                             new_best_tip,
                             new_root,
-                            &a.blocks_inbetween,
+                            blocks_inbetween,
                         );
                     }
                 }
                 _ => return,
             },
-            TransitionFrontierSyncAction::LedgerStakingPending(_) => {
+            TransitionFrontierSyncAction::LedgerStakingPending => {
                 if let Self::Init {
                     best_tip,
                     root_block,
@@ -259,7 +266,7 @@ impl TransitionFrontierSyncState {
                     });
                 }
             }
-            TransitionFrontierSyncAction::LedgerStakingSuccess(_) => {
+            TransitionFrontierSyncAction::LedgerStakingSuccess => {
                 if let Self::StakingLedgerPending(state) = self {
                     let TransitionFrontierSyncLedgerState::Success {
                         needed_protocol_states,
@@ -277,7 +284,7 @@ impl TransitionFrontierSyncState {
                     };
                 }
             }
-            TransitionFrontierSyncAction::LedgerNextEpochPending(_) => {
+            TransitionFrontierSyncAction::LedgerNextEpochPending => {
                 if let Self::StakingLedgerSuccess {
                     best_tip,
                     root_block,
@@ -300,7 +307,7 @@ impl TransitionFrontierSyncState {
                     });
                 }
             }
-            TransitionFrontierSyncAction::LedgerNextEpochSuccess(_) => {
+            TransitionFrontierSyncAction::LedgerNextEpochSuccess => {
                 if let Self::NextEpochLedgerPending(state) = self {
                     let TransitionFrontierSyncLedgerState::Success {
                         needed_protocol_states,
@@ -318,7 +325,7 @@ impl TransitionFrontierSyncState {
                     };
                 }
             }
-            TransitionFrontierSyncAction::LedgerRootPending(_) => {
+            TransitionFrontierSyncAction::LedgerRootPending => {
                 let (best_tip, root_block, blocks_inbetween) = match self {
                     Self::StakingLedgerSuccess {
                         best_tip,
@@ -345,7 +352,7 @@ impl TransitionFrontierSyncState {
                     },
                 });
             }
-            TransitionFrontierSyncAction::LedgerRootSuccess(_) => {
+            TransitionFrontierSyncAction::LedgerRootSuccess => {
                 if let Self::RootLedgerPending(state) = self {
                     let TransitionFrontierSyncLedgerState::Success {
                         needed_protocol_states,
@@ -363,7 +370,7 @@ impl TransitionFrontierSyncState {
                     };
                 }
             }
-            TransitionFrontierSyncAction::BlocksPending(_) => {
+            TransitionFrontierSyncAction::BlocksPending => {
                 let Self::RootLedgerSuccess {
                     best_tip,
                     root_block,
@@ -425,67 +432,77 @@ impl TransitionFrontierSyncState {
                     needed_protocol_states: std::mem::take(needed_protocol_states),
                 };
             }
-            TransitionFrontierSyncAction::BlocksPeersQuery(_) => {}
-            TransitionFrontierSyncAction::BlocksPeerQueryInit(a) => {
-                let Some(block_state) = self.block_state_mut(&a.hash) else {
+            TransitionFrontierSyncAction::BlocksPeersQuery => {}
+            TransitionFrontierSyncAction::BlocksPeerQueryInit { hash, peer_id } => {
+                let Some(block_state) = self.block_state_mut(hash) else {
                     return;
                 };
                 let Some(attempts) = block_state.fetch_pending_attempts_mut() else {
                     return;
                 };
-                attempts.insert(a.peer_id.clone(), PeerRpcState::Init { time: meta.time() });
+                attempts.insert(peer_id.clone(), PeerRpcState::Init { time: meta.time() });
             }
-            TransitionFrontierSyncAction::BlocksPeerQueryRetry(a) => {
-                let Some(block_state) = self.block_state_mut(&a.hash) else {
+            TransitionFrontierSyncAction::BlocksPeerQueryRetry { hash, peer_id } => {
+                let Some(block_state) = self.block_state_mut(hash) else {
                     return;
                 };
                 let Some(attempts) = block_state.fetch_pending_attempts_mut() else {
                     return;
                 };
-                attempts.insert(a.peer_id.clone(), PeerRpcState::Init { time: meta.time() });
+                attempts.insert(peer_id.clone(), PeerRpcState::Init { time: meta.time() });
             }
-            TransitionFrontierSyncAction::BlocksPeerQueryPending(a) => {
-                let Some(block_state) = self.block_state_mut(&a.hash) else {
+            TransitionFrontierSyncAction::BlocksPeerQueryPending {
+                hash,
+                peer_id,
+                rpc_id,
+            } => {
+                let Some(block_state) = self.block_state_mut(hash) else {
                     return;
                 };
-                let Some(peer_state) = block_state.fetch_pending_from_peer_mut(&a.peer_id) else {
+                let Some(peer_state) = block_state.fetch_pending_from_peer_mut(peer_id) else {
                     return;
                 };
                 *peer_state = PeerRpcState::Pending {
                     time: meta.time(),
-                    rpc_id: a.rpc_id,
+                    rpc_id: *rpc_id,
                 };
             }
-            TransitionFrontierSyncAction::BlocksPeerQueryError(a) => {
+            TransitionFrontierSyncAction::BlocksPeerQueryError {
+                peer_id,
+                rpc_id,
+                error,
+            } => {
                 let Self::BlocksPending { chain, .. } = self else {
                     return;
                 };
                 let Some(peer_state) = chain
                     .iter_mut()
-                    .find_map(|b| b.fetch_pending_from_peer_mut(&a.peer_id))
+                    .find_map(|b| b.fetch_pending_from_peer_mut(peer_id))
                 else {
                     return;
                 };
                 *peer_state = PeerRpcState::Error {
                     time: meta.time(),
-                    rpc_id: a.rpc_id,
-                    error: a.error.clone(),
+                    rpc_id: *rpc_id,
+                    error: error.clone(),
                 };
             }
-            TransitionFrontierSyncAction::BlocksPeerQuerySuccess(a) => {
-                let Some(block_state) = self.block_state_mut(&a.response.hash) else {
+            TransitionFrontierSyncAction::BlocksPeerQuerySuccess {
+                peer_id, response, ..
+            } => {
+                let Some(block_state) = self.block_state_mut(&response.hash) else {
                     return;
                 };
-                let Some(peer_state) = block_state.fetch_pending_from_peer_mut(&a.peer_id) else {
+                let Some(peer_state) = block_state.fetch_pending_from_peer_mut(peer_id) else {
                     return;
                 };
                 *peer_state = PeerRpcState::Success {
                     time: meta.time(),
-                    block: a.response.clone(),
+                    block: response.clone(),
                 };
             }
-            TransitionFrontierSyncAction::BlocksFetchSuccess(a) => {
-                let Some(block_state) = self.block_state_mut(&a.hash) else {
+            TransitionFrontierSyncAction::BlocksFetchSuccess { hash } => {
+                let Some(block_state) = self.block_state_mut(hash) else {
                     return;
                 };
                 let Some(block) = block_state.fetch_pending_fetched_block() else {
@@ -496,9 +513,9 @@ impl TransitionFrontierSyncState {
                     block: block.clone(),
                 };
             }
-            TransitionFrontierSyncAction::BlocksNextApplyInit(_) => {}
-            TransitionFrontierSyncAction::BlocksNextApplyPending(a) => {
-                let Some(block_state) = self.block_state_mut(&a.hash) else {
+            TransitionFrontierSyncAction::BlocksNextApplyInit => {}
+            TransitionFrontierSyncAction::BlocksNextApplyPending { hash } => {
+                let Some(block_state) = self.block_state_mut(hash) else {
                     return;
                 };
                 let Some(block) = block_state.block() else {
@@ -510,8 +527,8 @@ impl TransitionFrontierSyncState {
                     block: block.clone(),
                 };
             }
-            TransitionFrontierSyncAction::BlocksNextApplySuccess(a) => {
-                let Some(block_state) = self.block_state_mut(&a.hash) else {
+            TransitionFrontierSyncAction::BlocksNextApplySuccess { hash } => {
+                let Some(block_state) = self.block_state_mut(hash) else {
                     return;
                 };
                 let Some(block) = block_state.block() else {
@@ -523,7 +540,7 @@ impl TransitionFrontierSyncState {
                     block: block.clone(),
                 };
             }
-            TransitionFrontierSyncAction::BlocksSuccess(_) => {
+            TransitionFrontierSyncAction::BlocksSuccess => {
                 let Self::BlocksPending {
                     chain,
                     root_snarked_ledger_updates,

--- a/node/src/transition_frontier/transition_frontier_effects.rs
+++ b/node/src/transition_frontier/transition_frontier_effects.rs
@@ -15,11 +15,7 @@ use super::sync::ledger::{
     transition_frontier_sync_ledger_snarked_success_effects,
     transition_frontier_sync_ledger_staged_success_effects, TransitionFrontierSyncLedgerAction,
 };
-use super::sync::{
-    TransitionFrontierSyncAction, TransitionFrontierSyncLedgerNextEpochSuccessAction,
-    TransitionFrontierSyncLedgerRootSuccessAction,
-    TransitionFrontierSyncLedgerStakingSuccessAction, TransitionFrontierSyncState,
-};
+use super::sync::{TransitionFrontierSyncAction, TransitionFrontierSyncState};
 use super::{
     TransitionFrontierAction, TransitionFrontierActionWithMeta, TransitionFrontierSyncedAction,
 };
@@ -31,289 +27,255 @@ pub fn transition_frontier_effects<S: crate::Service>(
     let (action, meta) = action.split();
 
     match action {
-        TransitionFrontierAction::Sync(a) => match a {
-            TransitionFrontierSyncAction::Init(a) => {
-                if let Some(stats) = store.service.stats() {
-                    stats.new_sync_target(meta.time(), &a.best_tip);
-                    if let TransitionFrontierSyncState::BlocksPending { chain, .. } =
-                        &store.state.get().transition_frontier.sync
-                    {
-                        stats.syncing_blocks_init(chain);
-                    }
-                }
-                a.effects(&meta, store);
-            }
-            TransitionFrontierSyncAction::BestTipUpdate(a) => {
-                if let Some(stats) = store.service.stats() {
-                    stats.new_sync_target(meta.time(), &a.best_tip);
-                    if let Some(target) = store.state.get().transition_frontier.sync.ledger_target()
-                    {
-                        stats.syncing_ledger(
-                            target.kind,
-                            SyncingLedger::Init {
-                                snarked_ledger_hash: target.snarked_ledger_hash.clone(),
-                                staged_ledger_hash: target
-                                    .staged
-                                    .as_ref()
-                                    .map(|v| v.hashes.non_snark.ledger_hash.clone()),
-                            },
-                        );
-                    }
-                    if let TransitionFrontierSyncState::BlocksPending { chain, .. } =
-                        &store.state.get().transition_frontier.sync
-                    {
-                        stats.syncing_blocks_init(chain);
-                    }
-                }
-                a.effects(&meta, store);
-            }
-            TransitionFrontierSyncAction::LedgerStakingPending(a) => {
-                if let Some(stats) = store.service.stats() {
-                    if let Some(target) = store.state.get().transition_frontier.sync.ledger_target()
-                    {
-                        stats.syncing_ledger(
-                            target.kind,
-                            SyncingLedger::Init {
-                                snarked_ledger_hash: target.snarked_ledger_hash.clone(),
-                                staged_ledger_hash: target
-                                    .staged
-                                    .as_ref()
-                                    .map(|v| v.hashes.non_snark.ledger_hash.clone()),
-                            },
-                        );
-                    }
-                }
-                a.effects(&meta, store);
-            }
-            TransitionFrontierSyncAction::LedgerStakingSuccess(a) => {
-                a.effects(&meta, store);
-            }
-            TransitionFrontierSyncAction::LedgerNextEpochPending(a) => {
-                if let Some(stats) = store.service.stats() {
-                    if let Some(target) = store.state.get().transition_frontier.sync.ledger_target()
-                    {
-                        stats.syncing_ledger(
-                            target.kind,
-                            SyncingLedger::Init {
-                                snarked_ledger_hash: target.snarked_ledger_hash.clone(),
-                                staged_ledger_hash: target
-                                    .staged
-                                    .as_ref()
-                                    .map(|v| v.hashes.non_snark.ledger_hash.clone()),
-                            },
-                        );
-                    }
-                }
-                a.effects(&meta, store);
-            }
-            TransitionFrontierSyncAction::LedgerNextEpochSuccess(a) => {
-                a.effects(&meta, store);
-            }
-            TransitionFrontierSyncAction::LedgerRootPending(a) => {
-                if let Some(stats) = store.service.stats() {
-                    if let Some(target) = store.state.get().transition_frontier.sync.ledger_target()
-                    {
-                        stats.syncing_ledger(
-                            target.kind,
-                            SyncingLedger::Init {
-                                snarked_ledger_hash: target.snarked_ledger_hash.clone(),
-                                staged_ledger_hash: target
-                                    .staged
-                                    .as_ref()
-                                    .map(|v| v.hashes.non_snark.ledger_hash.clone()),
-                            },
-                        );
-                    }
-                }
-                a.effects(&meta, store);
-            }
-            TransitionFrontierSyncAction::LedgerRootSuccess(a) => {
-                a.effects(&meta, store);
-            }
-            TransitionFrontierSyncAction::BlocksPending(a) => {
-                if let Some(stats) = store.service.stats() {
-                    if let TransitionFrontierSyncState::BlocksPending { chain, .. } =
-                        &store.state.get().transition_frontier.sync
-                    {
-                        stats.syncing_blocks_init(chain);
-                    }
-                }
-                a.effects(&meta, store);
-            }
-            TransitionFrontierSyncAction::BlocksPeersQuery(a) => {
-                a.effects(&meta, store);
-            }
-            TransitionFrontierSyncAction::BlocksPeerQueryInit(a) => {
-                a.effects(&meta, store);
-            }
-            TransitionFrontierSyncAction::BlocksPeerQueryRetry(a) => {
-                a.effects(&meta, store);
-            }
-            TransitionFrontierSyncAction::BlocksPeerQueryPending(a) => {
-                if let Some(stats) = store.service.stats() {
-                    if let Some(state) = store
-                        .state
-                        .get()
-                        .transition_frontier
-                        .sync
-                        .block_state(&a.hash)
-                    {
-                        stats.syncing_block_update(state);
-                    }
-                }
-            }
-            TransitionFrontierSyncAction::BlocksPeerQueryError(a) => {
-                a.effects(&meta, store);
-            }
-            TransitionFrontierSyncAction::BlocksPeerQuerySuccess(a) => {
-                a.effects(&meta, store);
-            }
-            TransitionFrontierSyncAction::BlocksFetchSuccess(a) => {
-                if let Some(stats) = store.service.stats() {
-                    if let Some(state) = store
-                        .state
-                        .get()
-                        .transition_frontier
-                        .sync
-                        .block_state(&a.hash)
-                    {
-                        stats.syncing_block_update(state);
-                    }
-                }
-                a.effects(&meta, store);
-            }
-            TransitionFrontierSyncAction::BlocksNextApplyInit(a) => {
-                a.effects(&meta, store);
-            }
-            TransitionFrontierSyncAction::BlocksNextApplyPending(a) => {
-                if let Some(stats) = store.service.stats() {
-                    if let Some(state) = store
-                        .state
-                        .get()
-                        .transition_frontier
-                        .sync
-                        .block_state(&a.hash)
-                    {
-                        stats.syncing_block_update(state);
-                    }
-                }
-            }
-            TransitionFrontierSyncAction::BlocksNextApplySuccess(a) => {
-                if let Some(stats) = store.service.stats() {
-                    if let Some(state) = store
-                        .state
-                        .get()
-                        .transition_frontier
-                        .sync
-                        .block_state(&a.hash)
-                    {
-                        stats.syncing_block_update(state);
-                    }
-                }
-                // TODO(tizoc): push new snarked roots here?
-                a.effects(&meta, store);
-            }
-            // Bootstrap/Catchup is practically complete at this point.
-            // This effect is where the finalization part needs to be
-            // executed, which is mostly to grab some data that we need
-            // from previous chain, before it's discarded after dispatching
-            // `TransitionFrontierSyncedAction`.
-            TransitionFrontierSyncAction::BlocksSuccess(_) => {
-                let transition_frontier = &store.state.get().transition_frontier;
-                let sync = &transition_frontier.sync;
-                let TransitionFrontierSyncState::BlocksSuccess {
-                    chain,
-                    root_snarked_ledger_updates,
-                    needed_protocol_states,
-                    ..
-                } = sync
-                else {
-                    return;
-                };
-                let Some(root_block) = chain.first() else {
-                    return;
-                };
-                let Some(best_tip) = chain.last() else {
-                    return;
-                };
-                let ledgers_to_keep = chain
-                    .iter()
-                    .flat_map(|b| {
-                        [
-                            b.snarked_ledger_hash(),
-                            b.staged_ledger_hash(),
-                            b.staking_epoch_ledger_hash(),
-                            b.next_epoch_ledger_hash(),
-                        ]
-                    })
-                    .cloned()
-                    .collect();
-                let mut root_snarked_ledger_updates = root_snarked_ledger_updates.clone();
-                if transition_frontier
-                    .best_chain
-                    .iter()
-                    .any(|b| b.hash() == root_block.hash())
-                {
-                    root_snarked_ledger_updates
-                        .extend_with_needed(root_block, &transition_frontier.best_chain);
-                }
-
-                let needed_protocol_states = if root_snarked_ledger_updates.is_empty() {
-                    // We don't need protocol states unless we need to
-                    // recreate some snarked ledgers during `commit`.
-                    Default::default()
-                } else {
-                    needed_protocol_states
-                        .iter()
-                        .chain(&transition_frontier.needed_protocol_states)
-                        .map(|(k, v)| (k.clone(), v.clone()))
-                        .collect()
-                };
-
-                let own_peer_id = store.state().p2p.my_id();
-                let orphaned_snarks = transition_frontier
-                    .best_chain
-                    .iter()
-                    .rev()
-                    .take_while(|b1| {
-                        let height_diff = best_tip.height().saturating_sub(b1.height()) as usize;
-                        if height_diff == 0 {
-                            best_tip.hash() != b1.hash()
-                        } else if let Some(index) = chain.len().checked_sub(height_diff + 1) {
-                            chain.get(index).map_or(true, |b2| b1.hash() != b2.hash())
-                        } else {
-                            true
+        TransitionFrontierAction::Sync(a) => {
+            match a {
+                TransitionFrontierSyncAction::Init { ref best_tip, .. } => {
+                    if let Some(stats) = store.service.stats() {
+                        stats.new_sync_target(meta.time(), best_tip);
+                        if let TransitionFrontierSyncState::BlocksPending { chain, .. } =
+                            &store.state.get().transition_frontier.sync
+                        {
+                            stats.syncing_blocks_init(chain);
                         }
-                    })
-                    .flat_map(|v| v.completed_works_iter())
-                    .map(|v| SnarkWork {
-                        work: v.clone().into(),
-                        received_t: meta.time(),
-                        sender: own_peer_id,
-                    })
-                    .collect();
+                    }
+                }
+                TransitionFrontierSyncAction::BestTipUpdate { ref best_tip, .. } => {
+                    if let Some(stats) = store.service.stats() {
+                        stats.new_sync_target(meta.time(), best_tip);
+                        if let Some(target) =
+                            store.state.get().transition_frontier.sync.ledger_target()
+                        {
+                            stats.syncing_ledger(
+                                target.kind,
+                                SyncingLedger::Init {
+                                    snarked_ledger_hash: target.snarked_ledger_hash.clone(),
+                                    staged_ledger_hash: target
+                                        .staged
+                                        .as_ref()
+                                        .map(|v| v.hashes.non_snark.ledger_hash.clone()),
+                                },
+                            );
+                        }
+                        if let TransitionFrontierSyncState::BlocksPending { chain, .. } =
+                            &store.state.get().transition_frontier.sync
+                        {
+                            stats.syncing_blocks_init(chain);
+                        }
+                    }
+                }
+                TransitionFrontierSyncAction::LedgerStakingPending => {
+                    if let Some(stats) = store.service.stats() {
+                        if let Some(target) =
+                            store.state.get().transition_frontier.sync.ledger_target()
+                        {
+                            stats.syncing_ledger(
+                                target.kind,
+                                SyncingLedger::Init {
+                                    snarked_ledger_hash: target.snarked_ledger_hash.clone(),
+                                    staged_ledger_hash: target
+                                        .staged
+                                        .as_ref()
+                                        .map(|v| v.hashes.non_snark.ledger_hash.clone()),
+                                },
+                            );
+                        }
+                    }
+                }
+                TransitionFrontierSyncAction::LedgerStakingSuccess => {}
+                TransitionFrontierSyncAction::LedgerNextEpochPending => {
+                    if let Some(stats) = store.service.stats() {
+                        if let Some(target) =
+                            store.state.get().transition_frontier.sync.ledger_target()
+                        {
+                            stats.syncing_ledger(
+                                target.kind,
+                                SyncingLedger::Init {
+                                    snarked_ledger_hash: target.snarked_ledger_hash.clone(),
+                                    staged_ledger_hash: target
+                                        .staged
+                                        .as_ref()
+                                        .map(|v| v.hashes.non_snark.ledger_hash.clone()),
+                                },
+                            );
+                        }
+                    }
+                }
+                TransitionFrontierSyncAction::LedgerNextEpochSuccess => {}
+                TransitionFrontierSyncAction::LedgerRootPending => {
+                    if let Some(stats) = store.service.stats() {
+                        if let Some(target) =
+                            store.state.get().transition_frontier.sync.ledger_target()
+                        {
+                            stats.syncing_ledger(
+                                target.kind,
+                                SyncingLedger::Init {
+                                    snarked_ledger_hash: target.snarked_ledger_hash.clone(),
+                                    staged_ledger_hash: target
+                                        .staged
+                                        .as_ref()
+                                        .map(|v| v.hashes.non_snark.ledger_hash.clone()),
+                                },
+                            );
+                        }
+                    }
+                }
+                TransitionFrontierSyncAction::LedgerRootSuccess => {}
+                TransitionFrontierSyncAction::BlocksPending => {
+                    if let Some(stats) = store.service.stats() {
+                        if let TransitionFrontierSyncState::BlocksPending { chain, .. } =
+                            &store.state.get().transition_frontier.sync
+                        {
+                            stats.syncing_blocks_init(chain);
+                        }
+                    }
+                }
+                TransitionFrontierSyncAction::BlocksPeersQuery => {}
+                TransitionFrontierSyncAction::BlocksPeerQueryInit { .. } => {}
+                TransitionFrontierSyncAction::BlocksPeerQueryRetry { .. } => {}
+                TransitionFrontierSyncAction::BlocksPeerQueryPending { ref hash, .. } => {
+                    if let Some(stats) = store.service.stats() {
+                        if let Some(state) =
+                            store.state.get().transition_frontier.sync.block_state(hash)
+                        {
+                            stats.syncing_block_update(state);
+                        }
+                    }
+                }
+                TransitionFrontierSyncAction::BlocksPeerQueryError { .. } => {}
+                TransitionFrontierSyncAction::BlocksPeerQuerySuccess { .. } => {}
+                TransitionFrontierSyncAction::BlocksFetchSuccess { ref hash } => {
+                    if let Some(stats) = store.service.stats() {
+                        if let Some(state) =
+                            store.state.get().transition_frontier.sync.block_state(hash)
+                        {
+                            stats.syncing_block_update(state);
+                        }
+                    }
+                }
+                TransitionFrontierSyncAction::BlocksNextApplyInit => {}
+                TransitionFrontierSyncAction::BlocksNextApplyPending { ref hash } => {
+                    if let Some(stats) = store.service.stats() {
+                        if let Some(state) =
+                            store.state.get().transition_frontier.sync.block_state(hash)
+                        {
+                            stats.syncing_block_update(state);
+                        }
+                    }
+                }
+                TransitionFrontierSyncAction::BlocksNextApplySuccess { ref hash } => {
+                    if let Some(stats) = store.service.stats() {
+                        if let Some(state) =
+                            store.state.get().transition_frontier.sync.block_state(hash)
+                        {
+                            stats.syncing_block_update(state);
+                        }
+                    }
+                    // TODO(tizoc): push new snarked roots here?
+                }
+                // Bootstrap/Catchup is practically complete at this point.
+                // This effect is where the finalization part needs to be
+                // executed, which is mostly to grab some data that we need
+                // from previous chain, before it's discarded after dispatching
+                // `TransitionFrontierSyncedAction`.
+                TransitionFrontierSyncAction::BlocksSuccess => {
+                    let transition_frontier = &store.state.get().transition_frontier;
+                    let sync = &transition_frontier.sync;
+                    let TransitionFrontierSyncState::BlocksSuccess {
+                        chain,
+                        root_snarked_ledger_updates,
+                        needed_protocol_states,
+                        ..
+                    } = sync
+                    else {
+                        return;
+                    };
+                    let Some(root_block) = chain.first() else {
+                        return;
+                    };
+                    let Some(best_tip) = chain.last() else {
+                        return;
+                    };
+                    let ledgers_to_keep = chain
+                        .iter()
+                        .flat_map(|b| {
+                            [
+                                b.snarked_ledger_hash(),
+                                b.staged_ledger_hash(),
+                                b.staking_epoch_ledger_hash(),
+                                b.next_epoch_ledger_hash(),
+                            ]
+                        })
+                        .cloned()
+                        .collect();
+                    let mut root_snarked_ledger_updates = root_snarked_ledger_updates.clone();
+                    if transition_frontier
+                        .best_chain
+                        .iter()
+                        .any(|b| b.hash() == root_block.hash())
+                    {
+                        root_snarked_ledger_updates
+                            .extend_with_needed(root_block, &transition_frontier.best_chain);
+                    }
 
-                let res = store.service.commit(
-                    ledgers_to_keep,
-                    root_snarked_ledger_updates,
-                    needed_protocol_states,
-                    root_block,
-                    best_tip,
-                );
-                let needed_protocol_states = res.needed_protocol_states;
-                let jobs = res.available_jobs;
-                store.dispatch(TransitionFrontierSyncedAction {
-                    needed_protocol_states,
-                });
-                store.dispatch(SnarkPoolAction::JobsUpdate {
-                    jobs,
-                    orphaned_snarks,
-                });
+                    let needed_protocol_states = if root_snarked_ledger_updates.is_empty() {
+                        // We don't need protocol states unless we need to
+                        // recreate some snarked ledgers during `commit`.
+                        Default::default()
+                    } else {
+                        needed_protocol_states
+                            .iter()
+                            .chain(&transition_frontier.needed_protocol_states)
+                            .map(|(k, v)| (k.clone(), v.clone()))
+                            .collect()
+                    };
+
+                    let own_peer_id = store.state().p2p.my_id();
+                    let orphaned_snarks = transition_frontier
+                        .best_chain
+                        .iter()
+                        .rev()
+                        .take_while(|b1| {
+                            let height_diff =
+                                best_tip.height().saturating_sub(b1.height()) as usize;
+                            if height_diff == 0 {
+                                best_tip.hash() != b1.hash()
+                            } else if let Some(index) = chain.len().checked_sub(height_diff + 1) {
+                                chain.get(index).map_or(true, |b2| b1.hash() != b2.hash())
+                            } else {
+                                true
+                            }
+                        })
+                        .flat_map(|v| v.completed_works_iter())
+                        .map(|v| SnarkWork {
+                            work: v.clone().into(),
+                            received_t: meta.time(),
+                            sender: own_peer_id,
+                        })
+                        .collect();
+
+                    let res = store.service.commit(
+                        ledgers_to_keep,
+                        root_snarked_ledger_updates,
+                        needed_protocol_states,
+                        root_block,
+                        best_tip,
+                    );
+                    let needed_protocol_states = res.needed_protocol_states;
+                    let jobs = res.available_jobs;
+                    store.dispatch(TransitionFrontierSyncedAction {
+                        needed_protocol_states,
+                    });
+                    store.dispatch(SnarkPoolAction::JobsUpdate {
+                        jobs,
+                        orphaned_snarks,
+                    });
+                }
+                TransitionFrontierSyncAction::Ledger(ref a) => {
+                    handle_transition_frontier_sync_ledger_action(a.clone(), &meta, store)
+                }
             }
-            TransitionFrontierSyncAction::Ledger(a) => {
-                handle_transition_frontier_sync_ledger_action(a, &meta, store)
-            }
-        },
+            a.effects(&meta, store);
+        }
         TransitionFrontierAction::Synced(_) => {
             let Some(best_tip) = store.state.get().transition_frontier.best_tip() else {
                 return;
@@ -486,13 +448,13 @@ fn handle_transition_frontier_sync_ledger_action<S: crate::Service>(
         TransitionFrontierSyncLedgerAction::Success => {
             match &store.state().transition_frontier.sync {
                 TransitionFrontierSyncState::StakingLedgerPending { .. } => {
-                    store.dispatch(TransitionFrontierSyncLedgerStakingSuccessAction {});
+                    store.dispatch(TransitionFrontierSyncAction::LedgerStakingSuccess);
                 }
                 TransitionFrontierSyncState::NextEpochLedgerPending { .. } => {
-                    store.dispatch(TransitionFrontierSyncLedgerNextEpochSuccessAction {});
+                    store.dispatch(TransitionFrontierSyncAction::LedgerNextEpochSuccess);
                 }
                 TransitionFrontierSyncState::RootLedgerPending { .. } => {
-                    store.dispatch(TransitionFrontierSyncLedgerRootSuccessAction {});
+                    store.dispatch(TransitionFrontierSyncAction::LedgerRootSuccess);
                 }
                 _ => {}
             }

--- a/node/src/transition_frontier/transition_frontier_effects.rs
+++ b/node/src/transition_frontier/transition_frontier_effects.rs
@@ -1,6 +1,6 @@
 use redux::Timestamp;
 
-use crate::block_producer::BlockProducerBestTipUpdateAction;
+use crate::block_producer::BlockProducerAction;
 use crate::consensus::ConsensusAction;
 use crate::ledger::LEDGER_DEPTH;
 use crate::p2p::channels::best_tip::P2pChannelsBestTipAction;
@@ -294,7 +294,7 @@ pub fn transition_frontier_effects<S: crate::Service>(
             }
 
             store.dispatch(ConsensusAction::Prune);
-            store.dispatch(BlockProducerBestTipUpdateAction { best_tip });
+            store.dispatch(BlockProducerAction::BestTipUpdate { best_tip });
         }
     }
 }

--- a/node/src/watched_accounts/watched_accounts_effects.rs
+++ b/node/src/watched_accounts/watched_accounts_effects.rs
@@ -7,13 +7,7 @@ use mina_p2p_messages::{
 
 use crate::Store;
 
-use super::{
-    WatchedAccountBlockInfo, WatchedAccountsAction, WatchedAccountsActionWithMeta,
-    WatchedAccountsBlockLedgerQueryInitAction, WatchedAccountsBlockLedgerQueryPendingAction,
-    WatchedAccountsLedgerInitialStateGetInitAction,
-    WatchedAccountsLedgerInitialStateGetPendingAction,
-    WatchedAccountsLedgerInitialStateGetRetryAction,
-};
+use super::{WatchedAccountBlockInfo, WatchedAccountsAction, WatchedAccountsActionWithMeta};
 
 pub fn watched_accounts_effects<S: redux::Service>(
     store: &mut Store<S>,
@@ -22,23 +16,17 @@ pub fn watched_accounts_effects<S: redux::Service>(
     let (action, _) = action.split();
 
     match action {
-        WatchedAccountsAction::Add(action) => {
-            store.dispatch(WatchedAccountsLedgerInitialStateGetInitAction {
-                pub_key: action.pub_key.clone(),
+        WatchedAccountsAction::Add { pub_key } => {
+            store.dispatch(WatchedAccountsAction::LedgerInitialStateGetInit { pub_key });
+        }
+        WatchedAccountsAction::TransactionsIncludedInBlock { pub_key, block } => {
+            store.dispatch(WatchedAccountsAction::BlockLedgerQueryInit {
+                pub_key,
+                block_hash: block.hash,
             });
         }
-        WatchedAccountsAction::TransactionsIncludedInBlock(action) => {
-            store.dispatch(WatchedAccountsBlockLedgerQueryInitAction {
-                pub_key: action.pub_key,
-                block_hash: action.block.hash,
-            });
-        }
-        WatchedAccountsAction::LedgerInitialStateGetInit(
-            WatchedAccountsLedgerInitialStateGetInitAction { pub_key },
-        )
-        | WatchedAccountsAction::LedgerInitialStateGetRetry(
-            WatchedAccountsLedgerInitialStateGetRetryAction { pub_key },
-        ) => {
+        WatchedAccountsAction::LedgerInitialStateGetInit { pub_key }
+        | WatchedAccountsAction::LedgerInitialStateGetRetry { pub_key } => {
             // TODO(binier)
             // let Some((peer_id, p2p_rpc_id)) = store.state().p2p.get_free_peer_id_for_rpc() else { return };
             // let block = {
@@ -82,10 +70,10 @@ pub fn watched_accounts_effects<S: redux::Service>(
             //     p2p_rpc_id,
             // });
         }
-        WatchedAccountsAction::LedgerInitialStateGetPending(_) => {}
-        WatchedAccountsAction::LedgerInitialStateGetError(_) => {}
-        WatchedAccountsAction::LedgerInitialStateGetSuccess(_) => {}
-        WatchedAccountsAction::BlockLedgerQueryInit(action) => {
+        WatchedAccountsAction::LedgerInitialStateGetPending { .. } => {}
+        WatchedAccountsAction::LedgerInitialStateGetError { .. } => {}
+        WatchedAccountsAction::LedgerInitialStateGetSuccess { .. } => {}
+        WatchedAccountsAction::BlockLedgerQueryInit { .. } => {
             // TODO(binier)
             // let Some((peer_id, p2p_rpc_id)) = store.state().p2p.get_free_peer_id_for_rpc() else { return };
             // let ledger_hash = {
@@ -119,7 +107,7 @@ pub fn watched_accounts_effects<S: redux::Service>(
             //     p2p_rpc_id,
             // });
         }
-        WatchedAccountsAction::BlockLedgerQueryPending(_) => {}
-        WatchedAccountsAction::BlockLedgerQuerySuccess(_) => {}
+        WatchedAccountsAction::BlockLedgerQueryPending { .. } => {}
+        WatchedAccountsAction::BlockLedgerQuerySuccess { .. } => {}
     }
 }

--- a/node/src/watched_accounts/watched_accounts_reducer.rs
+++ b/node/src/watched_accounts/watched_accounts_reducer.rs
@@ -8,45 +8,45 @@ impl WatchedAccountsState {
     pub fn reducer(&mut self, action: WatchedAccountsActionWithMetaRef<'_>) {
         let (action, meta) = action.split();
         match action {
-            WatchedAccountsAction::Add(action) => {
+            WatchedAccountsAction::Add { pub_key } => {
                 self.insert(
-                    action.pub_key.clone(),
+                    pub_key.clone(),
                     WatchedAccountState {
                         initial_state: WatchedAccountLedgerInitialState::Idle { time: meta.time() },
                         blocks: Default::default(),
                     },
                 );
-            }
-            WatchedAccountsAction::LedgerInitialStateGetInit(_) => {}
-            WatchedAccountsAction::LedgerInitialStateGetPending(action) => {
-                let Some(account) = self.get_mut(&action.pub_key) else {
+            },
+            WatchedAccountsAction::LedgerInitialStateGetInit { .. } => {},
+            WatchedAccountsAction::LedgerInitialStateGetPending { pub_key, block, peer_id } => {
+                let Some(account) = self.get_mut(pub_key) else {
                     return;
                 };
                 account.blocks.clear();
 
                 account.initial_state = WatchedAccountLedgerInitialState::Pending {
                     time: meta.time(),
-                    block: action.block.clone(),
-                    peer_id: action.peer_id,
+                    block: block.clone(),
+                    peer_id: *peer_id,
                 };
-            }
-            WatchedAccountsAction::LedgerInitialStateGetError(action) => {
-                let Some(account) = self.get_mut(&action.pub_key) else {
+            },
+            WatchedAccountsAction::LedgerInitialStateGetError { pub_key, error } => {
+                let Some(account) = self.get_mut(pub_key) else {
                     return;
                 };
                 let peer_id = match &account.initial_state {
-                    WatchedAccountLedgerInitialState::Pending { peer_id, .. } => peer_id.clone(),
+                    WatchedAccountLedgerInitialState::Pending { peer_id, .. } => *peer_id,
                     _ => return,
                 };
                 account.initial_state = WatchedAccountLedgerInitialState::Error {
                     time: meta.time(),
-                    error: action.error.clone(),
+                    error: error.clone(),
                     peer_id,
                 };
-            }
-            WatchedAccountsAction::LedgerInitialStateGetRetry(_) => {}
-            WatchedAccountsAction::LedgerInitialStateGetSuccess(action) => {
-                let Some(account) = self.get_mut(&action.pub_key) else {
+            },
+            WatchedAccountsAction::LedgerInitialStateGetRetry { .. } => {},
+            WatchedAccountsAction::LedgerInitialStateGetSuccess { pub_key, data } => {
+                let Some(account) = self.get_mut(pub_key) else {
                     return;
                 };
                 let Some(block) = account.initial_state.block() else {
@@ -55,85 +55,60 @@ impl WatchedAccountsState {
                 account.initial_state = WatchedAccountLedgerInitialState::Success {
                     time: meta.time(),
                     block: block.clone(),
-                    data: action.data.clone(),
+                    data: data.clone(),
                 };
-            }
-            WatchedAccountsAction::TransactionsIncludedInBlock(action) => {
-                let block = &action.block;
-                let header = &block.block.header;
-                let diff = &block.block.body.staged_ledger_diff.diff;
-
+            },
+            WatchedAccountsAction::TransactionsIncludedInBlock { pub_key, block } => {
                 let transactions =
-                    account_relevant_transactions_in_diff_iter(&action.pub_key, diff).collect();
+                    account_relevant_transactions_in_diff_iter(pub_key, &block.block.body.staged_ledger_diff.diff).collect();
 
-                let Some(account) = self.get_mut(&action.pub_key) else {
+                let Some(account) = self.get_mut(pub_key) else {
                     return;
                 };
                 account
                     .blocks
                     .push_back(WatchedAccountBlockState::TransactionsInBlockBody {
                         block: WatchedAccountBlockInfo {
-                            level: header
-                                .protocol_state
-                                .body
-                                .consensus_state
-                                .blockchain_length
-                                .0
-                                 .0 as u32,
+                            level: block.block.header.protocol_state.body.consensus_state.blockchain_length.0 .0 as u32,
                             hash: block.hash.clone(),
-                            pred_hash: header.protocol_state.previous_state_hash.clone(),
-                            staged_ledger_hash: header
-                                .protocol_state
-                                .body
-                                .blockchain_state
-                                .staged_ledger_hash
-                                .non_snark
-                                .ledger_hash
-                                .clone(),
+                            pred_hash: block.block.header.protocol_state.previous_state_hash.clone(),
+                            staged_ledger_hash: block.block.header.protocol_state.body.blockchain_state.staged_ledger_hash.non_snark.ledger_hash.clone(),
                         },
                         transactions,
                     });
-            }
-            WatchedAccountsAction::BlockLedgerQueryInit(_) => {}
-            WatchedAccountsAction::BlockLedgerQueryPending(action) => {
-                let Some(account) = self.get_mut(&action.pub_key) else {
+            },
+            WatchedAccountsAction::BlockLedgerQueryInit { .. } => {},
+            WatchedAccountsAction::BlockLedgerQueryPending { pub_key, block_hash, .. } => {
+                let Some(account) = self.get_mut(pub_key) else {
                     return;
                 };
-                let Some(block_state) = account.block_find_by_hash_mut(&action.block_hash) else {
-                    return;
-                };
-                *block_state = match block_state {
-                    WatchedAccountBlockState::TransactionsInBlockBody {
-                        block,
-                        transactions,
-                    } => WatchedAccountBlockState::LedgerAccountGetPending {
-                        block: block.clone(),
-                        transactions: std::mem::take(transactions),
-                        // p2p_rpc_id: action.p2p_rpc_id,
-                    },
-                    _ => return,
-                };
-            }
-            WatchedAccountsAction::BlockLedgerQuerySuccess(action) => {
-                let Some(account) = self.get_mut(&action.pub_key) else {
-                    return;
-                };
-                let Some(block_state) = account.block_find_by_hash_mut(&action.block_hash) else {
+                let Some(block_state) = account.block_find_by_hash_mut(block_hash) else {
                     return;
                 };
                 *block_state = match block_state {
-                    WatchedAccountBlockState::LedgerAccountGetPending {
-                        block,
-                        transactions,
-                        ..
-                    } => WatchedAccountBlockState::LedgerAccountGetSuccess {
+                    WatchedAccountBlockState::TransactionsInBlockBody { block, transactions } => WatchedAccountBlockState::LedgerAccountGetPending {
                         block: block.clone(),
                         transactions: std::mem::take(transactions),
-                        ledger_account: action.ledger_account.clone(),
                     },
                     _ => return,
                 };
-            }
+            },
+            WatchedAccountsAction::BlockLedgerQuerySuccess { pub_key, block_hash, ledger_account } => {
+                let Some(account) = self.get_mut(pub_key) else {
+                    return;
+                };
+                let Some(block_state) = account.block_find_by_hash_mut(block_hash) else {
+                    return;
+                };
+                *block_state = match block_state {
+                    WatchedAccountBlockState::LedgerAccountGetPending { block, transactions, .. } => WatchedAccountBlockState::LedgerAccountGetSuccess {
+                        block: block.clone(),
+                        transactions: std::mem::take(transactions),
+                        ledger_account: ledger_account.clone(),
+                    },
+                    _ => return,
+                };
+            },
         }
     }
 }

--- a/node/testing/src/node/rust/mod.rs
+++ b/node/testing/src/node/rust/mod.rs
@@ -4,7 +4,7 @@ pub use config::{RustNodeBlockProducerTestingConfig, RustNodeTestingConfig, Test
 mod event;
 pub use event::*;
 
-use node::event_source::EventSourceNewEventAction;
+use node::event_source::EventSourceAction;
 use node::p2p::connection::outgoing::{
     P2pConnectionOutgoingInitLibp2pOpts, P2pConnectionOutgoingInitOpts,
 };
@@ -94,7 +94,7 @@ impl Node {
     }
 
     pub fn dispatch_event(&mut self, event: Event) -> bool {
-        self.dispatch(EventSourceNewEventAction { event })
+        self.dispatch(EventSourceAction::NewEvent { event })
     }
 
     pub fn get_pending_event(&self, event_id: PendingEventId) -> Option<&Event> {

--- a/p2p/src/channels/best_tip/p2p_channels_best_tip_effects.rs
+++ b/p2p/src/channels/best_tip/p2p_channels_best_tip_effects.rs
@@ -2,7 +2,7 @@ use redux::ActionMeta;
 
 use crate::{
     channels::{ChannelId, MsgId, P2pChannelsService},
-    peer::P2pPeerBestTipUpdateAction,
+    peer::P2pPeerAction,
 };
 
 use super::{BestTipPropagationChannelMsg, P2pChannelsBestTipAction};
@@ -13,7 +13,7 @@ impl P2pChannelsBestTipAction {
         Store: crate::P2pStore<S>,
         Store::Service: P2pChannelsService,
         P2pChannelsBestTipAction: redux::EnablingCondition<S>,
-        P2pPeerBestTipUpdateAction: redux::EnablingCondition<S>,
+        P2pPeerAction: redux::EnablingCondition<S>,
     {
         match self {
             P2pChannelsBestTipAction::Init { peer_id } => {
@@ -35,7 +35,7 @@ impl P2pChannelsBestTipAction {
                     .channel_send(peer_id, MsgId::first(), msg.into());
             }
             P2pChannelsBestTipAction::Received { peer_id, best_tip } => {
-                store.dispatch(P2pPeerBestTipUpdateAction {
+                store.dispatch(P2pPeerAction::BestTipUpdate {
                     peer_id,
                     best_tip: best_tip.clone(),
                 });

--- a/p2p/src/channels/p2p_channels_effects.rs
+++ b/p2p/src/channels/p2p_channels_effects.rs
@@ -1,7 +1,7 @@
 use openmina_core::block::BlockWithHash;
 use redux::ActionMeta;
 
-use crate::disconnection::{P2pDisconnectionInitAction, P2pDisconnectionReason};
+use crate::disconnection::{P2pDisconnectionAction, P2pDisconnectionReason};
 
 use super::{
     best_tip::{BestTipPropagationChannelMsg, P2pChannelsBestTipAction},
@@ -21,7 +21,7 @@ impl P2pChannelsMessageReceivedAction {
         P2pChannelsSnarkAction: redux::EnablingCondition<S>,
         P2pChannelsSnarkJobCommitmentAction: redux::EnablingCondition<S>,
         P2pChannelsRpcAction: redux::EnablingCondition<S>,
-        P2pDisconnectionInitAction: redux::EnablingCondition<S>,
+        P2pDisconnectionAction: redux::EnablingCondition<S>,
     {
         let peer_id = self.peer_id;
         let chan_id = self.message.channel_id();
@@ -89,7 +89,7 @@ impl P2pChannelsMessageReceivedAction {
 
         if !was_expected {
             let reason = P2pDisconnectionReason::P2pChannelMsgUnexpected(chan_id);
-            store.dispatch(P2pDisconnectionInitAction { peer_id, reason });
+            store.dispatch(P2pDisconnectionAction::Init { peer_id, reason });
         }
     }
 }

--- a/p2p/src/channels/rpc/p2p_channels_rpc_effects.rs
+++ b/p2p/src/channels/rpc/p2p_channels_rpc_effects.rs
@@ -3,7 +3,7 @@ use redux::ActionMeta;
 
 use crate::{
     channels::{ChannelId, MsgId, P2pChannelsService},
-    peer::P2pPeerBestTipUpdateAction,
+    peer::P2pPeerAction,
 };
 
 use super::{P2pChannelsRpcAction, P2pRpcResponse, RpcChannelMsg};
@@ -13,7 +13,7 @@ impl P2pChannelsRpcAction {
     where
         Store: crate::P2pStore<S>,
         Store::Service: P2pChannelsService,
-        P2pPeerBestTipUpdateAction: redux::EnablingCondition<S>,
+        P2pPeerAction: redux::EnablingCondition<S>,
         Self: redux::EnablingCondition<S>,
     {
         match self {
@@ -35,7 +35,7 @@ impl P2pChannelsRpcAction {
                 peer_id, response, ..
             } => {
                 if let Some(P2pRpcResponse::BestTipWithProof(resp)) = response {
-                    store.dispatch(P2pPeerBestTipUpdateAction {
+                    store.dispatch(P2pPeerAction::BestTipUpdate {
                         peer_id,
                         best_tip: BlockWithHash::new(resp.best_tip.clone()),
                     });

--- a/p2p/src/connection/incoming/p2p_connection_incoming_actions.rs
+++ b/p2p/src/connection/incoming/p2p_connection_incoming_actions.rs
@@ -2,294 +2,201 @@ use serde::{Deserialize, Serialize};
 
 use openmina_core::requests::RpcId;
 
-use crate::{webrtc, P2pState, PeerId};
+use crate::{webrtc, P2pAction, P2pState, PeerId};
 
 use super::P2pConnectionIncomingInitOpts;
 
 pub type P2pConnectionIncomingActionWithMetaRef<'a> =
     redux::ActionWithMeta<&'a P2pConnectionIncomingAction>;
 
-#[derive(derive_more::From, Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum P2pConnectionIncomingAction {
-    Init(P2pConnectionIncomingInitAction),
-    AnswerSdpCreatePending(P2pConnectionIncomingAnswerSdpCreatePendingAction),
-    AnswerSdpCreateError(P2pConnectionIncomingAnswerSdpCreateErrorAction),
-    AnswerSdpCreateSuccess(P2pConnectionIncomingAnswerSdpCreateSuccessAction),
-    AnswerReady(P2pConnectionIncomingAnswerReadyAction),
-    AnswerSendSuccess(P2pConnectionIncomingAnswerSendSuccessAction),
-    FinalizePending(P2pConnectionIncomingFinalizePendingAction),
-    FinalizeError(P2pConnectionIncomingFinalizeErrorAction),
-    FinalizeSuccess(P2pConnectionIncomingFinalizeSuccessAction),
-    Timeout(P2pConnectionIncomingTimeoutAction),
-    Error(P2pConnectionIncomingErrorAction),
-    Success(P2pConnectionIncomingSuccessAction),
-    Libp2pReceived(P2pConnectionIncomingLibp2pReceivedAction),
+    Init {
+        opts: P2pConnectionIncomingInitOpts,
+        rpc_id: Option<RpcId>,
+    },
+    AnswerSdpCreatePending {
+        peer_id: PeerId,
+    },
+    AnswerSdpCreateError {
+        peer_id: PeerId,
+        error: String,
+    },
+    AnswerSdpCreateSuccess {
+        peer_id: PeerId,
+        sdp: String,
+    },
+    AnswerReady {
+        peer_id: PeerId,
+        answer: webrtc::Answer,
+    },
+    AnswerSendSuccess {
+        peer_id: PeerId,
+    },
+    FinalizePending {
+        peer_id: PeerId,
+    },
+    FinalizeError {
+        peer_id: PeerId,
+        error: String,
+    },
+    FinalizeSuccess {
+        peer_id: PeerId,
+    },
+    Timeout {
+        peer_id: PeerId,
+    },
+    Error {
+        peer_id: PeerId,
+        error: P2pConnectionIncomingError,
+    },
+    Success {
+        peer_id: PeerId,
+    },
+    Libp2pReceived {
+        peer_id: PeerId,
+    },
 }
 
 impl P2pConnectionIncomingAction {
     pub fn peer_id(&self) -> Option<&PeerId> {
         match self {
-            Self::Init(v) => Some(&v.opts.peer_id),
-            Self::AnswerSdpCreatePending(v) => Some(&v.peer_id),
-            Self::AnswerSdpCreateError(v) => Some(&v.peer_id),
-            Self::AnswerSdpCreateSuccess(v) => Some(&v.peer_id),
-            Self::AnswerReady(v) => Some(&v.peer_id),
-            Self::AnswerSendSuccess(v) => Some(&v.peer_id),
-            Self::FinalizePending(v) => Some(&v.peer_id),
-            Self::FinalizeError(v) => Some(&v.peer_id),
-            Self::FinalizeSuccess(v) => Some(&v.peer_id),
-            Self::Timeout(v) => Some(&v.peer_id),
-            Self::Error(v) => Some(&v.peer_id),
-            Self::Success(v) => Some(&v.peer_id),
-            Self::Libp2pReceived(v) => Some(&v.peer_id),
+            Self::Init { opts, .. } => Some(&opts.peer_id),
+            Self::AnswerSdpCreatePending { peer_id }
+            | Self::AnswerSdpCreateError { peer_id, .. }
+            | Self::AnswerSdpCreateSuccess { peer_id, .. }
+            | Self::AnswerReady { peer_id, .. }
+            | Self::AnswerSendSuccess { peer_id }
+            | Self::FinalizePending { peer_id }
+            | Self::FinalizeError { peer_id, .. }
+            | Self::FinalizeSuccess { peer_id }
+            | Self::Timeout { peer_id }
+            | Self::Error { peer_id, .. }
+            | Self::Success { peer_id }
+            | Self::Libp2pReceived { peer_id } => Some(peer_id),
         }
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pConnectionIncomingInitAction {
-    pub opts: P2pConnectionIncomingInitOpts,
-    pub rpc_id: Option<RpcId>,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pConnectionIncomingInitAction {
+impl redux::EnablingCondition<P2pState> for P2pConnectionIncomingAction {
     fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .incoming_accept(self.opts.peer_id, &self.opts.offer)
-            .is_ok()
+        match self {
+            P2pConnectionIncomingAction::Init { opts, .. } => {
+                state.incoming_accept(opts.peer_id, &opts.offer).is_ok()
+            }
+            P2pConnectionIncomingAction::AnswerSdpCreatePending { peer_id } => state
+                .peers
+                .get(peer_id)
+                .map_or(false, |peer| match &peer.status {
+                    P2pPeerStatus::Connecting(P2pConnectionState::Incoming(
+                        P2pConnectionIncomingState::Init { .. },
+                    )) => true,
+                    _ => false,
+                }),
+            P2pConnectionIncomingAction::AnswerSdpCreateError { peer_id, .. } => state
+                .peers
+                .get(peer_id)
+                .map_or(false, |peer| match &peer.status {
+                    P2pPeerStatus::Connecting(P2pConnectionState::Incoming(
+                        P2pConnectionIncomingState::AnswerSdpCreatePending { .. },
+                    )) => true,
+                    _ => false,
+                }),
+            P2pConnectionIncomingAction::AnswerSdpCreateSuccess { peer_id, .. } => state
+                .peers
+                .get(peer_id)
+                .map_or(false, |peer| match &peer.status {
+                    P2pPeerStatus::Connecting(P2pConnectionState::Incoming(
+                        P2pConnectionIncomingState::AnswerSdpCreatePending { .. },
+                    )) => true,
+                    _ => false,
+                }),
+            P2pConnectionIncomingAction::AnswerReady { peer_id, .. } => state
+                .peers
+                .get(peer_id)
+                .map_or(false, |peer| match &peer.status {
+                    P2pPeerStatus::Connecting(P2pConnectionState::Incoming(
+                        P2pConnectionIncomingState::AnswerSdpCreateSuccess { .. },
+                    )) => true,
+                    _ => false,
+                }),
+            P2pConnectionIncomingAction::AnswerSendSuccess { peer_id } => state
+                .peers
+                .get(peer_id)
+                .map_or(false, |peer| match &peer.status {
+                    P2pPeerStatus::Connecting(P2pConnectionState::Incoming(
+                        P2pConnectionIncomingState::AnswerReady { .. },
+                    )) => true,
+                    _ => false,
+                }),
+            P2pConnectionIncomingAction::FinalizePending { peer_id } => state
+                .peers
+                .get(peer_id)
+                .map_or(false, |peer| match &peer.status {
+                    P2pPeerStatus::Connecting(P2pConnectionState::Incoming(
+                        P2pConnectionIncomingState::AnswerSendSuccess { .. },
+                    )) => true,
+                    _ => false,
+                }),
+            P2pConnectionIncomingAction::FinalizeError { peer_id, .. } => state
+                .peers
+                .get(peer_id)
+                .map_or(false, |peer| match &peer.status {
+                    P2pPeerStatus::Connecting(P2pConnectionState::Incoming(
+                        P2pConnectionIncomingState::FinalizePending { .. },
+                    )) => true,
+                    _ => false,
+                }),
+            P2pConnectionIncomingAction::FinalizeSuccess { peer_id } => state
+                .peers
+                .get(peer_id)
+                .map_or(false, |peer| match &peer.status {
+                    P2pPeerStatus::Connecting(P2pConnectionState::Incoming(
+                        P2pConnectionIncomingState::FinalizePending { .. },
+                    )) => true,
+                    _ => false,
+                }),
+            P2pConnectionIncomingAction::Timeout { peer_id } => state
+                .peers
+                .get(peer_id)
+                .and_then(|peer| peer.status.as_connecting()?.as_incoming())
+                .is_some(),
+            P2pConnectionIncomingAction::Error { peer_id, error } => state
+                .peers
+                .get(peer_id)
+                .map_or(false, |peer| match &peer.status {
+                    P2pPeerStatus::Connecting(P2pConnectionState::Incoming(s)) => match error {
+                        P2pConnectionIncomingError::SdpCreateError(_) => {
+                            matches!(s, P2pConnectionIncomingState::AnswerSdpCreatePending { .. })
+                        }
+                        P2pConnectionIncomingError::FinalizeError(_) => {
+                            matches!(s, P2pConnectionIncomingState::FinalizePending { .. })
+                        }
+                        P2pConnectionIncomingError::Timeout => true,
+                    },
+                    _ => false,
+                }),
+            P2pConnectionIncomingAction::Success { peer_id } => {
+                state
+                    .peers
+                    .get(peer_id)
+                    .map_or(false, |peer| match &peer.status {
+                        P2pPeerStatus::Connecting(P2pConnectionState::Incoming(
+                            P2pConnectionIncomingState::FinalizeSuccess { .. },
+                        )) => true,
+                        _ => false,
+                    })
+            }
+
+            P2pConnectionIncomingAction::Libp2pReceived { peer_id } => {
+                state.peers.get(&peer_id).map_or(true, |peer| {
+                    matches!(&peer.status, P2pPeerStatus::Disconnected { .. })
+                })
+            }
+        }
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pConnectionIncomingAnswerSdpCreatePendingAction {
-    pub peer_id: PeerId,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pConnectionIncomingAnswerSdpCreatePendingAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .peers
-            .get(&self.peer_id)
-            .map_or(false, |peer| match &peer.status {
-                P2pPeerStatus::Connecting(P2pConnectionState::Incoming(
-                    P2pConnectionIncomingState::Init { .. },
-                )) => true,
-                _ => false,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pConnectionIncomingAnswerSdpCreateErrorAction {
-    pub peer_id: PeerId,
-    pub error: String,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pConnectionIncomingAnswerSdpCreateErrorAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .peers
-            .get(&self.peer_id)
-            .map_or(false, |peer| match &peer.status {
-                P2pPeerStatus::Connecting(P2pConnectionState::Incoming(
-                    P2pConnectionIncomingState::AnswerSdpCreatePending { .. },
-                )) => true,
-                _ => false,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pConnectionIncomingAnswerSdpCreateSuccessAction {
-    pub peer_id: PeerId,
-    pub sdp: String,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pConnectionIncomingAnswerSdpCreateSuccessAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .peers
-            .get(&self.peer_id)
-            .map_or(false, |peer| match &peer.status {
-                P2pPeerStatus::Connecting(P2pConnectionState::Incoming(
-                    P2pConnectionIncomingState::AnswerSdpCreatePending { .. },
-                )) => true,
-                _ => false,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pConnectionIncomingAnswerReadyAction {
-    pub peer_id: PeerId,
-    pub answer: webrtc::Answer,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pConnectionIncomingAnswerReadyAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .peers
-            .get(&self.peer_id)
-            .map_or(false, |peer| match &peer.status {
-                P2pPeerStatus::Connecting(P2pConnectionState::Incoming(
-                    P2pConnectionIncomingState::AnswerSdpCreateSuccess { .. },
-                )) => true,
-                _ => false,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pConnectionIncomingAnswerSendSuccessAction {
-    pub peer_id: PeerId,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pConnectionIncomingAnswerSendSuccessAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .peers
-            .get(&self.peer_id)
-            .map_or(false, |peer| match &peer.status {
-                P2pPeerStatus::Connecting(P2pConnectionState::Incoming(
-                    P2pConnectionIncomingState::AnswerReady { .. },
-                )) => true,
-                _ => false,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pConnectionIncomingFinalizePendingAction {
-    pub peer_id: PeerId,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pConnectionIncomingFinalizePendingAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .peers
-            .get(&self.peer_id)
-            .map_or(false, |peer| match &peer.status {
-                P2pPeerStatus::Connecting(P2pConnectionState::Incoming(
-                    P2pConnectionIncomingState::AnswerSendSuccess { .. },
-                )) => true,
-                _ => false,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pConnectionIncomingFinalizeErrorAction {
-    pub peer_id: PeerId,
-    pub error: String,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pConnectionIncomingFinalizeErrorAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .peers
-            .get(&self.peer_id)
-            .map_or(false, |peer| match &peer.status {
-                P2pPeerStatus::Connecting(P2pConnectionState::Incoming(
-                    P2pConnectionIncomingState::FinalizePending { .. },
-                )) => true,
-                _ => false,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pConnectionIncomingFinalizeSuccessAction {
-    pub peer_id: PeerId,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pConnectionIncomingFinalizeSuccessAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .peers
-            .get(&self.peer_id)
-            .map_or(false, |peer| match &peer.status {
-                P2pPeerStatus::Connecting(P2pConnectionState::Incoming(
-                    P2pConnectionIncomingState::FinalizePending { .. },
-                )) => true,
-                _ => false,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pConnectionIncomingTimeoutAction {
-    pub peer_id: PeerId,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pConnectionIncomingTimeoutAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .peers
-            .get(&self.peer_id)
-            .and_then(|peer| peer.status.as_connecting()?.as_incoming())
-            .is_some()
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pConnectionIncomingErrorAction {
-    pub peer_id: PeerId,
-    pub error: P2pConnectionIncomingError,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pConnectionIncomingErrorAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .peers
-            .get(&self.peer_id)
-            .map_or(false, |peer| match &peer.status {
-                P2pPeerStatus::Connecting(P2pConnectionState::Incoming(s)) => match &self.error {
-                    P2pConnectionIncomingError::SdpCreateError(_) => {
-                        matches!(s, P2pConnectionIncomingState::AnswerSdpCreatePending { .. })
-                    }
-                    P2pConnectionIncomingError::FinalizeError(_) => {
-                        matches!(s, P2pConnectionIncomingState::FinalizePending { .. })
-                    }
-                    P2pConnectionIncomingError::Timeout => true,
-                },
-                _ => false,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pConnectionIncomingSuccessAction {
-    pub peer_id: PeerId,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pConnectionIncomingSuccessAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .peers
-            .get(&self.peer_id)
-            .map_or(false, |peer| match &peer.status {
-                P2pPeerStatus::Connecting(P2pConnectionState::Incoming(
-                    P2pConnectionIncomingState::FinalizeSuccess { .. },
-                )) => true,
-                _ => false,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pConnectionIncomingLibp2pReceivedAction {
-    pub peer_id: PeerId,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pConnectionIncomingLibp2pReceivedAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state.peers.get(&self.peer_id).map_or(true, |peer| {
-            matches!(&peer.status, P2pPeerStatus::Disconnected { .. })
-        })
-    }
-}
-
-// --- From<LeafAction> for Action impls.
 use crate::{
     connection::{P2pConnectionAction, P2pConnectionState},
     P2pPeerStatus,
@@ -297,80 +204,8 @@ use crate::{
 
 use super::{P2pConnectionIncomingError, P2pConnectionIncomingState};
 
-impl From<P2pConnectionIncomingInitAction> for crate::P2pAction {
-    fn from(a: P2pConnectionIncomingInitAction) -> Self {
-        Self::Connection(P2pConnectionAction::Incoming(a.into()))
-    }
-}
-
-impl From<P2pConnectionIncomingAnswerSdpCreatePendingAction> for crate::P2pAction {
-    fn from(a: P2pConnectionIncomingAnswerSdpCreatePendingAction) -> Self {
-        Self::Connection(P2pConnectionAction::Incoming(a.into()))
-    }
-}
-
-impl From<P2pConnectionIncomingAnswerSdpCreateErrorAction> for crate::P2pAction {
-    fn from(a: P2pConnectionIncomingAnswerSdpCreateErrorAction) -> Self {
-        Self::Connection(P2pConnectionAction::Incoming(a.into()))
-    }
-}
-
-impl From<P2pConnectionIncomingAnswerSdpCreateSuccessAction> for crate::P2pAction {
-    fn from(a: P2pConnectionIncomingAnswerSdpCreateSuccessAction) -> Self {
-        Self::Connection(P2pConnectionAction::Incoming(a.into()))
-    }
-}
-
-impl From<P2pConnectionIncomingAnswerReadyAction> for crate::P2pAction {
-    fn from(a: P2pConnectionIncomingAnswerReadyAction) -> Self {
-        Self::Connection(P2pConnectionAction::Incoming(a.into()))
-    }
-}
-
-impl From<P2pConnectionIncomingAnswerSendSuccessAction> for crate::P2pAction {
-    fn from(a: P2pConnectionIncomingAnswerSendSuccessAction) -> Self {
-        Self::Connection(P2pConnectionAction::Incoming(a.into()))
-    }
-}
-
-impl From<P2pConnectionIncomingFinalizePendingAction> for crate::P2pAction {
-    fn from(a: P2pConnectionIncomingFinalizePendingAction) -> Self {
-        Self::Connection(P2pConnectionAction::Incoming(a.into()))
-    }
-}
-
-impl From<P2pConnectionIncomingFinalizeErrorAction> for crate::P2pAction {
-    fn from(a: P2pConnectionIncomingFinalizeErrorAction) -> Self {
-        Self::Connection(P2pConnectionAction::Incoming(a.into()))
-    }
-}
-
-impl From<P2pConnectionIncomingFinalizeSuccessAction> for crate::P2pAction {
-    fn from(a: P2pConnectionIncomingFinalizeSuccessAction) -> Self {
-        Self::Connection(P2pConnectionAction::Incoming(a.into()))
-    }
-}
-
-impl From<P2pConnectionIncomingTimeoutAction> for crate::P2pAction {
-    fn from(a: P2pConnectionIncomingTimeoutAction) -> Self {
-        Self::Connection(P2pConnectionAction::Incoming(a.into()))
-    }
-}
-
-impl From<P2pConnectionIncomingErrorAction> for crate::P2pAction {
-    fn from(a: P2pConnectionIncomingErrorAction) -> Self {
-        Self::Connection(P2pConnectionAction::Incoming(a.into()))
-    }
-}
-
-impl From<P2pConnectionIncomingSuccessAction> for crate::P2pAction {
-    fn from(a: P2pConnectionIncomingSuccessAction) -> Self {
-        Self::Connection(P2pConnectionAction::Incoming(a.into()))
-    }
-}
-
-impl From<P2pConnectionIncomingLibp2pReceivedAction> for crate::P2pAction {
-    fn from(a: P2pConnectionIncomingLibp2pReceivedAction) -> Self {
-        Self::Connection(P2pConnectionAction::Incoming(a.into()))
+impl From<P2pConnectionIncomingAction> for P2pAction {
+    fn from(a: P2pConnectionIncomingAction) -> Self {
+        Self::Connection(P2pConnectionAction::Incoming(a))
     }
 }

--- a/p2p/src/connection/incoming/p2p_connection_incoming_effects.rs
+++ b/p2p/src/connection/incoming/p2p_connection_incoming_effects.rs
@@ -4,161 +4,80 @@ use crate::disconnection::{P2pDisconnectionAction, P2pDisconnectionReason};
 use crate::peer::P2pPeerAction;
 use crate::{connection::P2pConnectionService, webrtc};
 
-use super::{
-    P2pConnectionIncomingAnswerReadyAction, P2pConnectionIncomingAnswerSdpCreateErrorAction,
-    P2pConnectionIncomingAnswerSdpCreatePendingAction,
-    P2pConnectionIncomingAnswerSdpCreateSuccessAction,
-    P2pConnectionIncomingAnswerSendSuccessAction, P2pConnectionIncomingError,
-    P2pConnectionIncomingErrorAction, P2pConnectionIncomingFinalizeErrorAction,
-    P2pConnectionIncomingFinalizePendingAction, P2pConnectionIncomingFinalizeSuccessAction,
-    P2pConnectionIncomingInitAction, P2pConnectionIncomingLibp2pReceivedAction,
-    P2pConnectionIncomingSuccessAction, P2pConnectionIncomingTimeoutAction,
-};
+use super::{P2pConnectionIncomingAction, P2pConnectionIncomingError};
 
-impl P2pConnectionIncomingInitAction {
+impl P2pConnectionIncomingAction {
     pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
     where
         Store: crate::P2pStore<S>,
         Store::Service: P2pConnectionService,
-        P2pConnectionIncomingAnswerSdpCreatePendingAction: redux::EnablingCondition<S>,
-    {
-        let peer_id = self.opts.peer_id;
-        store.service().incoming_init(peer_id, self.opts.offer);
-        store.dispatch(P2pConnectionIncomingAnswerSdpCreatePendingAction { peer_id });
-    }
-}
-
-impl P2pConnectionIncomingAnswerSdpCreateErrorAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-        Store::Service: P2pConnectionService,
-        P2pConnectionIncomingErrorAction: redux::EnablingCondition<S>,
-    {
-        store.dispatch(P2pConnectionIncomingErrorAction {
-            peer_id: self.peer_id,
-            error: P2pConnectionIncomingError::SdpCreateError(self.error),
-        });
-    }
-}
-
-impl P2pConnectionIncomingAnswerSdpCreateSuccessAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-        Store::Service: P2pConnectionService,
-        P2pConnectionIncomingAnswerReadyAction: redux::EnablingCondition<S>,
-    {
-        let answer = webrtc::Answer {
-            sdp: self.sdp,
-            identity_pub_key: store.state().config.identity_pub_key.clone(),
-            target_peer_id: self.peer_id,
-        };
-        store.dispatch(P2pConnectionIncomingAnswerReadyAction {
-            peer_id: self.peer_id,
-            answer,
-        });
-    }
-}
-
-impl P2pConnectionIncomingAnswerReadyAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-        Store::Service: P2pConnectionService,
-    {
-        store.service().set_answer(self.peer_id, self.answer);
-    }
-}
-
-impl P2pConnectionIncomingAnswerSendSuccessAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-        Store::Service: P2pConnectionService,
-        P2pConnectionIncomingFinalizePendingAction: redux::EnablingCondition<S>,
-    {
-        store.dispatch(P2pConnectionIncomingFinalizePendingAction {
-            peer_id: self.peer_id,
-        });
-    }
-}
-
-impl P2pConnectionIncomingFinalizeErrorAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-        Store::Service: P2pConnectionService,
-        P2pConnectionIncomingErrorAction: redux::EnablingCondition<S>,
-    {
-        store.dispatch(P2pConnectionIncomingErrorAction {
-            peer_id: self.peer_id,
-            error: P2pConnectionIncomingError::FinalizeError(self.error),
-        });
-    }
-}
-
-impl P2pConnectionIncomingFinalizeSuccessAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-        Store::Service: P2pConnectionService,
-        P2pConnectionIncomingSuccessAction: redux::EnablingCondition<S>,
-    {
-        store.dispatch(P2pConnectionIncomingSuccessAction {
-            peer_id: self.peer_id,
-        });
-    }
-}
-
-impl P2pConnectionIncomingTimeoutAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-        Store::Service: P2pConnectionService,
-        P2pConnectionIncomingErrorAction: redux::EnablingCondition<S>,
-    {
-        store.dispatch(P2pConnectionIncomingErrorAction {
-            peer_id: self.peer_id,
-            error: P2pConnectionIncomingError::Timeout,
-        });
-    }
-}
-
-impl P2pConnectionIncomingSuccessAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-        Store::Service: P2pConnectionService,
-        P2pPeerAction: redux::EnablingCondition<S>,
-    {
-        let peer_id = self.peer_id;
-        store.dispatch(P2pPeerAction::Ready {
-            peer_id,
-            incoming: true,
-        });
-    }
-}
-
-impl P2pConnectionIncomingLibp2pReceivedAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-        Store::Service: P2pConnectionService,
-        P2pPeerAction: redux::EnablingCondition<S>,
         P2pDisconnectionAction: redux::EnablingCondition<S>,
+        P2pPeerAction: redux::EnablingCondition<S>,
+        P2pConnectionIncomingAction: redux::EnablingCondition<S>,
     {
-        let peer_id = self.peer_id;
-        if let Err(err) = store.state().libp2p_incoming_accept(peer_id) {
-            store.dispatch(P2pDisconnectionAction::Init {
-                peer_id,
-                reason: P2pDisconnectionReason::Libp2pIncomingRejected(err),
-            });
-        } else {
-            store.dispatch(P2pPeerAction::Ready {
-                peer_id,
-                incoming: true,
-            });
+        match self {
+            P2pConnectionIncomingAction::Init { opts, .. } => {
+                let peer_id = opts.peer_id;
+                store.service().incoming_init(peer_id, opts.offer);
+                store.dispatch(P2pConnectionIncomingAction::AnswerSdpCreatePending { peer_id });
+            }
+            P2pConnectionIncomingAction::AnswerSdpCreateError { peer_id, error } => {
+                store.dispatch(P2pConnectionIncomingAction::Error {
+                    peer_id,
+                    error: P2pConnectionIncomingError::SdpCreateError(error),
+                });
+            }
+            P2pConnectionIncomingAction::AnswerSdpCreateSuccess { peer_id, sdp } => {
+                let answer = webrtc::Answer {
+                    sdp,
+                    identity_pub_key: store.state().config.identity_pub_key.clone(),
+                    target_peer_id: peer_id,
+                };
+                store.dispatch(P2pConnectionIncomingAction::AnswerReady { peer_id, answer });
+            }
+            P2pConnectionIncomingAction::AnswerReady { peer_id, answer } => {
+                store.service().set_answer(peer_id, answer);
+            }
+            P2pConnectionIncomingAction::AnswerSendSuccess { peer_id } => {
+                store.dispatch(P2pConnectionIncomingAction::FinalizePending { peer_id });
+            }
+            P2pConnectionIncomingAction::FinalizeError { peer_id, error } => {
+                store.dispatch(P2pConnectionIncomingAction::Error {
+                    peer_id,
+                    error: P2pConnectionIncomingError::FinalizeError(error),
+                });
+            }
+            P2pConnectionIncomingAction::FinalizeSuccess { peer_id } => {
+                store.dispatch(P2pConnectionIncomingAction::Success { peer_id });
+            }
+            P2pConnectionIncomingAction::Timeout { peer_id } => {
+                store.dispatch(P2pConnectionIncomingAction::Error {
+                    peer_id,
+                    error: P2pConnectionIncomingError::Timeout,
+                });
+            }
+            P2pConnectionIncomingAction::Success { peer_id } => {
+                store.dispatch(P2pPeerAction::Ready {
+                    peer_id,
+                    incoming: true,
+                });
+            }
+            P2pConnectionIncomingAction::Libp2pReceived { peer_id } => {
+                if let Err(err) = store.state().libp2p_incoming_accept(peer_id) {
+                    store.dispatch(P2pDisconnectionAction::Init {
+                        peer_id,
+                        reason: P2pDisconnectionReason::Libp2pIncomingRejected(err),
+                    });
+                } else {
+                    store.dispatch(P2pPeerAction::Ready {
+                        peer_id,
+                        incoming: true,
+                    });
+                }
+            }
+            P2pConnectionIncomingAction::AnswerSdpCreatePending { .. } => {}
+            P2pConnectionIncomingAction::FinalizePending { .. } => {}
+            P2pConnectionIncomingAction::Error { .. } => {}
         }
     }
 }

--- a/p2p/src/connection/incoming/p2p_connection_incoming_effects.rs
+++ b/p2p/src/connection/incoming/p2p_connection_incoming_effects.rs
@@ -1,6 +1,6 @@
 use redux::ActionMeta;
 
-use crate::disconnection::{P2pDisconnectionInitAction, P2pDisconnectionReason};
+use crate::disconnection::{P2pDisconnectionAction, P2pDisconnectionReason};
 use crate::peer::P2pPeerAction;
 use crate::{connection::P2pConnectionService, webrtc};
 
@@ -146,11 +146,11 @@ impl P2pConnectionIncomingLibp2pReceivedAction {
         Store: crate::P2pStore<S>,
         Store::Service: P2pConnectionService,
         P2pPeerAction: redux::EnablingCondition<S>,
-        P2pDisconnectionInitAction: redux::EnablingCondition<S>,
+        P2pDisconnectionAction: redux::EnablingCondition<S>,
     {
         let peer_id = self.peer_id;
         if let Err(err) = store.state().libp2p_incoming_accept(peer_id) {
-            store.dispatch(P2pDisconnectionInitAction {
+            store.dispatch(P2pDisconnectionAction::Init {
                 peer_id,
                 reason: P2pDisconnectionReason::Libp2pIncomingRejected(err),
             });

--- a/p2p/src/connection/incoming/p2p_connection_incoming_effects.rs
+++ b/p2p/src/connection/incoming/p2p_connection_incoming_effects.rs
@@ -1,7 +1,7 @@
 use redux::ActionMeta;
 
 use crate::disconnection::{P2pDisconnectionInitAction, P2pDisconnectionReason};
-use crate::peer::P2pPeerReadyAction;
+use crate::peer::P2pPeerAction;
 use crate::{connection::P2pConnectionService, webrtc};
 
 use super::{
@@ -130,10 +130,10 @@ impl P2pConnectionIncomingSuccessAction {
     where
         Store: crate::P2pStore<S>,
         Store::Service: P2pConnectionService,
-        P2pPeerReadyAction: redux::EnablingCondition<S>,
+        P2pPeerAction: redux::EnablingCondition<S>,
     {
         let peer_id = self.peer_id;
-        store.dispatch(P2pPeerReadyAction {
+        store.dispatch(P2pPeerAction::Ready {
             peer_id,
             incoming: true,
         });
@@ -145,7 +145,7 @@ impl P2pConnectionIncomingLibp2pReceivedAction {
     where
         Store: crate::P2pStore<S>,
         Store::Service: P2pConnectionService,
-        P2pPeerReadyAction: redux::EnablingCondition<S>,
+        P2pPeerAction: redux::EnablingCondition<S>,
         P2pDisconnectionInitAction: redux::EnablingCondition<S>,
     {
         let peer_id = self.peer_id;
@@ -155,7 +155,7 @@ impl P2pConnectionIncomingLibp2pReceivedAction {
                 reason: P2pDisconnectionReason::Libp2pIncomingRejected(err),
             });
         } else {
-            store.dispatch(P2pPeerReadyAction {
+            store.dispatch(P2pPeerAction::Ready {
                 peer_id,
                 incoming: true,
             });

--- a/p2p/src/connection/incoming/p2p_connection_incoming_reducer.rs
+++ b/p2p/src/connection/incoming/p2p_connection_incoming_reducer.rs
@@ -6,15 +6,15 @@ impl P2pConnectionIncomingState {
     pub fn reducer(&mut self, action: P2pConnectionIncomingActionWithMetaRef<'_>) {
         let (action, meta) = action.split();
         match action {
-            P2pConnectionIncomingAction::Init(content) => {
+            P2pConnectionIncomingAction::Init { opts, rpc_id } => {
                 *self = Self::Init {
                     time: meta.time(),
-                    signaling: content.opts.signaling.clone(),
-                    offer: content.opts.offer.clone(),
-                    rpc_id: content.rpc_id,
+                    signaling: opts.signaling.clone(),
+                    offer: opts.offer.clone(),
+                    rpc_id: *rpc_id,
                 };
             }
-            P2pConnectionIncomingAction::AnswerSdpCreatePending(_) => {
+            P2pConnectionIncomingAction::AnswerSdpCreatePending { .. } => {
                 if let Self::Init {
                     signaling,
                     offer,
@@ -30,8 +30,8 @@ impl P2pConnectionIncomingState {
                     };
                 }
             }
-            P2pConnectionIncomingAction::AnswerSdpCreateError(_) => {}
-            P2pConnectionIncomingAction::AnswerSdpCreateSuccess(action) => {
+            P2pConnectionIncomingAction::AnswerSdpCreateError { .. } => {}
+            P2pConnectionIncomingAction::AnswerSdpCreateSuccess { sdp, .. } => {
                 if let Self::AnswerSdpCreatePending {
                     signaling,
                     offer,
@@ -43,12 +43,12 @@ impl P2pConnectionIncomingState {
                         time: meta.time(),
                         signaling: signaling.clone(),
                         offer: offer.clone(),
-                        sdp: action.sdp.clone(),
+                        sdp: sdp.clone(),
                         rpc_id: rpc_id.take(),
                     };
                 }
             }
-            P2pConnectionIncomingAction::AnswerReady(action) => {
+            P2pConnectionIncomingAction::AnswerReady { answer, .. } => {
                 if let Self::AnswerSdpCreateSuccess {
                     signaling,
                     offer,
@@ -60,12 +60,12 @@ impl P2pConnectionIncomingState {
                         time: meta.time(),
                         signaling: signaling.clone(),
                         offer: offer.clone(),
-                        answer: action.answer.clone(),
+                        answer: answer.clone(),
                         rpc_id: rpc_id.take(),
                     };
                 }
             }
-            P2pConnectionIncomingAction::AnswerSendSuccess(_) => {
+            P2pConnectionIncomingAction::AnswerSendSuccess { .. } => {
                 if let Self::AnswerReady {
                     signaling,
                     offer,
@@ -83,7 +83,7 @@ impl P2pConnectionIncomingState {
                     };
                 }
             }
-            P2pConnectionIncomingAction::FinalizePending(_) => {
+            P2pConnectionIncomingAction::FinalizePending { .. } => {
                 if let Self::AnswerSendSuccess {
                     signaling,
                     offer,
@@ -101,8 +101,8 @@ impl P2pConnectionIncomingState {
                     };
                 }
             }
-            P2pConnectionIncomingAction::FinalizeError(_) => {}
-            P2pConnectionIncomingAction::FinalizeSuccess(_) => {
+            P2pConnectionIncomingAction::FinalizeError { .. } => {}
+            P2pConnectionIncomingAction::FinalizeSuccess { .. } => {
                 if let Self::FinalizePending {
                     signaling,
                     offer,
@@ -120,16 +120,16 @@ impl P2pConnectionIncomingState {
                     };
                 }
             }
-            P2pConnectionIncomingAction::Timeout(_) => {}
-            P2pConnectionIncomingAction::Error(action) => {
+            P2pConnectionIncomingAction::Timeout { .. } => {}
+            P2pConnectionIncomingAction::Error { error, .. } => {
                 let rpc_id = self.rpc_id();
                 *self = Self::Error {
                     time: meta.time(),
-                    error: action.error.clone(),
+                    error: error.clone(),
                     rpc_id,
                 };
             }
-            P2pConnectionIncomingAction::Success(_) => {
+            P2pConnectionIncomingAction::Success { .. } => {
                 if let Self::FinalizeSuccess {
                     signaling,
                     offer,
@@ -147,7 +147,7 @@ impl P2pConnectionIncomingState {
                     };
                 }
             }
-            P2pConnectionIncomingAction::Libp2pReceived(_) => {
+            P2pConnectionIncomingAction::Libp2pReceived { .. } => {
                 // handled in the parent reducer.
             }
         }

--- a/p2p/src/connection/outgoing/p2p_connection_outgoing_actions.rs
+++ b/p2p/src/connection/outgoing/p2p_connection_outgoing_actions.rs
@@ -11,389 +11,264 @@ use super::{P2pConnectionOutgoingError, P2pConnectionOutgoingInitOpts};
 pub type P2pConnectionOutgoingActionWithMetaRef<'a> =
     redux::ActionWithMeta<&'a P2pConnectionOutgoingAction>;
 
-#[derive(derive_more::From, Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum P2pConnectionOutgoingAction {
-    RandomInit(P2pConnectionOutgoingRandomInitAction),
-    Init(P2pConnectionOutgoingInitAction),
-    Reconnect(P2pConnectionOutgoingReconnectAction),
-    OfferSdpCreatePending(P2pConnectionOutgoingOfferSdpCreatePendingAction),
-    OfferSdpCreateError(P2pConnectionOutgoingOfferSdpCreateErrorAction),
-    OfferSdpCreateSuccess(P2pConnectionOutgoingOfferSdpCreateSuccessAction),
-    OfferReady(P2pConnectionOutgoingOfferReadyAction),
-    OfferSendSuccess(P2pConnectionOutgoingOfferSendSuccessAction),
-    AnswerRecvPending(P2pConnectionOutgoingAnswerRecvPendingAction),
-    AnswerRecvError(P2pConnectionOutgoingAnswerRecvErrorAction),
-    AnswerRecvSuccess(P2pConnectionOutgoingAnswerRecvSuccessAction),
-    FinalizePending(P2pConnectionOutgoingFinalizePendingAction),
-    FinalizeError(P2pConnectionOutgoingFinalizeErrorAction),
-    FinalizeSuccess(P2pConnectionOutgoingFinalizeSuccessAction),
-    Timeout(P2pConnectionOutgoingTimeoutAction),
-    Error(P2pConnectionOutgoingErrorAction),
-    Success(P2pConnectionOutgoingSuccessAction),
+    RandomInit,
+    Init {
+        opts: P2pConnectionOutgoingInitOpts,
+        rpc_id: Option<RpcId>,
+    },
+    Reconnect {
+        opts: P2pConnectionOutgoingInitOpts,
+        rpc_id: Option<RpcId>,
+    },
+    OfferSdpCreatePending {
+        peer_id: PeerId,
+    },
+    OfferSdpCreateError {
+        peer_id: PeerId,
+        error: String,
+    },
+    OfferSdpCreateSuccess {
+        peer_id: PeerId,
+        sdp: String,
+    },
+    OfferReady {
+        peer_id: PeerId,
+        offer: webrtc::Offer,
+    },
+    OfferSendSuccess {
+        peer_id: PeerId,
+    },
+    AnswerRecvPending {
+        peer_id: PeerId,
+    },
+    AnswerRecvError {
+        peer_id: PeerId,
+        error: P2pConnectionErrorResponse,
+    },
+    AnswerRecvSuccess {
+        peer_id: PeerId,
+        answer: webrtc::Answer,
+    },
+    FinalizePending {
+        peer_id: PeerId,
+    },
+    FinalizeError {
+        peer_id: PeerId,
+        error: String,
+    },
+    FinalizeSuccess {
+        peer_id: PeerId,
+    },
+    Timeout {
+        peer_id: PeerId,
+    },
+    Error {
+        peer_id: PeerId,
+        error: P2pConnectionOutgoingError,
+    },
+    Success {
+        peer_id: PeerId,
+    },
 }
 
 impl P2pConnectionOutgoingAction {
     pub fn peer_id(&self) -> Option<&PeerId> {
         match self {
-            Self::RandomInit(_) => None,
-            Self::Init(v) => Some(v.opts.peer_id()),
-            Self::Reconnect(v) => Some(v.opts.peer_id()),
-            Self::OfferSdpCreatePending(v) => Some(&v.peer_id),
-            Self::OfferSdpCreateError(v) => Some(&v.peer_id),
-            Self::OfferSdpCreateSuccess(v) => Some(&v.peer_id),
-            Self::OfferReady(v) => Some(&v.peer_id),
-            Self::OfferSendSuccess(v) => Some(&v.peer_id),
-            Self::AnswerRecvPending(v) => Some(&v.peer_id),
-            Self::AnswerRecvError(v) => Some(&v.peer_id),
-            Self::AnswerRecvSuccess(v) => Some(&v.peer_id),
-            Self::FinalizePending(v) => Some(&v.peer_id),
-            Self::FinalizeError(v) => Some(&v.peer_id),
-            Self::FinalizeSuccess(v) => Some(&v.peer_id),
-            Self::Timeout(v) => Some(&v.peer_id),
-            Self::Error(v) => Some(&v.peer_id),
-            Self::Success(v) => Some(&v.peer_id),
+            Self::RandomInit => None,
+            Self::Init { opts, .. } | Self::Reconnect { opts, .. } => Some(opts.peer_id()),
+            Self::OfferSdpCreatePending { peer_id, .. }
+            | Self::OfferSdpCreateError { peer_id, .. }
+            | Self::OfferSdpCreateSuccess { peer_id, .. }
+            | Self::OfferReady { peer_id, .. }
+            | Self::OfferSendSuccess { peer_id }
+            | Self::AnswerRecvPending { peer_id }
+            | Self::AnswerRecvError { peer_id, .. }
+            | Self::AnswerRecvSuccess { peer_id, .. }
+            | Self::FinalizePending { peer_id }
+            | Self::FinalizeError { peer_id, .. }
+            | Self::FinalizeSuccess { peer_id }
+            | Self::Timeout { peer_id }
+            | Self::Error { peer_id, .. }
+            | Self::Success { peer_id } => Some(peer_id),
         }
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pConnectionOutgoingRandomInitAction {}
-
-impl redux::EnablingCondition<P2pState> for P2pConnectionOutgoingRandomInitAction {
+impl redux::EnablingCondition<P2pState> for P2pConnectionOutgoingAction {
     fn is_enabled(&self, state: &P2pState) -> bool {
-        !state.already_has_min_peers() && !state.initial_unused_peers().is_empty()
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pConnectionOutgoingInitAction {
-    pub opts: P2pConnectionOutgoingInitOpts,
-    pub rpc_id: Option<RpcId>,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pConnectionOutgoingInitAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        !state.already_has_min_peers() && !state.peers.contains_key(self.opts.peer_id())
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pConnectionOutgoingReconnectAction {
-    pub opts: P2pConnectionOutgoingInitOpts,
-    pub rpc_id: Option<RpcId>,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pConnectionOutgoingReconnectAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        if state.already_has_min_peers() {
-            return false;
-        }
-
-        state
-            .peers
-            .iter()
-            .filter_map(|(id, p)| match &p.status {
-                P2pPeerStatus::Connecting(s) => match s {
-                    P2pConnectionState::Outgoing(P2pConnectionOutgoingState::Error {
-                        time,
-                        ..
-                    }) => Some((*time, id, &p.dial_opts)),
-                    P2pConnectionState::Incoming(P2pConnectionIncomingState::Error {
-                        time,
-                        ..
-                    }) => Some((*time, id, &p.dial_opts)),
-                    _ => None,
-                },
-                P2pPeerStatus::Disconnected { time } => Some((*time, id, &p.dial_opts)),
-                P2pPeerStatus::Ready(_) => None,
-            })
-            .min_by_key(|(time, ..)| *time)
-            .filter(|(_, id, _)| *id == self.opts.peer_id())
-            .filter(|(.., opts)| opts.as_ref().map_or(true, |opts| opts == &self.opts))
-            .is_some()
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pConnectionOutgoingOfferSdpCreatePendingAction {
-    pub peer_id: PeerId,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pConnectionOutgoingOfferSdpCreatePendingAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .peers
-            .get(&self.peer_id)
-            .map_or(false, |peer| match &peer.status {
-                P2pPeerStatus::Connecting(P2pConnectionState::Outgoing(
-                    P2pConnectionOutgoingState::Init { .. },
-                )) => true,
-                _ => false,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pConnectionOutgoingOfferSdpCreateErrorAction {
-    pub peer_id: PeerId,
-    pub error: String,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pConnectionOutgoingOfferSdpCreateErrorAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .peers
-            .get(&self.peer_id)
-            .map_or(false, |peer| match &peer.status {
-                P2pPeerStatus::Connecting(P2pConnectionState::Outgoing(
-                    P2pConnectionOutgoingState::OfferSdpCreatePending { .. },
-                )) => true,
-                _ => false,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pConnectionOutgoingOfferSdpCreateSuccessAction {
-    pub peer_id: PeerId,
-    pub sdp: String,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pConnectionOutgoingOfferSdpCreateSuccessAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .peers
-            .get(&self.peer_id)
-            .map_or(false, |peer| match &peer.status {
-                P2pPeerStatus::Connecting(P2pConnectionState::Outgoing(
-                    P2pConnectionOutgoingState::OfferSdpCreatePending { .. },
-                )) => true,
-                _ => false,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pConnectionOutgoingOfferReadyAction {
-    pub peer_id: PeerId,
-    pub offer: webrtc::Offer,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pConnectionOutgoingOfferReadyAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .peers
-            .get(&self.peer_id)
-            .map_or(false, |peer| match &peer.status {
-                P2pPeerStatus::Connecting(P2pConnectionState::Outgoing(
-                    P2pConnectionOutgoingState::OfferSdpCreateSuccess { .. },
-                )) => true,
-                _ => false,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pConnectionOutgoingOfferSendSuccessAction {
-    pub peer_id: PeerId,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pConnectionOutgoingOfferSendSuccessAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .peers
-            .get(&self.peer_id)
-            .map_or(false, |peer| match &peer.status {
-                P2pPeerStatus::Connecting(P2pConnectionState::Outgoing(
-                    P2pConnectionOutgoingState::OfferReady { .. },
-                )) => true,
-                _ => false,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pConnectionOutgoingAnswerRecvPendingAction {
-    pub peer_id: PeerId,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pConnectionOutgoingAnswerRecvPendingAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .peers
-            .get(&self.peer_id)
-            .map_or(false, |peer| match &peer.status {
-                P2pPeerStatus::Connecting(P2pConnectionState::Outgoing(
-                    P2pConnectionOutgoingState::OfferSendSuccess { .. },
-                )) => true,
-                _ => false,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pConnectionOutgoingAnswerRecvErrorAction {
-    pub peer_id: PeerId,
-    pub error: P2pConnectionErrorResponse,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pConnectionOutgoingAnswerRecvErrorAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .peers
-            .get(&self.peer_id)
-            .map_or(false, |peer| match &peer.status {
-                P2pPeerStatus::Connecting(P2pConnectionState::Outgoing(
-                    P2pConnectionOutgoingState::AnswerRecvPending { .. },
-                )) => true,
-                _ => false,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pConnectionOutgoingAnswerRecvSuccessAction {
-    pub peer_id: PeerId,
-    pub answer: webrtc::Answer,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pConnectionOutgoingAnswerRecvSuccessAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .peers
-            .get(&self.peer_id)
-            .map_or(false, |peer| match &peer.status {
-                P2pPeerStatus::Connecting(P2pConnectionState::Outgoing(
-                    P2pConnectionOutgoingState::AnswerRecvPending { .. },
-                )) => true,
-                _ => false,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pConnectionOutgoingFinalizePendingAction {
-    pub peer_id: PeerId,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pConnectionOutgoingFinalizePendingAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .peers
-            .get(&self.peer_id)
-            .map_or(false, |peer| match &peer.status {
-                P2pPeerStatus::Connecting(P2pConnectionState::Outgoing(v)) => match v {
-                    P2pConnectionOutgoingState::Init { opts, .. } => opts.is_libp2p(),
-                    P2pConnectionOutgoingState::AnswerRecvSuccess { .. } => true,
+        match self {
+            P2pConnectionOutgoingAction::RandomInit => {
+                !state.already_has_min_peers() && !state.initial_unused_peers().is_empty()
+            }
+            P2pConnectionOutgoingAction::Init { opts, .. } => {
+                !state.already_has_min_peers() && !state.peers.contains_key(opts.peer_id())
+            }
+            P2pConnectionOutgoingAction::Reconnect { opts, .. } => {
+                if state.already_has_min_peers() {
+                    return false;
+                }
+                state
+                    .peers
+                    .iter()
+                    .filter_map(|(id, p)| match &p.status {
+                        P2pPeerStatus::Connecting(s) => {
+                            match s {
+                                P2pConnectionState::Outgoing(
+                                    P2pConnectionOutgoingState::Error { time, .. },
+                                )
+                                | P2pConnectionState::Incoming(
+                                    P2pConnectionIncomingState::Error { time, .. },
+                                ) => Some((*time, id, &p.dial_opts)),
+                                _ => None,
+                            }
+                        }
+                        P2pPeerStatus::Disconnected { time } => Some((*time, id, &p.dial_opts)),
+                        _ => None,
+                    })
+                    .min_by_key(|(time, ..)| *time)
+                    .filter(|(_, id, _)| *id == opts.peer_id())
+                    .filter(|(.., peer_opts)| peer_opts.as_ref().map_or(true, |o| o == opts))
+                    .is_some()
+            }
+            P2pConnectionOutgoingAction::OfferSdpCreatePending { peer_id } => state
+                .peers
+                .get(peer_id)
+                .map_or(false, |peer| match &peer.status {
+                    P2pPeerStatus::Connecting(P2pConnectionState::Outgoing(
+                        P2pConnectionOutgoingState::Init { .. },
+                    )) => true,
                     _ => false,
-                },
-                _ => false,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pConnectionOutgoingFinalizeErrorAction {
-    pub peer_id: PeerId,
-    pub error: String,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pConnectionOutgoingFinalizeErrorAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .peers
-            .get(&self.peer_id)
-            .map_or(false, |peer| match &peer.status {
-                P2pPeerStatus::Connecting(P2pConnectionState::Outgoing(
-                    P2pConnectionOutgoingState::FinalizePending { .. },
-                )) => true,
-                _ => false,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pConnectionOutgoingFinalizeSuccessAction {
-    pub peer_id: PeerId,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pConnectionOutgoingFinalizeSuccessAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .peers
-            .get(&self.peer_id)
-            .map_or(false, |peer| match &peer.status {
-                P2pPeerStatus::Connecting(P2pConnectionState::Outgoing(
-                    P2pConnectionOutgoingState::FinalizePending { .. },
-                )) => true,
-                _ => false,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pConnectionOutgoingTimeoutAction {
-    pub peer_id: PeerId,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pConnectionOutgoingTimeoutAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .peers
-            .get(&self.peer_id)
-            .and_then(|peer| peer.status.as_connecting()?.as_outgoing())
-            .is_some()
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pConnectionOutgoingErrorAction {
-    pub peer_id: PeerId,
-    pub error: P2pConnectionOutgoingError,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pConnectionOutgoingErrorAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .peers
-            .get(&self.peer_id)
-            .map_or(false, |peer| match &peer.status {
-                P2pPeerStatus::Connecting(P2pConnectionState::Outgoing(s)) => match &self.error {
-                    P2pConnectionOutgoingError::SdpCreateError(_) => {
-                        matches!(s, P2pConnectionOutgoingState::OfferSdpCreatePending { .. })
-                    }
-                    P2pConnectionOutgoingError::Rejected(_) => {
-                        matches!(s, P2pConnectionOutgoingState::AnswerRecvPending { .. })
-                    }
-                    P2pConnectionOutgoingError::RemoteInternalError => {
-                        matches!(s, P2pConnectionOutgoingState::AnswerRecvPending { .. })
-                    }
-                    P2pConnectionOutgoingError::FinalizeError(_) => {
-                        matches!(s, P2pConnectionOutgoingState::FinalizePending { .. })
-                    }
-                    P2pConnectionOutgoingError::Timeout => true,
-                },
-                _ => false,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pConnectionOutgoingSuccessAction {
-    pub peer_id: PeerId,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pConnectionOutgoingSuccessAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .peers
-            .get(&self.peer_id)
-            .map_or(false, |peer| match &peer.status {
-                P2pPeerStatus::Connecting(P2pConnectionState::Outgoing(
-                    P2pConnectionOutgoingState::FinalizeSuccess { .. },
-                )) => true,
-                _ => false,
-            })
+                }),
+            P2pConnectionOutgoingAction::OfferSdpCreateError { peer_id, .. } => state
+                .peers
+                .get(peer_id)
+                .map_or(false, |peer| match &peer.status {
+                    P2pPeerStatus::Connecting(P2pConnectionState::Outgoing(
+                        P2pConnectionOutgoingState::OfferSdpCreatePending { .. },
+                    )) => true,
+                    _ => false,
+                }),
+            P2pConnectionOutgoingAction::OfferSdpCreateSuccess { peer_id, .. } => state
+                .peers
+                .get(peer_id)
+                .map_or(false, |peer| match &peer.status {
+                    P2pPeerStatus::Connecting(P2pConnectionState::Outgoing(
+                        P2pConnectionOutgoingState::OfferSdpCreatePending { .. },
+                    )) => true,
+                    _ => false,
+                }),
+            P2pConnectionOutgoingAction::OfferReady { peer_id, .. } => state
+                .peers
+                .get(peer_id)
+                .map_or(false, |peer| match &peer.status {
+                    P2pPeerStatus::Connecting(P2pConnectionState::Outgoing(
+                        P2pConnectionOutgoingState::OfferSdpCreateSuccess { .. },
+                    )) => true,
+                    _ => false,
+                }),
+            P2pConnectionOutgoingAction::OfferSendSuccess { peer_id } => state
+                .peers
+                .get(peer_id)
+                .map_or(false, |peer| match &peer.status {
+                    P2pPeerStatus::Connecting(P2pConnectionState::Outgoing(
+                        P2pConnectionOutgoingState::OfferReady { .. },
+                    )) => true,
+                    _ => false,
+                }),
+            P2pConnectionOutgoingAction::AnswerRecvPending { peer_id } => state
+                .peers
+                .get(peer_id)
+                .map_or(false, |peer| match &peer.status {
+                    P2pPeerStatus::Connecting(P2pConnectionState::Outgoing(
+                        P2pConnectionOutgoingState::OfferSendSuccess { .. },
+                    )) => true,
+                    _ => false,
+                }),
+            P2pConnectionOutgoingAction::AnswerRecvError { peer_id, .. } => state
+                .peers
+                .get(peer_id)
+                .map_or(false, |peer| match &peer.status {
+                    P2pPeerStatus::Connecting(P2pConnectionState::Outgoing(
+                        P2pConnectionOutgoingState::AnswerRecvPending { .. },
+                    )) => true,
+                    _ => false,
+                }),
+            P2pConnectionOutgoingAction::AnswerRecvSuccess { peer_id, .. } => state
+                .peers
+                .get(peer_id)
+                .map_or(false, |peer| match &peer.status {
+                    P2pPeerStatus::Connecting(P2pConnectionState::Outgoing(
+                        P2pConnectionOutgoingState::AnswerRecvPending { .. },
+                    )) => true,
+                    _ => false,
+                }),
+            P2pConnectionOutgoingAction::FinalizePending { peer_id } => state
+                .peers
+                .get(peer_id)
+                .map_or(false, |peer| match &peer.status {
+                    P2pPeerStatus::Connecting(P2pConnectionState::Outgoing(v)) => match v {
+                        P2pConnectionOutgoingState::Init { opts, .. } => opts.is_libp2p(),
+                        P2pConnectionOutgoingState::AnswerRecvSuccess { .. } => true,
+                        _ => false,
+                    },
+                    _ => false,
+                }),
+            P2pConnectionOutgoingAction::FinalizeError { peer_id, .. } => state
+                .peers
+                .get(peer_id)
+                .map_or(false, |peer| match &peer.status {
+                    P2pPeerStatus::Connecting(P2pConnectionState::Outgoing(
+                        P2pConnectionOutgoingState::FinalizePending { .. },
+                    )) => true,
+                    _ => false,
+                }),
+            P2pConnectionOutgoingAction::FinalizeSuccess { peer_id } => state
+                .peers
+                .get(peer_id)
+                .map_or(false, |peer| match &peer.status {
+                    P2pPeerStatus::Connecting(P2pConnectionState::Outgoing(
+                        P2pConnectionOutgoingState::FinalizePending { .. },
+                    )) => true,
+                    _ => false,
+                }),
+            P2pConnectionOutgoingAction::Timeout { peer_id } => state
+                .peers
+                .get(peer_id)
+                .and_then(|peer| peer.status.as_connecting()?.as_outgoing())
+                .is_some(),
+            P2pConnectionOutgoingAction::Error { peer_id, error } => state
+                .peers
+                .get(peer_id)
+                .map_or(false, |peer| match &peer.status {
+                    P2pPeerStatus::Connecting(P2pConnectionState::Outgoing(s)) => match error {
+                        P2pConnectionOutgoingError::SdpCreateError(_) => {
+                            matches!(s, P2pConnectionOutgoingState::OfferSdpCreatePending { .. })
+                        }
+                        P2pConnectionOutgoingError::Rejected(_)
+                        | P2pConnectionOutgoingError::RemoteInternalError => {
+                            matches!(s, P2pConnectionOutgoingState::AnswerRecvPending { .. })
+                        }
+                        P2pConnectionOutgoingError::FinalizeError(_) => {
+                            matches!(s, P2pConnectionOutgoingState::FinalizePending { .. })
+                        }
+                        P2pConnectionOutgoingError::Timeout => true,
+                    },
+                    _ => false,
+                }),
+            P2pConnectionOutgoingAction::Success { peer_id } => {
+                state
+                    .peers
+                    .get(peer_id)
+                    .map_or(false, |peer| match &peer.status {
+                        P2pPeerStatus::Connecting(P2pConnectionState::Outgoing(
+                            P2pConnectionOutgoingState::FinalizeSuccess { .. },
+                        )) => true,
+                        _ => false,
+                    })
+            }
+        }
     }
 }
 
@@ -405,104 +280,8 @@ use crate::{
 
 use super::P2pConnectionOutgoingState;
 
-impl From<P2pConnectionOutgoingRandomInitAction> for crate::P2pAction {
-    fn from(a: P2pConnectionOutgoingRandomInitAction) -> Self {
-        Self::Connection(P2pConnectionAction::Outgoing(a.into()))
-    }
-}
-
-impl From<P2pConnectionOutgoingInitAction> for crate::P2pAction {
-    fn from(a: P2pConnectionOutgoingInitAction) -> Self {
-        Self::Connection(P2pConnectionAction::Outgoing(a.into()))
-    }
-}
-
-impl From<P2pConnectionOutgoingReconnectAction> for crate::P2pAction {
-    fn from(a: P2pConnectionOutgoingReconnectAction) -> Self {
-        Self::Connection(P2pConnectionAction::Outgoing(a.into()))
-    }
-}
-
-impl From<P2pConnectionOutgoingOfferSdpCreatePendingAction> for crate::P2pAction {
-    fn from(a: P2pConnectionOutgoingOfferSdpCreatePendingAction) -> Self {
-        Self::Connection(P2pConnectionAction::Outgoing(a.into()))
-    }
-}
-
-impl From<P2pConnectionOutgoingOfferSdpCreateErrorAction> for crate::P2pAction {
-    fn from(a: P2pConnectionOutgoingOfferSdpCreateErrorAction) -> Self {
-        Self::Connection(P2pConnectionAction::Outgoing(a.into()))
-    }
-}
-
-impl From<P2pConnectionOutgoingOfferSdpCreateSuccessAction> for crate::P2pAction {
-    fn from(a: P2pConnectionOutgoingOfferSdpCreateSuccessAction) -> Self {
-        Self::Connection(P2pConnectionAction::Outgoing(a.into()))
-    }
-}
-
-impl From<P2pConnectionOutgoingOfferReadyAction> for crate::P2pAction {
-    fn from(a: P2pConnectionOutgoingOfferReadyAction) -> Self {
-        Self::Connection(P2pConnectionAction::Outgoing(a.into()))
-    }
-}
-
-impl From<P2pConnectionOutgoingOfferSendSuccessAction> for crate::P2pAction {
-    fn from(a: P2pConnectionOutgoingOfferSendSuccessAction) -> Self {
-        Self::Connection(P2pConnectionAction::Outgoing(a.into()))
-    }
-}
-
-impl From<P2pConnectionOutgoingAnswerRecvPendingAction> for crate::P2pAction {
-    fn from(a: P2pConnectionOutgoingAnswerRecvPendingAction) -> Self {
-        Self::Connection(P2pConnectionAction::Outgoing(a.into()))
-    }
-}
-
-impl From<P2pConnectionOutgoingAnswerRecvErrorAction> for crate::P2pAction {
-    fn from(a: P2pConnectionOutgoingAnswerRecvErrorAction) -> Self {
-        Self::Connection(P2pConnectionAction::Outgoing(a.into()))
-    }
-}
-
-impl From<P2pConnectionOutgoingAnswerRecvSuccessAction> for crate::P2pAction {
-    fn from(a: P2pConnectionOutgoingAnswerRecvSuccessAction) -> Self {
-        Self::Connection(P2pConnectionAction::Outgoing(a.into()))
-    }
-}
-
-impl From<P2pConnectionOutgoingFinalizePendingAction> for crate::P2pAction {
-    fn from(a: P2pConnectionOutgoingFinalizePendingAction) -> Self {
-        Self::Connection(P2pConnectionAction::Outgoing(a.into()))
-    }
-}
-
-impl From<P2pConnectionOutgoingFinalizeErrorAction> for crate::P2pAction {
-    fn from(a: P2pConnectionOutgoingFinalizeErrorAction) -> Self {
-        Self::Connection(P2pConnectionAction::Outgoing(a.into()))
-    }
-}
-
-impl From<P2pConnectionOutgoingFinalizeSuccessAction> for crate::P2pAction {
-    fn from(a: P2pConnectionOutgoingFinalizeSuccessAction) -> Self {
-        Self::Connection(P2pConnectionAction::Outgoing(a.into()))
-    }
-}
-
-impl From<P2pConnectionOutgoingTimeoutAction> for crate::P2pAction {
-    fn from(a: P2pConnectionOutgoingTimeoutAction) -> Self {
-        Self::Connection(P2pConnectionAction::Outgoing(a.into()))
-    }
-}
-
-impl From<P2pConnectionOutgoingErrorAction> for crate::P2pAction {
-    fn from(a: P2pConnectionOutgoingErrorAction) -> Self {
-        Self::Connection(P2pConnectionAction::Outgoing(a.into()))
-    }
-}
-
-impl From<P2pConnectionOutgoingSuccessAction> for crate::P2pAction {
-    fn from(a: P2pConnectionOutgoingSuccessAction) -> Self {
-        Self::Connection(P2pConnectionAction::Outgoing(a.into()))
+impl From<P2pConnectionOutgoingAction> for crate::P2pAction {
+    fn from(a: P2pConnectionOutgoingAction) -> Self {
+        Self::Connection(P2pConnectionAction::Outgoing(a))
     }
 }

--- a/p2p/src/connection/outgoing/p2p_connection_outgoing_effects.rs
+++ b/p2p/src/connection/outgoing/p2p_connection_outgoing_effects.rs
@@ -7,242 +7,128 @@ use crate::P2pPeerStatus;
 use crate::{connection::P2pConnectionService, webrtc};
 
 use super::{
-    P2pConnectionOutgoingAnswerRecvErrorAction, P2pConnectionOutgoingAnswerRecvPendingAction,
-    P2pConnectionOutgoingAnswerRecvSuccessAction, P2pConnectionOutgoingError,
-    P2pConnectionOutgoingErrorAction, P2pConnectionOutgoingFinalizeErrorAction,
-    P2pConnectionOutgoingFinalizePendingAction, P2pConnectionOutgoingFinalizeSuccessAction,
-    P2pConnectionOutgoingInitAction, P2pConnectionOutgoingInitOpts,
-    P2pConnectionOutgoingOfferReadyAction, P2pConnectionOutgoingOfferSdpCreateErrorAction,
-    P2pConnectionOutgoingOfferSdpCreatePendingAction,
-    P2pConnectionOutgoingOfferSdpCreateSuccessAction, P2pConnectionOutgoingOfferSendSuccessAction,
-    P2pConnectionOutgoingRandomInitAction, P2pConnectionOutgoingReconnectAction,
-    P2pConnectionOutgoingState, P2pConnectionOutgoingSuccessAction,
-    P2pConnectionOutgoingTimeoutAction,
+    P2pConnectionOutgoingAction, P2pConnectionOutgoingError, P2pConnectionOutgoingInitOpts,
+    P2pConnectionOutgoingState,
 };
 
-impl P2pConnectionOutgoingRandomInitAction {
+impl P2pConnectionOutgoingAction {
     pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
     where
         Store: crate::P2pStore<S>,
         Store::Service: P2pConnectionService,
-        P2pConnectionOutgoingInitAction: redux::EnablingCondition<S>,
-    {
-        let peers = store.state().initial_unused_peers();
-        let picked_peer = store.service().random_pick(&peers);
-        store.dispatch(P2pConnectionOutgoingInitAction {
-            opts: picked_peer,
-            rpc_id: None,
-        });
-    }
-}
-
-impl P2pConnectionOutgoingInitAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-        Store::Service: P2pConnectionService,
-        P2pConnectionOutgoingOfferSdpCreatePendingAction: redux::EnablingCondition<S>,
-        P2pConnectionOutgoingFinalizePendingAction: redux::EnablingCondition<S>,
-    {
-        let peer_id = *self.opts.peer_id();
-        store.service().outgoing_init(self.opts);
-        if !store.dispatch(P2pConnectionOutgoingFinalizePendingAction { peer_id }) {
-            store.dispatch(P2pConnectionOutgoingOfferSdpCreatePendingAction { peer_id });
-        }
-    }
-}
-
-impl P2pConnectionOutgoingReconnectAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-        Store::Service: P2pConnectionService,
-        P2pConnectionOutgoingOfferSdpCreatePendingAction: redux::EnablingCondition<S>,
-        P2pConnectionOutgoingFinalizePendingAction: redux::EnablingCondition<S>,
-    {
-        let peer_id = *self.opts.peer_id();
-        store.service().outgoing_init(self.opts);
-        // for libp2p
-        if !store.dispatch(P2pConnectionOutgoingFinalizePendingAction { peer_id }) {
-            store.dispatch(P2pConnectionOutgoingOfferSdpCreatePendingAction { peer_id });
-        }
-    }
-}
-
-impl P2pConnectionOutgoingOfferSdpCreateErrorAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-        Store::Service: P2pConnectionService,
-        P2pConnectionOutgoingErrorAction: redux::EnablingCondition<S>,
-    {
-        store.dispatch(P2pConnectionOutgoingErrorAction {
-            peer_id: self.peer_id,
-            error: P2pConnectionOutgoingError::SdpCreateError(self.error),
-        });
-    }
-}
-
-impl P2pConnectionOutgoingOfferSdpCreateSuccessAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-        Store::Service: P2pConnectionService,
-        P2pConnectionOutgoingOfferReadyAction: redux::EnablingCondition<S>,
-    {
-        let offer = webrtc::Offer {
-            sdp: self.sdp,
-            identity_pub_key: store.state().config.identity_pub_key.clone(),
-            target_peer_id: self.peer_id,
-            // TODO(vlad9486): put real address
-            host: Host::Ipv4([127, 0, 0, 1].into()),
-            listen_port: store.state().config.listen_port,
-        };
-        store.dispatch(P2pConnectionOutgoingOfferReadyAction {
-            peer_id: self.peer_id,
-            offer,
-        });
-    }
-}
-
-impl P2pConnectionOutgoingOfferReadyAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-        Store::Service: P2pConnectionService,
-        P2pConnectionOutgoingOfferSendSuccessAction: redux::EnablingCondition<S>,
-    {
-        let (state, service) = store.state_and_service();
-        let Some(peer) = state.peers.get(&self.peer_id) else {
-            return;
-        };
-        let P2pPeerStatus::Connecting(P2pConnectionState::Outgoing(
-            P2pConnectionOutgoingState::OfferReady { opts, .. },
-        )) = &peer.status
-        else {
-            return;
-        };
-        let signaling_method = match opts {
-            P2pConnectionOutgoingInitOpts::WebRTC { signaling, .. } => signaling,
-            #[allow(unreachable_patterns)]
-            _ => return,
-        };
-        match signaling_method {
-            webrtc::SignalingMethod::Http(_) | webrtc::SignalingMethod::Https(_) => {
-                let Some(url) = signaling_method.http_url() else {
-                    return;
-                };
-                service.http_signaling_request(url, self.offer);
-            }
-        }
-        store.dispatch(P2pConnectionOutgoingOfferSendSuccessAction {
-            peer_id: self.peer_id,
-        });
-    }
-}
-
-impl P2pConnectionOutgoingOfferSendSuccessAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-        Store::Service: P2pConnectionService,
-        P2pConnectionOutgoingAnswerRecvPendingAction: redux::EnablingCondition<S>,
-    {
-        store.dispatch(P2pConnectionOutgoingAnswerRecvPendingAction {
-            peer_id: self.peer_id,
-        });
-    }
-}
-
-impl P2pConnectionOutgoingAnswerRecvErrorAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-        Store::Service: P2pConnectionService,
-        P2pConnectionOutgoingErrorAction: redux::EnablingCondition<S>,
-    {
-        store.dispatch(P2pConnectionOutgoingErrorAction {
-            peer_id: self.peer_id,
-            error: match self.error {
-                P2pConnectionErrorResponse::Rejected(reason) => {
-                    P2pConnectionOutgoingError::Rejected(reason)
-                }
-                P2pConnectionErrorResponse::InternalError => {
-                    P2pConnectionOutgoingError::RemoteInternalError
-                }
-            },
-        });
-    }
-}
-
-impl P2pConnectionOutgoingAnswerRecvSuccessAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-        Store::Service: P2pConnectionService,
-        P2pConnectionOutgoingFinalizePendingAction: redux::EnablingCondition<S>,
-    {
-        store
-            .service()
-            .set_answer(self.peer_id, self.answer.clone());
-        store.dispatch(P2pConnectionOutgoingFinalizePendingAction {
-            peer_id: self.peer_id,
-        });
-    }
-}
-
-impl P2pConnectionOutgoingFinalizeErrorAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-        Store::Service: P2pConnectionService,
-        P2pConnectionOutgoingErrorAction: redux::EnablingCondition<S>,
-    {
-        store.dispatch(P2pConnectionOutgoingErrorAction {
-            peer_id: self.peer_id,
-            error: P2pConnectionOutgoingError::FinalizeError(self.error),
-        });
-    }
-}
-
-impl P2pConnectionOutgoingFinalizeSuccessAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-        Store::Service: P2pConnectionService,
-        P2pConnectionOutgoingSuccessAction: redux::EnablingCondition<S>,
-    {
-        store.dispatch(P2pConnectionOutgoingSuccessAction {
-            peer_id: self.peer_id,
-        });
-    }
-}
-
-impl P2pConnectionOutgoingTimeoutAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-        Store::Service: P2pConnectionService,
-        P2pConnectionOutgoingErrorAction: redux::EnablingCondition<S>,
-    {
-        store.dispatch(P2pConnectionOutgoingErrorAction {
-            peer_id: self.peer_id,
-            error: P2pConnectionOutgoingError::Timeout,
-        });
-    }
-}
-
-impl P2pConnectionOutgoingSuccessAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-        Store::Service: P2pConnectionService,
+        Self: redux::EnablingCondition<S>,
         P2pPeerAction: redux::EnablingCondition<S>,
     {
-        let peer_id = self.peer_id;
-        store.dispatch(P2pPeerAction::Ready {
-            peer_id,
-            incoming: false,
-        });
+        match self {
+            P2pConnectionOutgoingAction::RandomInit => {
+                let peers = store.state().initial_unused_peers();
+                let picked_peer = store.service().random_pick(&peers);
+                store.dispatch(P2pConnectionOutgoingAction::Init {
+                    opts: picked_peer,
+                    rpc_id: None,
+                });
+            }
+            P2pConnectionOutgoingAction::Init { opts, .. } => {
+                let peer_id = *opts.peer_id();
+                store.service().outgoing_init(opts.clone());
+                // for libp2p
+                if !store.dispatch(P2pConnectionOutgoingAction::FinalizePending { peer_id }) {
+                    store.dispatch(P2pConnectionOutgoingAction::OfferSdpCreatePending { peer_id });
+                }
+            }
+            P2pConnectionOutgoingAction::Reconnect { opts, .. } => {
+                let peer_id = *opts.peer_id();
+                store.service().outgoing_init(opts);
+                // for libp2p
+                if !store.dispatch(P2pConnectionOutgoingAction::FinalizePending { peer_id }) {
+                    store.dispatch(P2pConnectionOutgoingAction::OfferSdpCreatePending { peer_id });
+                }
+            }
+            P2pConnectionOutgoingAction::OfferSdpCreateError { peer_id, error } => {
+                store.dispatch(P2pConnectionOutgoingAction::Error {
+                    peer_id,
+                    error: P2pConnectionOutgoingError::SdpCreateError(error),
+                });
+            }
+            P2pConnectionOutgoingAction::OfferSdpCreateSuccess { peer_id, sdp } => {
+                let offer = webrtc::Offer {
+                    sdp,
+                    identity_pub_key: store.state().config.identity_pub_key.clone(),
+                    target_peer_id: peer_id,
+                    // TODO(vlad9486): put real address
+                    host: Host::Ipv4([127, 0, 0, 1].into()),
+                    listen_port: store.state().config.listen_port,
+                };
+                store.dispatch(P2pConnectionOutgoingAction::OfferReady { peer_id, offer });
+            }
+            P2pConnectionOutgoingAction::OfferReady { peer_id, offer } => {
+                let (state, service) = store.state_and_service();
+                let Some(peer) = state.peers.get(&peer_id) else {
+                    return;
+                };
+                let P2pPeerStatus::Connecting(P2pConnectionState::Outgoing(
+                    P2pConnectionOutgoingState::OfferReady { opts, .. },
+                )) = &peer.status
+                else {
+                    return;
+                };
+                let signaling_method = match opts {
+                    P2pConnectionOutgoingInitOpts::WebRTC { signaling, .. } => signaling,
+                    #[allow(unreachable_patterns)]
+                    _ => return,
+                };
+                match signaling_method {
+                    webrtc::SignalingMethod::Http(_) | webrtc::SignalingMethod::Https(_) => {
+                        let Some(url) = signaling_method.http_url() else {
+                            return;
+                        };
+                        service.http_signaling_request(url, offer);
+                    }
+                }
+                store.dispatch(P2pConnectionOutgoingAction::OfferSendSuccess { peer_id });
+            }
+            P2pConnectionOutgoingAction::OfferSendSuccess { peer_id } => {
+                store.dispatch(P2pConnectionOutgoingAction::AnswerRecvPending { peer_id });
+            }
+            P2pConnectionOutgoingAction::AnswerRecvError { peer_id, error } => {
+                store.dispatch(P2pConnectionOutgoingAction::Error {
+                    peer_id,
+                    error: match error {
+                        P2pConnectionErrorResponse::Rejected(reason) => {
+                            P2pConnectionOutgoingError::Rejected(reason)
+                        }
+                        P2pConnectionErrorResponse::InternalError => {
+                            P2pConnectionOutgoingError::RemoteInternalError
+                        }
+                    },
+                });
+            }
+            P2pConnectionOutgoingAction::AnswerRecvSuccess { peer_id, answer } => {
+                store.service().set_answer(peer_id, answer.clone());
+                store.dispatch(P2pConnectionOutgoingAction::FinalizePending { peer_id });
+            }
+            P2pConnectionOutgoingAction::FinalizeError { peer_id, error } => {
+                store.dispatch(P2pConnectionOutgoingAction::Error {
+                    peer_id,
+                    error: P2pConnectionOutgoingError::FinalizeError(error),
+                });
+            }
+            P2pConnectionOutgoingAction::FinalizeSuccess { peer_id } => {
+                store.dispatch(P2pConnectionOutgoingAction::Success { peer_id });
+            }
+            P2pConnectionOutgoingAction::Timeout { peer_id } => {
+                store.dispatch(P2pConnectionOutgoingAction::Error {
+                    peer_id,
+                    error: P2pConnectionOutgoingError::Timeout,
+                });
+            }
+            P2pConnectionOutgoingAction::Success { peer_id } => {
+                store.dispatch(P2pPeerAction::Ready {
+                    peer_id,
+                    incoming: false,
+                });
+            }
+            _ => {}
+        }
     }
 }

--- a/p2p/src/connection/outgoing/p2p_connection_outgoing_effects.rs
+++ b/p2p/src/connection/outgoing/p2p_connection_outgoing_effects.rs
@@ -1,7 +1,7 @@
 use redux::ActionMeta;
 
 use crate::connection::{P2pConnectionErrorResponse, P2pConnectionState};
-use crate::peer::P2pPeerReadyAction;
+use crate::peer::P2pPeerAction;
 use crate::webrtc::Host;
 use crate::P2pPeerStatus;
 use crate::{connection::P2pConnectionService, webrtc};
@@ -237,10 +237,10 @@ impl P2pConnectionOutgoingSuccessAction {
     where
         Store: crate::P2pStore<S>,
         Store::Service: P2pConnectionService,
-        P2pPeerReadyAction: redux::EnablingCondition<S>,
+        P2pPeerAction: redux::EnablingCondition<S>,
     {
         let peer_id = self.peer_id;
-        store.dispatch(P2pPeerReadyAction {
+        store.dispatch(P2pPeerAction::Ready {
             peer_id,
             incoming: false,
         });

--- a/p2p/src/connection/p2p_connection_reducer.rs
+++ b/p2p/src/connection/p2p_connection_reducer.rs
@@ -13,12 +13,12 @@ pub fn p2p_connection_reducer(
     let (action, meta) = action.split();
     match action {
         P2pConnectionAction::Outgoing(action) => {
-            if let P2pConnectionOutgoingAction::Reconnect(a) = action {
+            if let P2pConnectionOutgoingAction::Reconnect { opts, rpc_id } = action {
                 state.status = P2pPeerStatus::Connecting(P2pConnectionState::Outgoing(
                     P2pConnectionOutgoingState::Init {
                         time: meta.time(),
-                        opts: a.opts.clone(),
-                        rpc_id: a.rpc_id,
+                        opts: opts.clone(),
+                        rpc_id: *rpc_id,
                     },
                 ));
             }

--- a/p2p/src/connection/p2p_connection_reducer.rs
+++ b/p2p/src/connection/p2p_connection_reducer.rs
@@ -29,16 +29,16 @@ pub fn p2p_connection_reducer(
             state.reducer(meta.with_action(action));
         }
         P2pConnectionAction::Incoming(action) => {
-            if let P2pConnectionIncomingAction::Init(a) = action {
+            if let P2pConnectionIncomingAction::Init { opts, rpc_id } = action {
                 state.status = P2pPeerStatus::Connecting(P2pConnectionState::Incoming(
                     P2pConnectionIncomingState::Init {
                         time: meta.time(),
-                        signaling: a.opts.signaling.clone(),
-                        offer: a.opts.offer.clone(),
-                        rpc_id: a.rpc_id,
+                        signaling: opts.signaling.clone(),
+                        offer: opts.offer.clone(),
+                        rpc_id: *rpc_id,
                     },
                 ))
-            } else if let P2pConnectionIncomingAction::Libp2pReceived(_) = action {
+            } else if let P2pConnectionIncomingAction::Libp2pReceived { .. } = action {
                 state.status = P2pPeerStatus::Connecting(P2pConnectionState::Incoming(
                     P2pConnectionIncomingState::Libp2pReceived { time: meta.time() },
                 ))

--- a/p2p/src/disconnection/p2p_disconnection_actions.rs
+++ b/p2p/src/disconnection/p2p_disconnection_actions.rs
@@ -1,61 +1,30 @@
 use serde::{Deserialize, Serialize};
 
 use super::P2pDisconnectionReason;
+use crate::{P2pPeerStatus, P2pState, PeerId};
 
 pub type P2pDisconnectionActionWithMetaRef<'a> = redux::ActionWithMeta<&'a P2pDisconnectionAction>;
 
-#[derive(derive_more::From, Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum P2pDisconnectionAction {
-    Init(P2pDisconnectionInitAction),
-    Finish(P2pDisconnectionFinishAction),
+    Init {
+        peer_id: PeerId,
+        reason: P2pDisconnectionReason,
+    },
+    Finish {
+        peer_id: PeerId,
+    },
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pDisconnectionInitAction {
-    pub peer_id: crate::PeerId,
-    pub reason: P2pDisconnectionReason,
-}
-
-impl redux::EnablingCondition<crate::P2pState> for P2pDisconnectionInitAction {
-    fn is_enabled(&self, state: &crate::P2pState) -> bool {
-        state
-            .peers
-            .get(&self.peer_id)
-            .map_or(false, |peer| match &peer.status {
-                P2pPeerStatus::Disconnected { .. } => false,
-                _ => true,
-            })
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pDisconnectionFinishAction {
-    pub peer_id: crate::PeerId,
-}
-
-impl redux::EnablingCondition<crate::P2pState> for P2pDisconnectionFinishAction {
-    fn is_enabled(&self, state: &crate::P2pState) -> bool {
-        state
-            .peers
-            .get(&self.peer_id)
-            .map_or(false, |peer| match &peer.status {
-                P2pPeerStatus::Disconnected { .. } => false,
-                _ => true,
-            })
-    }
-}
-
-// --- From<LeafAction> for Action impls.
-use crate::P2pPeerStatus;
-
-impl From<P2pDisconnectionInitAction> for crate::P2pAction {
-    fn from(a: P2pDisconnectionInitAction) -> Self {
-        Self::Disconnection(P2pDisconnectionAction::Init(a.into()))
-    }
-}
-
-impl From<P2pDisconnectionFinishAction> for crate::P2pAction {
-    fn from(a: P2pDisconnectionFinishAction) -> Self {
-        Self::Disconnection(P2pDisconnectionAction::Finish(a.into()))
+impl redux::EnablingCondition<P2pState> for P2pDisconnectionAction {
+    fn is_enabled(&self, state: &P2pState) -> bool {
+        match self {
+            P2pDisconnectionAction::Init { peer_id, .. }
+            | P2pDisconnectionAction::Finish { peer_id } => {
+                state.peers.get(peer_id).map_or(false, |peer| {
+                    !matches!(peer.status, P2pPeerStatus::Disconnected { .. })
+                })
+            }
+        }
     }
 }

--- a/p2p/src/disconnection/p2p_disconnection_effects.rs
+++ b/p2p/src/disconnection/p2p_disconnection_effects.rs
@@ -1,17 +1,22 @@
 use redux::ActionMeta;
 
-use super::{P2pDisconnectionFinishAction, P2pDisconnectionInitAction, P2pDisconnectionService};
+use super::{P2pDisconnectionAction, P2pDisconnectionService};
 
-impl P2pDisconnectionInitAction {
+impl P2pDisconnectionAction {
     pub fn effects<Store, S>(&self, _: &ActionMeta, store: &mut Store)
     where
         Store: crate::P2pStore<S>,
         Store::Service: P2pDisconnectionService,
-        P2pDisconnectionFinishAction: redux::EnablingCondition<S>,
+        P2pDisconnectionAction: redux::EnablingCondition<S>,
     {
-        store.service().disconnect(self.peer_id);
-        store.dispatch(P2pDisconnectionFinishAction {
-            peer_id: self.peer_id,
-        });
+        match self {
+            P2pDisconnectionAction::Init { peer_id, .. } => {
+                store.service().disconnect(*peer_id);
+                store.dispatch(P2pDisconnectionAction::Finish {
+                    peer_id: *peer_id,
+                });
+            }
+            P2pDisconnectionAction::Finish { .. } => {}
+        }
     }
 }

--- a/p2p/src/discovery/p2p_discovery_actions.rs
+++ b/p2p/src/discovery/p2p_discovery_actions.rs
@@ -6,146 +6,43 @@ use crate::{connection::outgoing::P2pConnectionOutgoingInitOpts, P2pState, PeerI
 
 pub type P2pDiscoveryActionWithMetaRef<'a> = redux::ActionWithMeta<&'a P2pDiscoveryAction>;
 
-#[derive(derive_more::From, Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum P2pDiscoveryAction {
-    Init(P2pDiscoveryInitAction),
-    Success(P2pDiscoverySuccessAction),
-    KademliaBootstrap(P2pDiscoveryKademliaBootstrapAction),
-    KademliaInit(P2pDiscoveryKademliaInitAction),
-    KademliaAddRoute(P2pDiscoveryKademliaAddRouteAction),
-    KademliaSuccess(P2pDiscoveryKademliaSuccessAction),
-    KademliaFailure(P2pDiscoveryKademliaFailureAction),
+    Init {
+        peer_id: PeerId,
+    },
+    Success {
+        peer_id: PeerId,
+        peers: Vec<P2pConnectionOutgoingInitOpts>,
+    },
+    KademliaBootstrap,
+    KademliaInit,
+    KademliaAddRoute {
+        peer_id: PeerId,
+        addresses: Vec<P2pConnectionOutgoingInitOpts>,
+    },
+    KademliaSuccess {
+        peers: Vec<PeerId>,
+    },
+    KademliaFailure {
+        description: String,
+    },
 }
 
 impl redux::EnablingCondition<P2pState> for P2pDiscoveryAction {
     fn is_enabled(&self, state: &P2pState) -> bool {
         match self {
-            Self::Init(action) => action.is_enabled(state),
-            Self::Success(action) => action.is_enabled(state),
-            Self::KademliaBootstrap(action) => action.is_enabled(state),
-            Self::KademliaAddRoute(action) => action.is_enabled(state),
-            Self::KademliaInit(action) => action.is_enabled(state),
-            Self::KademliaSuccess(action) => action.is_enabled(state),
-            Self::KademliaFailure(action) => action.is_enabled(state),
+            Self::Init { peer_id } => state.get_ready_peer(peer_id).is_some(),
+            Self::Success { .. } => true,
+            Self::KademliaBootstrap => !state.kademlia.is_ready && !state.kademlia.is_bootstrapping,
+            Self::KademliaInit => {
+                state.kademlia.is_ready
+                    && state.kademlia.outgoing_requests < 1
+                    && !state.already_knows_max_peers()
+            }
+            Self::KademliaAddRoute { .. } => true,
+            Self::KademliaSuccess { .. } => true,
+            Self::KademliaFailure { .. } => true,
         }
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pDiscoveryInitAction {
-    pub peer_id: PeerId,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pDiscoveryInitAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state.get_ready_peer(&self.peer_id).is_some()
-    }
-}
-
-impl From<P2pDiscoveryInitAction> for crate::P2pAction {
-    fn from(a: P2pDiscoveryInitAction) -> Self {
-        Self::Discovery(a.into())
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pDiscoveryKademliaAddRouteAction {
-    pub peer_id: PeerId,
-    pub addresses: Vec<P2pConnectionOutgoingInitOpts>,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pDiscoveryKademliaAddRouteAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
-        true
-    }
-}
-
-impl From<P2pDiscoveryKademliaAddRouteAction> for crate::P2pAction {
-    fn from(a: P2pDiscoveryKademliaAddRouteAction) -> Self {
-        Self::Discovery(a.into())
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pDiscoverySuccessAction {
-    pub peer_id: PeerId,
-    pub peers: Vec<P2pConnectionOutgoingInitOpts>,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pDiscoverySuccessAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
-        true
-    }
-}
-
-impl From<P2pDiscoverySuccessAction> for crate::P2pAction {
-    fn from(a: P2pDiscoverySuccessAction) -> Self {
-        Self::Discovery(a.into())
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pDiscoveryKademliaBootstrapAction {}
-
-impl redux::EnablingCondition<P2pState> for P2pDiscoveryKademliaBootstrapAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        !state.kademlia.is_ready && !state.kademlia.is_bootstrapping
-    }
-}
-
-impl From<P2pDiscoveryKademliaBootstrapAction> for crate::P2pAction {
-    fn from(a: P2pDiscoveryKademliaBootstrapAction) -> Self {
-        Self::Discovery(a.into())
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pDiscoveryKademliaInitAction {}
-
-impl redux::EnablingCondition<P2pState> for P2pDiscoveryKademliaInitAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        state.kademlia.is_ready
-            && state.kademlia.outgoing_requests < 1
-            && !state.already_knows_max_peers()
-    }
-}
-
-impl From<P2pDiscoveryKademliaInitAction> for crate::P2pAction {
-    fn from(a: P2pDiscoveryKademliaInitAction) -> Self {
-        Self::Discovery(a.into())
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pDiscoveryKademliaSuccessAction {
-    pub peers: Vec<PeerId>,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pDiscoveryKademliaSuccessAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
-        true
-    }
-}
-
-impl From<P2pDiscoveryKademliaSuccessAction> for crate::P2pAction {
-    fn from(a: P2pDiscoveryKademliaSuccessAction) -> Self {
-        Self::Discovery(a.into())
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pDiscoveryKademliaFailureAction {
-    pub description: String,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pDiscoveryKademliaFailureAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
-        true
-    }
-}
-
-impl From<P2pDiscoveryKademliaFailureAction> for crate::P2pAction {
-    fn from(a: P2pDiscoveryKademliaFailureAction) -> Self {
-        Self::Discovery(a.into())
     }
 }

--- a/p2p/src/listen/p2p_listen_actions.rs
+++ b/p2p/src/listen/p2p_listen_actions.rs
@@ -1,86 +1,28 @@
 use redux::EnablingCondition;
 use serde::{Deserialize, Serialize};
 
-use crate::{P2pAction, P2pListenerId, P2pState};
+use crate::{P2pListenerId, P2pState};
 
 pub type P2pListenActionWithMetaRef<'a> = redux::ActionWithMeta<&'a P2pListenAction>;
 
-#[derive(derive_more::From, Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum P2pListenAction {
-    New(P2pListenNewAction),
-    Expired(P2pListenExpiredAction),
-    Error(P2pListenErrorAction),
-    Closed(P2pListenClosedAction),
+    New {
+        listener_id: P2pListenerId,
+        addr: libp2p::Multiaddr,
+    },
+    Expired {
+        listener_id: P2pListenerId,
+        addr: libp2p::Multiaddr,
+    },
+    Error {
+        listener_id: P2pListenerId,
+        error: String,
+    },
+    Closed {
+        listener_id: P2pListenerId,
+        error: Option<String>,
+    },
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pListenNewAction {
-    pub listener_id: P2pListenerId,
-    pub addr: libp2p::Multiaddr,
-}
-
-impl EnablingCondition<P2pState> for P2pListenNewAction {
-    fn is_enabled(&self, #[allow(unused_variables)] state: &P2pState) -> bool {
-        true
-    }
-}
-
-impl From<P2pListenNewAction> for P2pAction {
-    fn from(value: P2pListenNewAction) -> Self {
-        P2pListenAction::from(value).into()
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pListenExpiredAction {
-    pub listener_id: P2pListenerId,
-    pub addr: libp2p::Multiaddr,
-}
-
-impl EnablingCondition<P2pState> for P2pListenExpiredAction {
-    fn is_enabled(&self, #[allow(unused_variables)] state: &P2pState) -> bool {
-        true
-    }
-}
-
-impl From<P2pListenExpiredAction> for P2pAction {
-    fn from(value: P2pListenExpiredAction) -> Self {
-        P2pListenAction::from(value).into()
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pListenErrorAction {
-    pub listener_id: P2pListenerId,
-    pub error: String,
-}
-
-impl EnablingCondition<P2pState> for P2pListenErrorAction {
-    fn is_enabled(&self, #[allow(unused_variables)] state: &P2pState) -> bool {
-        true
-    }
-}
-
-impl From<P2pListenErrorAction> for P2pAction {
-    fn from(value: P2pListenErrorAction) -> Self {
-        P2pListenAction::from(value).into()
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pListenClosedAction {
-    pub listener_id: P2pListenerId,
-    pub error: Option<String>,
-}
-
-impl EnablingCondition<P2pState> for P2pListenClosedAction {
-    fn is_enabled(&self, #[allow(unused_variables)] state: &P2pState) -> bool {
-        true
-    }
-}
-
-impl From<P2pListenClosedAction> for P2pAction {
-    fn from(value: P2pListenClosedAction) -> Self {
-        P2pListenAction::from(value).into()
-    }
-}
+impl EnablingCondition<P2pState> for P2pListenAction {}

--- a/p2p/src/listen/p2p_listen_effects.rs
+++ b/p2p/src/listen/p2p_listen_effects.rs
@@ -1,37 +1,8 @@
 use redux::ActionMeta;
 
-use super::{
-    P2pListenClosedAction, P2pListenErrorAction, P2pListenExpiredAction, P2pListenNewAction,
-};
+use super::P2pListenAction;
 
-impl P2pListenNewAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, _store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-    {
-        // TODO run Kademlia expose
-    }
-}
-
-impl P2pListenExpiredAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, _store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-    {
-        // TODO run Kademlia expose
-    }
-}
-
-impl P2pListenErrorAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, _store: &mut Store)
-    where
-        Store: crate::P2pStore<S>,
-    {
-        // TODO run Kademlia expose
-    }
-}
-
-impl P2pListenClosedAction {
+impl P2pListenAction {
     pub fn effects<Store, S>(self, _: &ActionMeta, _store: &mut Store)
     where
         Store: crate::P2pStore<S>,

--- a/p2p/src/listen/p2p_listen_reducer.rs
+++ b/p2p/src/listen/p2p_listen_reducer.rs
@@ -7,33 +7,30 @@ impl P2pListenersState {
         let (action, _meta) = action.split();
 
         match action {
-            super::P2pListenAction::New(action) => {
+            super::P2pListenAction::New { listener_id, addr } => {
                 if let P2pListenerState::Open { addrs, .. } =
-                    self.0.entry(action.listener_id.clone()).or_default()
+                    self.0.entry(listener_id.clone()).or_default()
                 {
-                    addrs.insert(action.addr.clone());
+                    addrs.insert(addr.clone());
                 }
             }
-            super::P2pListenAction::Expired(action) => {
-                if let Some(P2pListenerState::Open { addrs, .. }) =
-                    self.0.get_mut(&action.listener_id)
-                {
-                    addrs.remove(&action.addr);
+            super::P2pListenAction::Expired { listener_id, addr } => {
+                if let Some(P2pListenerState::Open { addrs, .. }) = self.0.get_mut(&listener_id) {
+                    addrs.remove(&addr);
                 }
             }
-            super::P2pListenAction::Error(action) => {
+            super::P2pListenAction::Error { listener_id, error } => {
                 if let P2pListenerState::Open { errors, .. } =
-                    self.0.entry(action.listener_id.clone()).or_default()
+                    self.0.entry(listener_id.clone()).or_default()
                 {
-                    errors.push(action.error.clone());
+                    errors.push(error.clone());
                 }
             }
-            super::P2pListenAction::Closed(action) => {
-                let new_state = action
-                    .error
+            super::P2pListenAction::Closed { listener_id, error } => {
+                let new_state = error
                     .clone()
                     .map_or(P2pListenerState::Closed, P2pListenerState::ClosedWithError);
-                self.0.insert(action.listener_id.clone(), new_state);
+                self.0.insert(listener_id.clone(), new_state);
             }
         }
     }

--- a/p2p/src/p2p_reducer.rs
+++ b/p2p/src/p2p_reducer.rs
@@ -18,15 +18,14 @@ impl P2pState {
                     return;
                 };
                 let peer = match action {
-                    P2pConnectionAction::Outgoing(P2pConnectionOutgoingAction::Init(v)) => {
-                        self.peers.entry(*peer_id).or_insert_with(|| P2pPeerState {
-                            is_libp2p: v.opts.is_libp2p(),
-                            dial_opts: Some(v.opts.clone()),
-                            status: P2pPeerStatus::Connecting(P2pConnectionState::outgoing_init(
-                                &v.opts,
-                            )),
-                        })
-                    }
+                    P2pConnectionAction::Outgoing(P2pConnectionOutgoingAction::Init {
+                        opts,
+                        ..
+                    }) => self.peers.entry(*peer_id).or_insert_with(|| P2pPeerState {
+                        is_libp2p: opts.is_libp2p(),
+                        dial_opts: Some(opts.clone()),
+                        status: P2pPeerStatus::Connecting(P2pConnectionState::outgoing_init(opts)),
+                    }),
                     P2pConnectionAction::Incoming(P2pConnectionIncomingAction::Init {
                         opts,
                         ..

--- a/p2p/src/p2p_reducer.rs
+++ b/p2p/src/p2p_reducer.rs
@@ -67,9 +67,9 @@ impl P2pState {
                 p2p_connection_reducer(peer, meta.with_action(action));
             }
             P2pAction::Disconnection(action) => match action {
-                P2pDisconnectionAction::Init(_) => {}
-                P2pDisconnectionAction::Finish(a) => {
-                    let Some(peer) = self.peers.get_mut(&a.peer_id) else {
+                P2pDisconnectionAction::Init { .. } => {}
+                P2pDisconnectionAction::Finish { peer_id } => {
+                    let Some(peer) = self.peers.get_mut(peer_id) else {
                         return;
                     };
                     peer.status = P2pPeerStatus::Disconnected { time: meta.time() };

--- a/p2p/src/p2p_reducer.rs
+++ b/p2p/src/p2p_reducer.rs
@@ -27,31 +27,30 @@ impl P2pState {
                             )),
                         })
                     }
-                    P2pConnectionAction::Incoming(P2pConnectionIncomingAction::Init(v)) => {
-                        self.peers.entry(*peer_id).or_insert_with(|| P2pPeerState {
-                            is_libp2p: false,
-                            dial_opts: {
-                                let signaling = match v.opts.signaling {
-                                    IncomingSignalingMethod::Http => {
-                                        SignalingMethod::Http(HttpSignalingInfo {
-                                            host: v.opts.offer.host.clone(),
-                                            port: v.opts.offer.listen_port,
-                                        })
-                                    }
-                                };
-                                Some(P2pConnectionOutgoingInitOpts::WebRTC {
-                                    peer_id: *peer_id,
-                                    signaling,
-                                })
-                            },
-                            status: P2pPeerStatus::Connecting(P2pConnectionState::incoming_init(
-                                &v.opts,
-                            )),
-                        })
-                    }
-                    P2pConnectionAction::Incoming(P2pConnectionIncomingAction::Libp2pReceived(
-                        _,
-                    )) => {
+                    P2pConnectionAction::Incoming(P2pConnectionIncomingAction::Init {
+                        opts,
+                        ..
+                    }) => self.peers.entry(*peer_id).or_insert_with(|| P2pPeerState {
+                        is_libp2p: false,
+                        dial_opts: {
+                            let signaling = match opts.signaling {
+                                IncomingSignalingMethod::Http => {
+                                    SignalingMethod::Http(HttpSignalingInfo {
+                                        host: opts.offer.host.clone(),
+                                        port: opts.offer.listen_port,
+                                    })
+                                }
+                            };
+                            Some(P2pConnectionOutgoingInitOpts::WebRTC {
+                                peer_id: *peer_id,
+                                signaling,
+                            })
+                        },
+                        status: P2pPeerStatus::Connecting(P2pConnectionState::incoming_init(opts)),
+                    }),
+                    P2pConnectionAction::Incoming(
+                        P2pConnectionIncomingAction::Libp2pReceived { .. },
+                    ) => {
                         self.peers.entry(*peer_id).or_insert_with(|| P2pPeerState {
                             is_libp2p: true,
                             dial_opts: None,

--- a/p2p/src/peer/p2p_peer_actions.rs
+++ b/p2p/src/peer/p2p_peer_actions.rs
@@ -1,63 +1,44 @@
 use openmina_core::block::ArcBlockWithHash;
 use serde::{Deserialize, Serialize};
 
-use crate::{P2pAction, P2pState, PeerId};
+use crate::{P2pState, PeerId};
 
 pub type P2pPeerActionWithMeta = redux::ActionWithMeta<P2pPeerAction>;
 pub type P2pPeerActionWithMetaRef<'a> = redux::ActionWithMeta<&'a P2pPeerAction>;
 
-#[derive(derive_more::From, Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum P2pPeerAction {
-    Ready(P2pPeerReadyAction),
-    BestTipUpdate(P2pPeerBestTipUpdateAction),
+    Ready {
+        peer_id: PeerId,
+        incoming: bool,
+    },
+    BestTipUpdate {
+        peer_id: PeerId,
+        best_tip: ArcBlockWithHash,
+    },
 }
 
 impl P2pPeerAction {
     pub fn peer_id(&self) -> &PeerId {
         match self {
-            Self::Ready(v) => &v.peer_id,
-            Self::BestTipUpdate(v) => &v.peer_id,
+            Self::Ready { peer_id, .. } => peer_id,
+            Self::BestTipUpdate { peer_id, .. } => peer_id,
         }
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pPeerReadyAction {
-    pub peer_id: PeerId,
-    pub incoming: bool,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pPeerReadyAction {
+impl redux::EnablingCondition<P2pState> for P2pPeerAction {
     fn is_enabled(&self, state: &P2pState) -> bool {
-        state
-            .peers
-            .get(&self.peer_id)
-            .map_or(false, |p| p.status.is_connecting_success())
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct P2pPeerBestTipUpdateAction {
-    pub peer_id: PeerId,
-    pub best_tip: ArcBlockWithHash,
-}
-
-impl redux::EnablingCondition<P2pState> for P2pPeerBestTipUpdateAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
-        // TODO(binier): don't enable if block inferior than existing peer's
-        // best tip.
-        state.get_ready_peer(&self.peer_id).is_some()
-    }
-}
-
-impl From<P2pPeerReadyAction> for P2pAction {
-    fn from(value: P2pPeerReadyAction) -> Self {
-        Self::Peer(value.into())
-    }
-}
-
-impl From<P2pPeerBestTipUpdateAction> for P2pAction {
-    fn from(value: P2pPeerBestTipUpdateAction) -> Self {
-        Self::Peer(value.into())
+        match self {
+            Self::Ready { peer_id, .. } => state
+                .peers
+                .get(peer_id)
+                .map_or(false, |p| p.status.is_connecting_success()),
+            Self::BestTipUpdate { peer_id, .. } => {
+                // TODO: don't enable if block inferior than existing peer's
+                // best tip.
+                state.get_ready_peer(peer_id).is_some()
+            }
+        }
     }
 }

--- a/p2p/src/peer/p2p_peer_effects.rs
+++ b/p2p/src/peer/p2p_peer_effects.rs
@@ -5,9 +5,9 @@ use crate::channels::{
     snark_job_commitment::P2pChannelsSnarkJobCommitmentAction, ChannelId,
 };
 
-use super::P2pPeerReadyAction;
+use super::P2pPeerAction;
 
-impl P2pPeerReadyAction {
+impl P2pPeerAction {
     pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
     where
         Store: crate::P2pStore<S>,
@@ -16,24 +16,29 @@ impl P2pPeerReadyAction {
         P2pChannelsSnarkJobCommitmentAction: redux::EnablingCondition<S>,
         P2pChannelsRpcAction: redux::EnablingCondition<S>,
     {
-        let peer_id = self.peer_id;
-        // Dispatches can be done without a loop, but inside we do
-        // exhaustive matching so that we don't miss any channels.
-        for id in ChannelId::iter_all() {
-            match id {
-                ChannelId::BestTipPropagation => {
-                    store.dispatch(P2pChannelsBestTipAction::Init { peer_id });
-                }
-                ChannelId::SnarkPropagation => {
-                    store.dispatch(P2pChannelsSnarkAction::Init { peer_id });
-                }
-                ChannelId::SnarkJobCommitmentPropagation => {
-                    store.dispatch(P2pChannelsSnarkJobCommitmentAction::Init { peer_id });
-                }
-                ChannelId::Rpc => {
-                    store.dispatch(P2pChannelsRpcAction::Init { peer_id });
+        match self {
+            P2pPeerAction::Ready { peer_id, .. } => {
+                let peer_id = peer_id;
+                // Dispatches can be done without a loop, but inside we do
+                // exhaustive matching so that we don't miss any channels.
+                for id in ChannelId::iter_all() {
+                    match id {
+                        ChannelId::BestTipPropagation => {
+                            store.dispatch(P2pChannelsBestTipAction::Init { peer_id });
+                        }
+                        ChannelId::SnarkPropagation => {
+                            store.dispatch(P2pChannelsSnarkAction::Init { peer_id });
+                        }
+                        ChannelId::SnarkJobCommitmentPropagation => {
+                            store.dispatch(P2pChannelsSnarkJobCommitmentAction::Init { peer_id });
+                        }
+                        ChannelId::Rpc => {
+                            store.dispatch(P2pChannelsRpcAction::Init { peer_id });
+                        }
+                    }
                 }
             }
+            P2pPeerAction::BestTipUpdate { .. } => {}
         }
     }
 }

--- a/p2p/src/peer/p2p_peer_reducer.rs
+++ b/p2p/src/peer/p2p_peer_reducer.rs
@@ -6,21 +6,21 @@ pub fn p2p_peer_reducer(state: &mut P2pState, action: P2pPeerActionWithMetaRef<'
     let (action, meta) = action.split();
 
     match action {
-        P2pPeerAction::Ready(action) => {
-            let Some(peer) = state.peers.get_mut(&action.peer_id) else {
+        P2pPeerAction::Ready { peer_id, incoming } => {
+            let Some(peer) = state.peers.get_mut(peer_id) else {
                 return;
             };
             peer.status = P2pPeerStatus::Ready(P2pPeerStatusReady::new(
-                action.incoming,
+                *incoming,
                 meta.time(),
                 &state.config.enabled_channels,
             ));
         }
-        P2pPeerAction::BestTipUpdate(action) => {
-            let Some(peer) = state.get_ready_peer_mut(&action.peer_id) else {
+        P2pPeerAction::BestTipUpdate { peer_id, best_tip } => {
+            let Some(peer) = state.get_ready_peer_mut(peer_id) else {
                 return;
             };
-            peer.best_tip = Some(action.best_tip.clone());
+            peer.best_tip = Some(best_tip.clone());
         }
     }
 }


### PR DESCRIPTION
Continuation of #193 

- [x] event_source
- [x] p2p_peer
- [x] p2p_disconnection
- [x] p2p_discovery
- [x] p2p_listen
- [x] p2p_connection_incoming
- [x] p2p_connection_outgoing
- [x] watched_accounts
- [x] transition_frontier_sync_ledger_snarked
- [x] transition_frontier_sync_ledger_staged
- [x] transition_frontier_sync
- [x] rpc
- [x] vrf_evaluator
- [x] block_producer