### PR TITLE
chore: Fix warnings

### DIFF
--- a/node/src/block_producer/mod.rs
+++ b/node/src/block_producer/mod.rs
@@ -13,7 +13,7 @@ mod block_producer_actions;
 pub use block_producer_actions::*;
 
 mod block_producer_reducer;
-pub use block_producer_reducer::*;
+
 
 mod block_producer_effects;
 pub use block_producer_effects::*;

--- a/node/src/block_producer/vrf_evaluator/mod.rs
+++ b/node/src/block_producer/vrf_evaluator/mod.rs
@@ -15,10 +15,10 @@ mod block_producer_vrf_evaluator_actions;
 pub use block_producer_vrf_evaluator_actions::*;
 
 mod block_producer_vrf_evaluator_reducer;
-pub use block_producer_vrf_evaluator_reducer::*;
+
 
 mod block_producer_vrf_evaluator_effects;
-pub use block_producer_vrf_evaluator_effects::*;
+
 
 mod block_producer_vrf_evaluator_service;
 pub use block_producer_vrf_evaluator_service::*;

--- a/node/src/consensus/mod.rs
+++ b/node/src/consensus/mod.rs
@@ -5,7 +5,7 @@ mod consensus_actions;
 pub use consensus_actions::*;
 
 mod consensus_reducer;
-pub use consensus_reducer::*;
+
 
 mod consensus_effects;
 pub use consensus_effects::*;

--- a/node/src/ledger/ledger_service.rs
+++ b/node/src/ledger/ledger_service.rs
@@ -784,7 +784,7 @@ impl<T: LedgerService> BlockProducerService for T {
             won_slot.global_slot_since_genesis(pred_block.global_slot_diff());
 
         // TODO(binier): include `invalid_txns` in output.
-        let (pre_diff, invalid_txns) = staged_ledger
+        let (pre_diff, _invalid_txns) = staged_ledger
             .create_diff(
                 &CONSTRAINT_CONSTANTS,
                 (&global_slot_since_genesis).into(),

--- a/node/src/logger/logger_effects.rs
+++ b/node/src/logger/logger_effects.rs
@@ -681,7 +681,6 @@ pub fn logger_effects<S: Service>(store: &Store<S>, action: ActionWithMetaRef<'_
                         summary = format!("Vrf Evaluation requested: {:?}", a.vrf_input),
                     )
                 }
-                _ => {}
             },
             BlockProducerAction::BestTipUpdate(_) => {}
             _ => {}

--- a/node/src/p2p/channels/best_tip/mod.rs
+++ b/node/src/p2p/channels/best_tip/mod.rs
@@ -1,4 +1,4 @@
 pub use ::p2p::channels::best_tip::*;
 
 mod p2p_channels_best_tip_actions;
-pub use p2p_channels_best_tip_actions::*;
+

--- a/node/src/p2p/channels/mod.rs
+++ b/node/src/p2p/channels/mod.rs
@@ -6,4 +6,4 @@ pub mod snark;
 pub mod snark_job_commitment;
 
 mod p2p_channels_actions;
-pub use p2p_channels_actions::*;
+

--- a/node/src/p2p/channels/rpc/mod.rs
+++ b/node/src/p2p/channels/rpc/mod.rs
@@ -1,4 +1,4 @@
 pub use ::p2p::channels::rpc::*;
 
 mod p2p_channels_rpc_actions;
-pub use p2p_channels_rpc_actions::*;
+

--- a/node/src/p2p/channels/snark/mod.rs
+++ b/node/src/p2p/channels/snark/mod.rs
@@ -1,4 +1,4 @@
 pub use ::p2p::channels::snark::*;
 
 mod p2p_channels_snark_actions;
-pub use p2p_channels_snark_actions::*;
+

--- a/node/src/p2p/channels/snark_job_commitment/mod.rs
+++ b/node/src/p2p/channels/snark_job_commitment/mod.rs
@@ -1,4 +1,4 @@
 pub use ::p2p::channels::snark_job_commitment::*;
 
 mod p2p_channels_snark_job_commitment_actions;
-pub use p2p_channels_snark_job_commitment_actions::*;
+

--- a/node/src/p2p/connection/incoming/mod.rs
+++ b/node/src/p2p/connection/incoming/mod.rs
@@ -1,4 +1,4 @@
 pub use ::p2p::connection::incoming::*;
 
 mod p2p_connection_incoming_actions;
-pub use p2p_connection_incoming_actions::*;
+

--- a/node/src/p2p/connection/outgoing/mod.rs
+++ b/node/src/p2p/connection/outgoing/mod.rs
@@ -1,4 +1,4 @@
 pub use ::p2p::connection::outgoing::*;
 
 mod p2p_connection_outgoing_actions;
-pub use p2p_connection_outgoing_actions::*;
+

--- a/node/src/p2p/disconnection/mod.rs
+++ b/node/src/p2p/disconnection/mod.rs
@@ -1,4 +1,4 @@
 pub use ::p2p::disconnection::*;
 
 mod p2p_disconnection_actions;
-pub use p2p_disconnection_actions::*;
+

--- a/node/src/p2p/peer/mod.rs
+++ b/node/src/p2p/peer/mod.rs
@@ -1,4 +1,4 @@
 pub use ::p2p::peer::*;
 
 mod p2p_peer_actions;
-pub use p2p_peer_actions::*;
+

--- a/node/src/rpc/mod.rs
+++ b/node/src/rpc/mod.rs
@@ -10,7 +10,7 @@ mod rpc_actions;
 pub use rpc_actions::*;
 
 mod rpc_reducer;
-pub use rpc_reducer::*;
+
 
 mod rpc_effects;
 pub use rpc_effects::*;

--- a/node/src/snark/block_verify/mod.rs
+++ b/node/src/snark/block_verify/mod.rs
@@ -1,4 +1,4 @@
 pub use ::snark::block_verify::*;
 
 mod snark_block_verify_actions;
-pub use snark_block_verify_actions::*;
+

--- a/node/src/snark/work_verify/mod.rs
+++ b/node/src/snark/work_verify/mod.rs
@@ -1,4 +1,4 @@
 pub use ::snark::work_verify::*;
 
 mod snark_work_verify_actions;
-pub use snark_work_verify_actions::*;
+

--- a/node/src/snark_pool/candidate/mod.rs
+++ b/node/src/snark_pool/candidate/mod.rs
@@ -5,7 +5,7 @@ mod snark_pool_candidate_actions;
 pub use snark_pool_candidate_actions::*;
 
 mod snark_pool_candidate_reducer;
-pub use snark_pool_candidate_reducer::*;
+
 
 mod snark_pool_candidate_effects;
 pub use snark_pool_candidate_effects::*;

--- a/node/src/snark_pool/mod.rs
+++ b/node/src/snark_pool/mod.rs
@@ -10,7 +10,7 @@ mod snark_pool_actions;
 pub use snark_pool_actions::*;
 
 mod snark_pool_reducer;
-pub use snark_pool_reducer::*;
+
 
 mod snark_pool_effects;
 pub use snark_pool_effects::*;

--- a/node/src/transition_frontier/mod.rs
+++ b/node/src/transition_frontier/mod.rs
@@ -10,7 +10,7 @@ mod transition_frontier_actions;
 pub use transition_frontier_actions::*;
 
 mod transition_frontier_reducer;
-pub use transition_frontier_reducer::*;
+
 
 mod transition_frontier_effects;
 pub use transition_frontier_effects::*;

--- a/node/src/transition_frontier/sync/ledger/mod.rs
+++ b/node/src/transition_frontier/sync/ledger/mod.rs
@@ -8,10 +8,10 @@ mod transition_frontier_sync_ledger_actions;
 pub use transition_frontier_sync_ledger_actions::*;
 
 mod transition_frontier_sync_ledger_reducer;
-pub use transition_frontier_sync_ledger_reducer::*;
+
 
 mod transition_frontier_sync_ledger_effects;
-pub use transition_frontier_sync_ledger_effects::*;
+
 
 use mina_p2p_messages::v2::{LedgerHash, MinaBaseStagedLedgerHashStableV1, StateHash};
 use openmina_core::block::ArcBlockWithHash;

--- a/node/src/transition_frontier/sync/ledger/snarked/mod.rs
+++ b/node/src/transition_frontier/sync/ledger/snarked/mod.rs
@@ -5,10 +5,10 @@ mod transition_frontier_sync_ledger_snarked_actions;
 pub use transition_frontier_sync_ledger_snarked_actions::*;
 
 mod transition_frontier_sync_ledger_snarked_reducer;
-pub use transition_frontier_sync_ledger_snarked_reducer::*;
+
 
 mod transition_frontier_sync_ledger_snarked_effects;
-pub use transition_frontier_sync_ledger_snarked_effects::*;
+
 
 mod transition_frontier_sync_ledger_snarked_service;
 pub use transition_frontier_sync_ledger_snarked_service::*;

--- a/node/src/transition_frontier/sync/ledger/staged/mod.rs
+++ b/node/src/transition_frontier/sync/ledger/staged/mod.rs
@@ -5,10 +5,10 @@ mod transition_frontier_sync_ledger_staged_actions;
 pub use transition_frontier_sync_ledger_staged_actions::*;
 
 mod transition_frontier_sync_ledger_staged_reducer;
-pub use transition_frontier_sync_ledger_staged_reducer::*;
+
 
 mod transition_frontier_sync_ledger_staged_effects;
-pub use transition_frontier_sync_ledger_staged_effects::*;
+
 
 mod transition_frontier_sync_ledger_staged_service;
 pub use transition_frontier_sync_ledger_staged_service::*;

--- a/node/src/transition_frontier/sync/mod.rs
+++ b/node/src/transition_frontier/sync/mod.rs
@@ -7,10 +7,10 @@ mod transition_frontier_sync_actions;
 pub use transition_frontier_sync_actions::*;
 
 mod transition_frontier_sync_reducer;
-pub use transition_frontier_sync_reducer::*;
+
 
 mod transition_frontier_sync_effects;
-pub use transition_frontier_sync_effects::*;
+
 
 use serde::{Deserialize, Serialize};
 

--- a/node/src/watched_accounts/mod.rs
+++ b/node/src/watched_accounts/mod.rs
@@ -5,7 +5,7 @@ mod watched_accounts_actions;
 pub use watched_accounts_actions::*;
 
 mod watched_accounts_reducer;
-pub use watched_accounts_reducer::*;
+
 
 mod watched_accounts_effects;
 pub use watched_accounts_effects::*;

--- a/p2p/src/channels/best_tip/mod.rs
+++ b/p2p/src/channels/best_tip/mod.rs
@@ -5,10 +5,10 @@ mod p2p_channels_best_tip_actions;
 pub use p2p_channels_best_tip_actions::*;
 
 mod p2p_channels_best_tip_reducer;
-pub use p2p_channels_best_tip_reducer::*;
+
 
 mod p2p_channels_best_tip_effects;
-pub use p2p_channels_best_tip_effects::*;
+
 
 use binprot_derive::{BinProtRead, BinProtWrite};
 use openmina_core::block::ArcBlock;

--- a/p2p/src/channels/mod.rs
+++ b/p2p/src/channels/mod.rs
@@ -10,10 +10,10 @@ mod p2p_channels_actions;
 pub use p2p_channels_actions::*;
 
 mod p2p_channels_reducer;
-pub use p2p_channels_reducer::*;
+
 
 mod p2p_channels_effects;
-pub use p2p_channels_effects::*;
+
 
 mod p2p_channels_service;
 pub use p2p_channels_service::*;

--- a/p2p/src/channels/rpc/mod.rs
+++ b/p2p/src/channels/rpc/mod.rs
@@ -5,10 +5,10 @@ mod p2p_channels_rpc_actions;
 pub use p2p_channels_rpc_actions::*;
 
 mod p2p_channels_rpc_reducer;
-pub use p2p_channels_rpc_reducer::*;
+
 
 mod p2p_channels_rpc_effects;
-pub use p2p_channels_rpc_effects::*;
+
 
 use std::{sync::Arc, time::Duration};
 

--- a/p2p/src/channels/snark/mod.rs
+++ b/p2p/src/channels/snark/mod.rs
@@ -5,10 +5,10 @@ mod p2p_channels_snark_actions;
 pub use p2p_channels_snark_actions::*;
 
 mod p2p_channels_snark_reducer;
-pub use p2p_channels_snark_reducer::*;
+
 
 mod p2p_channels_snark_effects;
-pub use p2p_channels_snark_effects::*;
+
 
 use binprot_derive::{BinProtRead, BinProtWrite};
 use openmina_core::snark::SnarkInfo;

--- a/p2p/src/channels/snark_job_commitment/mod.rs
+++ b/p2p/src/channels/snark_job_commitment/mod.rs
@@ -5,10 +5,10 @@ mod p2p_channels_snark_job_commitment_actions;
 pub use p2p_channels_snark_job_commitment_actions::*;
 
 mod p2p_channels_snark_job_commitment_reducer;
-pub use p2p_channels_snark_job_commitment_reducer::*;
+
 
 mod p2p_channels_snark_job_commitment_effects;
-pub use p2p_channels_snark_job_commitment_effects::*;
+
 
 use binprot_derive::{BinProtRead, BinProtWrite};
 use openmina_core::snark::SnarkJobCommitment;

--- a/p2p/src/connection/incoming/mod.rs
+++ b/p2p/src/connection/incoming/mod.rs
@@ -5,10 +5,10 @@ mod p2p_connection_incoming_actions;
 pub use p2p_connection_incoming_actions::*;
 
 mod p2p_connection_incoming_reducer;
-pub use p2p_connection_incoming_reducer::*;
+
 
 mod p2p_connection_incoming_effects;
-pub use p2p_connection_incoming_effects::*;
+
 
 use serde::{Deserialize, Serialize};
 

--- a/p2p/src/connection/outgoing/mod.rs
+++ b/p2p/src/connection/outgoing/mod.rs
@@ -5,10 +5,10 @@ mod p2p_connection_outgoing_actions;
 pub use p2p_connection_outgoing_actions::*;
 
 mod p2p_connection_outgoing_reducer;
-pub use p2p_connection_outgoing_reducer::*;
+
 
 mod p2p_connection_outgoing_effects;
-pub use p2p_connection_outgoing_effects::*;
+
 
 use std::{fmt, str::FromStr};
 

--- a/p2p/src/disconnection/mod.rs
+++ b/p2p/src/disconnection/mod.rs
@@ -5,7 +5,7 @@ mod p2p_disconnection_actions;
 pub use p2p_disconnection_actions::*;
 
 mod p2p_disconnection_effects;
-pub use p2p_disconnection_effects::*;
+
 
 mod p2p_disconnection_service;
 pub use p2p_disconnection_service::*;

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -26,7 +26,7 @@ mod p2p_state;
 pub use p2p_state::*;
 
 mod p2p_reducer;
-pub use p2p_reducer::*;
+
 
 use redux::SubStore;
 pub trait P2pStore<GlobalState>: SubStore<GlobalState, P2pState, SubAction = P2pAction> {}

--- a/p2p/src/peer/mod.rs
+++ b/p2p/src/peer/mod.rs
@@ -5,4 +5,4 @@ mod p2p_peer_reducer;
 pub use p2p_peer_reducer::*;
 
 mod p2p_peer_effects;
-pub use p2p_peer_effects::*;
+

--- a/snark/src/block_verify/mod.rs
+++ b/snark/src/block_verify/mod.rs
@@ -5,10 +5,10 @@ mod snark_block_verify_actions;
 pub use snark_block_verify_actions::*;
 
 mod snark_block_verify_reducer;
-pub use snark_block_verify_reducer::*;
+
 
 mod snark_block_verify_effects;
-pub use snark_block_verify_effects::*;
+
 
 mod snark_block_verify_service;
 pub use snark_block_verify_service::*;

--- a/snark/src/lib.rs
+++ b/snark/src/lib.rs
@@ -25,7 +25,7 @@ mod snark_state;
 pub use snark_state::*;
 
 mod snark_reducer;
-pub use snark_reducer::*;
+
 
 pub type VerifierIndex = kimchi::verifier_index::VerifierIndex<Pallas>;
 pub type VerifierSRS = poly_commitment::srs::SRS<Vesta>;

--- a/snark/src/work_verify/mod.rs
+++ b/snark/src/work_verify/mod.rs
@@ -5,10 +5,10 @@ mod snark_work_verify_actions;
 pub use snark_work_verify_actions::*;
 
 mod snark_work_verify_reducer;
-pub use snark_work_verify_reducer::*;
+
 
 mod snark_work_verify_effects;
-pub use snark_work_verify_effects::*;
+
 
 mod snark_work_verify_service;
 pub use snark_work_verify_service::*;

--- a/vrf/src/lib.rs
+++ b/vrf/src/lib.rs
@@ -1,3 +1,6 @@
+// TODO: remove after finalization (once the num::* rexports have been removed)
+#![allow(hidden_glob_reexports)]
+
 use ark_ec::AffineCurve;
 use ark_ff::{BigInteger, BigInteger256, One, PrimeField, SquareRootField, Zero};
 use ledger::AccountIndex;
@@ -20,7 +23,7 @@ mod message;
 mod output;
 mod threshold;
 
-// TODO: remove after finalization
+// TODO: remove after finalization, and `hidden_glob_reexports` lint attribute at beginning of file
 pub use num::*;
 
 type VrfResult<T> = std::result::Result<T, VrfError>;


### PR DESCRIPTION
Fix a bunch of warnings related to unused re-exports and overrides from glob re-exports