### PR TITLE
fix(berkeley-rc1): fix RPCs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3250,6 +3250,7 @@ dependencies = [
  "mina-poseidon",
  "mina-signer",
  "o1-utils",
+ "rsexp",
  "serde",
  "serde_json",
  "sha2 0.10.8",
@@ -4894,6 +4895,12 @@ dependencies = [
  "rmp",
  "serde",
 ]
+
+[[package]]
+name = "rsexp"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3df9a9b6491d42c0fc527e92a87525c17e45c6b9c22345702a6dc0400320bf1"
 
 [[package]]
 name = "rtcp"

--- a/mina-p2p-messages/Cargo.toml
+++ b/mina-p2p-messages/Cargo.toml
@@ -26,6 +26,7 @@ mina-poseidon = { workspace = true, optional = true }
 o1-utils = { workspace = true, optional = true }
 
 ark-ff = { version = "0.3.0", features = [ "parallel", "asm" ], optional = true }
+rsexp = "0.2.3"
 
 [target.'cfg(fuzzing)'.dev-dependencies]
 fuzzcheck = "0.12.1"

--- a/mina-p2p-messages/src/core.rs
+++ b/mina-p2p-messages/src/core.rs
@@ -2,27 +2,67 @@ use std::net::IpAddr;
 
 use binprot_derive::{BinProtRead, BinProtWrite};
 use serde::{Deserialize, Serialize};
-
-use crate::versioned::Versioned;
+use crate::{
+    string::{ByteString, CharString},
+    versioned::Versioned,
+};
 
 ///! Types from Janestreet's Core library.
 
-/// Core.Error type.
-///
-/// TODO properly implement payloads.
-#[derive(Clone, Debug, Serialize, Deserialize, BinProtRead, BinProtWrite, PartialEq, Eq)]
-pub enum Info {
-    CouldNotConstruct(super::string::CharString), // of Sexp.t
-    String(super::string::CharString),            // of string
-    Exn,                                          // of Binable_exn.V1.t
-    Sexp,                                         // of Sexp.t
-    TagSexp,       // of string * Sexp.t * Source_code_position.V1.t option
-    TagT,          // of string * t
-    TagArg,        // of string * Sexp.t * t
-    OfList,        // of int option * t list
-    WithBacktrace, // of t * string (* backtrace *)
+/// This type corresponds to `Bounded_types.Wrapped_error` OCaml type, but the
+/// structure is different. It only refrects the data that is passed over the
+/// wire (stringified sexp representation of the error)
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, derive_more::Display)]
+#[serde(into = "SexpString", try_from = "SexpString")]
+#[display(fmt = "{}", "String::from_utf8_lossy(&_0.to_bytes())")]
+pub struct Info(rsexp::Sexp);
+
+impl Info {
+    pub fn from_str(msg: &str) -> Self {
+        Info(rsexp::atom(msg.as_bytes()))
+    }
 }
 
+#[derive(Debug, thiserror::Error)]
+#[error("error parsing info sexp: {0:?}")]
+pub struct InfoFromSexpError(rsexp::Error);
+
+impl binprot::BinProtRead for Info {
+    fn binprot_read<R: std::io::Read + ?Sized>(r: &mut R) -> Result<Self, binprot::Error> {
+        let sexp = ByteString::binprot_read(r)?;
+        let parsed = rsexp::from_slice(&sexp)
+            .map_err(|e| binprot::Error::CustomError(Box::new(InfoFromSexpError(e))))?;
+        Ok(Info(parsed))
+    }
+}
+
+impl binprot::BinProtWrite for Info {
+    fn binprot_write<W: std::io::Write>(&self, w: &mut W) -> std::io::Result<()> {
+        ByteString::from(self.0.to_bytes()).binprot_write(w)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SexpString(CharString);
+
+impl From<Info> for SexpString {
+    fn from(value: Info) -> Self {
+        SexpString(CharString::from(value.0.to_bytes()))
+    }
+}
+
+impl TryFrom<SexpString> for Info {
+    type Error = InfoFromSexpError;
+
+    fn try_from(value: SexpString) -> Result<Self, Self::Error> {
+        let parsed = rsexp::from_slice(&value.0)
+            .map_err(|e| InfoFromSexpError(e))?;
+        Ok(Info(parsed))
+    }
+}
+
+/// Represents error processing an RPC request.
 pub type Error = Info;
 
 // TODO
@@ -52,5 +92,39 @@ impl binprot::BinProtRead for InetAddrV1 {
 impl binprot::BinProtWrite for InetAddrV1 {
     fn binprot_write<W: std::io::Write>(&self, w: &mut W) -> std::io::Result<()> {
         self.0.to_string().binprot_write(w)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use binprot::{BinProtWrite, BinProtRead};
+
+    use super::Info;
+
+    fn info_to_bytes(info: &Info) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        info.binprot_write(&mut bytes).unwrap();
+        bytes
+    }
+
+    fn bytes_to_info(mut bytes: &[u8]) -> Info {
+        let info = Info::binprot_read(&mut bytes).unwrap();
+        assert!(bytes.len() == 0);
+        info
+    }
+
+    #[test]
+    fn sexp_binprot() {
+        use rsexp::*;
+
+        let info = Info(atom(b"atom"));
+        let bytes = info_to_bytes(&info);
+        assert_eq!(&bytes, b"\x04atom");
+        assert_eq!(info, bytes_to_info(&bytes));
+
+        let info = Info(atom(b"atom atom"));
+        let bytes = info_to_bytes(&info);
+        assert_eq!(&bytes, b"\x0b\"atom atom\"");
+        assert_eq!(info, bytes_to_info(&bytes));
     }
 }

--- a/mina-p2p-messages/src/rpc.rs
+++ b/mina-p2p-messages/src/rpc.rs
@@ -18,6 +18,7 @@ use crate::{v1, v2};
 
 macro_rules! mina_rpc {
     ($name:ident, $tag:literal, $version:literal, $query:ty, $response:ty $(,)?) => {
+        #[derive(Debug)]
         pub struct $name;
         impl crate::rpc_kernel::RpcMethod for $name {
             const NAME: &'static str = $tag;
@@ -93,7 +94,7 @@ mina_rpc!(
 mina_rpc!(
     AnswerSyncLedgerQueryV2,
     "answer_sync_ledger_query",
-    2,
+    3,
     (LedgerHashV1, v2::MinaLedgerSyncLedgerQueryStableV1),
     RpcResult<v2::MinaLedgerSyncLedgerAnswerStableV2, core::Error>
 );

--- a/mina-p2p-messages/src/rpc_kernel.rs
+++ b/mina-p2p-messages/src/rpc_kernel.rs
@@ -63,6 +63,12 @@ where
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, derive_more::From)]
 pub struct NeedsLength<T>(pub T);
 
+impl<T> NeedsLength<T> {
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
 impl<T> BinProtRead for NeedsLength<T>
 where
     T: BinProtRead,
@@ -297,7 +303,7 @@ where
         R: Read,
     {
         ResponsePayload::<Self::Response>::binprot_read(r)
-            .map(|v| Result::from(v).map(|NeedsLength(v)| v))
+            .map(|v| Result::from(v).map(NeedsLength::into_inner))
     }
 }
 
@@ -353,7 +359,7 @@ where
         R: Read,
     {
         if let Message::Response(response) = Message::<T::Response>::binprot_read(r)? {
-            Ok(Result::from(response.data).map(|v| v.0))
+            Ok(Result::from(response.data).map(NeedsLength::into_inner))
         } else {
             Err(RpcDebuggerReaderError::ExpectResponse)
         }

--- a/p2p/src/service_impl/libp2p/mod.rs
+++ b/p2p/src/service_impl/libp2p/mod.rs
@@ -480,12 +480,13 @@ impl Libp2pService {
                                 b.rpc.respond::<T>(peer_id, stream_id, id, Ok(None))?
                             }
                             (AnswerSyncLedgerQueryV2::NAME, AnswerSyncLedgerQueryV2::VERSION) => {
+                                // TODO: shouldn't we disable this method in menu?
                                 type T = AnswerSyncLedgerQueryV2;
                                 b.rpc.respond::<T>(
                                     peer_id,
                                     stream_id,
                                     id,
-                                    Ok(RpcResult(Err(Info::String(Vec::new().into())))),
+                                    Ok(RpcResult(Err(Info::from_str("not implemented")))),
                                 )?
                             }
                             (


### PR DESCRIPTION
- bump version for answer_sync_ledger_query
- sync up with the new Error type

@tizoc Following up our discussion in Slack. Now I assume that the only option is to have a sexp representation for errors. Can you confirm that? Or should we extend that at some point?