### PR TITLE
Workaround for missing hashing code in `mina-p2p-messages`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4124,6 +4124,7 @@ dependencies = [
  "libp2p",
  "libp2p-rpc-behaviour",
  "mina-p2p-messages",
+ "mina-tree",
  "multihash 0.18.1",
  "openmina-core",
  "rand 0.8.5",

--- a/node/src/ledger/ledger_service.rs
+++ b/node/src/ledger/ledger_service.rs
@@ -7,6 +7,7 @@ use std::{
 use ledger::{
     scan_state::{
         currency::{Amount, Fee, Slot},
+        protocol_state::MinaHash,
         scan_state::{
             AvailableJobMessage, ConstraintConstants, JobValueBase, JobValueMerge,
             JobValueWithIndex, Pass,
@@ -452,7 +453,7 @@ impl<T: LedgerService> TransitionFrontierSyncLedgerStagedService for T {
             let states = parts
                 .needed_blocks
                 .iter()
-                .map(|state| (state.hash().to_fp().unwrap(), state.clone()))
+                .map(|state| (MinaHash::hash(state), state.clone()))
                 .collect::<BTreeMap<_, _>>();
 
             StagedLedger::of_scan_state_pending_coinbases_and_snarked_ledger(

--- a/node/src/p2p/p2p_effects.rs
+++ b/node/src/p2p/p2p_effects.rs
@@ -1,3 +1,4 @@
+use ledger::proofs::public_input::protocol_state::MinaHash;
 use mina_p2p_messages::v2::{MinaLedgerSyncLedgerAnswerStableV2, StateHash};
 use openmina_core::block::BlockWithHash;
 
@@ -343,8 +344,10 @@ pub fn p2p_effects<S: Service>(store: &mut Store<S>, action: P2pActionWithMeta) 
                             }
                             Some(P2pRpcResponse::BestTipWithProof(resp)) => {
                                 let (body_hashes, root_block) = &resp.proof;
-                                let best_tip = BlockWithHash::new(resp.best_tip.clone());
-                                let root_block = BlockWithHash::new(root_block.clone());
+                                let best_tip =
+                                    BlockWithHash::new(resp.best_tip.clone(), MinaHash::hash);
+                                let root_block =
+                                    BlockWithHash::new(root_block.clone(), MinaHash::hash);
 
                                 // reconstruct hashes
                                 let hashes = body_hashes
@@ -411,7 +414,7 @@ pub fn p2p_effects<S: Service>(store: &mut Store<S>, action: P2pActionWithMeta) 
                                 );
                             }
                             Some(P2pRpcResponse::Block(block)) => {
-                                let block = BlockWithHash::new(block.clone());
+                                let block = BlockWithHash::new(block.clone(), MinaHash::hash);
                                 store.dispatch(
                                     TransitionFrontierSyncAction::BlocksPeerQuerySuccess {
                                         peer_id,

--- a/node/src/transition_frontier/sync/ledger/staged/transition_frontier_sync_ledger_staged_reducer.rs
+++ b/node/src/transition_frontier/sync/ledger/staged/transition_frontier_sync_ledger_staged_reducer.rs
@@ -1,3 +1,6 @@
+use ledger::scan_state::protocol_state::MinaHash;
+use mina_p2p_messages::v2;
+
 use super::{
     PeerStagedLedgerPartsFetchState, StagedLedgerAuxAndPendingCoinbasesValidated,
     TransitionFrontierSyncLedgerStagedAction, TransitionFrontierSyncLedgerStagedActionWithMetaRef,
@@ -26,7 +29,8 @@ impl TransitionFrontierSyncLedgerStagedState {
             }
             TransitionFrontierSyncLedgerStagedAction::PartsPeerFetchError {
                 peer_id,
-                error, ..
+                error,
+                ..
             } => {
                 let Self::PartsFetchPending { attempts, .. } = self else {
                     return;
@@ -158,7 +162,7 @@ impl TransitionFrontierSyncLedgerStagedState {
                         .map(|parts| &parts.needed_blocks[..])
                         .unwrap_or(&[])
                         .iter()
-                        .map(|block| (block.hash(), block.clone()))
+                        .map(|block| (v2::StateHash::from_fp(MinaHash::hash(block)), block.clone()))
                         .collect(),
                 };
             }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -32,6 +32,8 @@ mina-p2p-messages = { workspace = true }
 
 openmina-core = { path = "../core" }
 
+ledger = { workspace = true }
+
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1.26", features = ["rt"] }
 webrtc = { git = "https://github.com/openmina/webrtc.git", branch = "openmina-13c490c3", optional = true }

--- a/p2p/src/channels/p2p_channels_effects.rs
+++ b/p2p/src/channels/p2p_channels_effects.rs
@@ -1,3 +1,4 @@
+use ledger::proofs::public_input::protocol_state::MinaHash;
 use openmina_core::block::BlockWithHash;
 use redux::ActionMeta;
 
@@ -31,7 +32,7 @@ impl P2pChannelsMessageReceivedAction {
                     store.dispatch(P2pChannelsBestTipAction::RequestReceived { peer_id })
                 }
                 BestTipPropagationChannelMsg::BestTip(best_tip) => {
-                    let best_tip = BlockWithHash::new(best_tip);
+                    let best_tip = BlockWithHash::new(best_tip, MinaHash::hash);
                     store.dispatch(P2pChannelsBestTipAction::Received { peer_id, best_tip })
                 }
             },

--- a/p2p/src/channels/rpc/p2p_channels_rpc_effects.rs
+++ b/p2p/src/channels/rpc/p2p_channels_rpc_effects.rs
@@ -1,4 +1,6 @@
+use ledger::proofs::public_input::protocol_state::MinaHash;
 use openmina_core::block::BlockWithHash;
+
 use redux::ActionMeta;
 
 use crate::{
@@ -37,7 +39,7 @@ impl P2pChannelsRpcAction {
                 if let Some(P2pRpcResponse::BestTipWithProof(resp)) = response {
                     store.dispatch(P2pPeerAction::BestTipUpdate {
                         peer_id,
-                        best_tip: BlockWithHash::new(resp.best_tip.clone()),
+                        best_tip: BlockWithHash::new(resp.best_tip.clone(), MinaHash::hash),
                     });
                 }
             }


### PR DESCRIPTION
Use some of the hashing implementation in the `ledger` crate in place of the currently missing hashing code in `mina-p2p-messages`