### PR TITLE
fixup(ledger_service): Revert hashing modification (not needed after fix in #243)

### DIFF
--- a/node/src/ledger/ledger_service.rs
+++ b/node/src/ledger/ledger_service.rs
@@ -8,7 +8,6 @@ use std::{
 use ledger::{
     scan_state::{
         currency::{Amount, Fee, Slot},
-        protocol_state::MinaHash,
         scan_state::{
             AvailableJobMessage, ConstraintConstants, JobValueBase, JobValueMerge,
             JobValueWithIndex, Pass,
@@ -473,7 +472,7 @@ impl<T: LedgerService> TransitionFrontierSyncLedgerStagedService for T {
             let states = parts
                 .needed_blocks
                 .iter()
-                .map(|state| (MinaHash::hash(state), state.clone()))
+                .map(|state| (state.hash().to_fp().unwrap(), state.clone()))
                 .collect::<BTreeMap<_, _>>();
 
             StagedLedger::of_scan_state_pending_coinbases_and_snarked_ledger(


### PR DESCRIPTION
Just a fixup that reverts a change introduced in #241 that is not needed anymore after #243 got merged.