### PR TITLE
Move time-related enabling conditions to p2p

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -33,14 +33,14 @@ pub trait EnablingCondition<State> {
     /// Enabling condition for the Action.
     ///
     /// Checks if the given action is enabled for a given state.
-    fn is_enabled(&self, state: &State) -> bool {
+    fn is_enabled(&self, state: &State, time: Timestamp) -> bool {
         ...
     }
 }
 ```
 
-`is_enabled(state)` must return `false`, if action doesn't make sense given
-the current state.
+`is_enabled(state, time)` must return `false`, if action doesn't make sense given
+the current state and, optionally, time.
 
 For example message action from peer that isn't connected or we don't know
 about in the state, must not be enabled.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4971,7 +4971,7 @@ dependencies = [
 [[package]]
 name = "redux"
 version = "0.1.0"
-source = "git+https://github.com/openmina/redux-rs.git?branch=feat/global-time#056887aa168c018d5da7d34eb44ad37c76e1508c"
+source = "git+https://github.com/openmina/redux-rs.git?branch=feat/enabling-condition-with-time#c1707773f9008198d2ce350f77388b9e3bd16a78"
 dependencies = [
  "enum_dispatch",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ mina-poseidon = {git = "https://github.com/openmina/proof-systems", branch = "le
 poly-commitment = {git = "https://github.com/openmina/proof-systems", branch = "ledger-newtypes-rampup4-vrf"}
 libp2p = { git = "https://github.com/openmina/rust-libp2p", rev = "cd5425a759d959d7fde58a42f71ab059449760c5", default-features = false }
 vrf = { path = "vrf" }
+redux = { git = "https://github.com/openmina/redux-rs.git", branch = "feat/enabling-condition-with-time", features = ["serde"] }
 
 [profile.fuzz]
 inherits = "release"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,7 +17,7 @@ num_cpus = "1.0"
 rayon = "1.5"
 tokio = { version = "1.26.0" }
 libp2p-identity = { version = "=0.2.7", features = ["peerid"] }
-redux = { git = "https://github.com/openmina/redux-rs.git", branch="feat/global-time", features = ["serde"] }
+redux = { workspace = true }
 ledger = { workspace = true }
 mina-p2p-messages = { workspace = true }
 vrf = { workspace = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,7 +9,7 @@ serde = { version = "1.0.147", features = ["rc"] }
 slab = { version = "0.4.7", features = ["serde"] }
 tracing = { version = "0.1", features = ["std"] }
 sha2 = "0.10.6"
-redux = { git = "https://github.com/openmina/redux-rs.git", branch="feat/global-time", features = ["serde"] }
+redux = { workspace = true }
 tokio = { version = "1.26", features = ["sync"] }
 
 mina-hasher = { workspace = true }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -18,7 +18,7 @@ bs58 = "0.4.0"
 bincode = "1.3.3"
 hex = "0.4.3"
 rand = "0.8"
-redux = { git = "https://github.com/openmina/redux-rs.git", branch="feat/global-time", features = ["serde"] }
+redux = { workspace = true }
 mina-hasher = { workspace = true }
 mina-signer = { workspace = true }
 ledger = { workspace = true }

--- a/node/invariants/Cargo.toml
+++ b/node/invariants/Cargo.toml
@@ -15,5 +15,5 @@ strum = "0.24.1"
 strum_macros = "0.24.3"
 serde = "1.0.147"
 serde_json = { version = "1.0.82", features = ["unbounded_depth", "arbitrary_precision"] }
-redux = { git = "https://github.com/openmina/redux-rs.git", branch="feat/global-time", features = ["serde"] }
+redux = { workspace = true }
 node = { path = "../" }

--- a/node/native/Cargo.toml
+++ b/node/native/Cargo.toml
@@ -14,7 +14,7 @@ warp = "0.3"
 libp2p = { workspace = true, features = ["macros", "serde", "tcp", "dns", "tokio", "yamux", "pnet", "noise", "gossipsub"] }
 juniper = { version = "0.15.11" }
 juniper_warp = { version = "0.7.0" }
-redux = { git = "https://github.com/openmina/redux-rs.git", branch="feat/global-time", features = ["serde"] }
+redux = { workspace = true }
 ledger = { workspace = true }
 mina-p2p-messages = { workspace = true }
 mina-signer = { workspace = true }

--- a/node/src/action.rs
+++ b/node/src/action.rs
@@ -51,7 +51,7 @@ impl redux::EnablingCondition<crate::State> for CheckTimeoutsAction {}
 
 #[cfg(feature = "replay")]
 impl redux::EnablingCondition<crate::State> for Action {
-    fn is_enabled(&self, _: &crate::State) -> bool {
+    fn is_enabled(&self, _: &crate::State, _time: redux::Timestamp) -> bool {
         true
     }
 }

--- a/node/src/block_producer/block_producer_actions.rs
+++ b/node/src/block_producer/block_producer_actions.rs
@@ -41,9 +41,9 @@ pub enum BlockProducerAction {
 }
 
 impl redux::EnablingCondition<crate::State> for BlockProducerAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
         match self {
-            BlockProducerAction::VrfEvaluator(a) => a.is_enabled(state),
+            BlockProducerAction::VrfEvaluator(a) => a.is_enabled(state, time),
             BlockProducerAction::BestTipUpdate { .. } => true,
             BlockProducerAction::WonSlotSearch => state
                 .block_producer
@@ -66,12 +66,12 @@ impl redux::EnablingCondition<crate::State> for BlockProducerAction {
                     && won_slot.global_slot() >= state.cur_global_slot().unwrap()
                     && won_slot > best_tip
             }),
-            BlockProducerAction::WonSlotWait => state.block_producer.with(false, |this| {
-                this.current.won_slot_should_wait(state.time())
-            }),
-            BlockProducerAction::WonSlotProduceInit => state.block_producer.with(false, |this| {
-                this.current.won_slot_should_produce(state.time())
-            }),
+            BlockProducerAction::WonSlotWait => state
+                .block_producer
+                .with(false, |this| this.current.won_slot_should_wait(time)),
+            BlockProducerAction::WonSlotProduceInit => state
+                .block_producer
+                .with(false, |this| this.current.won_slot_should_produce(time)),
             BlockProducerAction::StagedLedgerDiffCreateInit => {
                 state.block_producer.with(false, |this| {
                     matches!(

--- a/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_actions.rs
+++ b/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_actions.rs
@@ -43,7 +43,7 @@ pub enum BlockProducerVrfEvaluatorAction {
 }
 
 impl redux::EnablingCondition<crate::State> for BlockProducerVrfEvaluatorAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
+    fn is_enabled(&self, state: &crate::State, _time: redux::Timestamp) -> bool {
         match self {
             BlockProducerVrfEvaluatorAction::UpdateProducerAndDelegates { .. } => {
                 state.block_producer.with(false, |this| {

--- a/node/src/consensus/consensus_actions.rs
+++ b/node/src/consensus/consensus_actions.rs
@@ -44,7 +44,7 @@ pub enum ConsensusAction {
 }
 
 impl redux::EnablingCondition<crate::State> for ConsensusAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
+    fn is_enabled(&self, state: &crate::State, _time: redux::Timestamp) -> bool {
         match self {
             ConsensusAction::BlockReceived { hash, .. } => {
                 !state.consensus.blocks.contains_key(hash)

--- a/node/src/effects.rs
+++ b/node/src/effects.rs
@@ -97,7 +97,7 @@ pub fn effects<S: Service>(store: &mut Store<S>, action: ActionWithMeta) {
             #[cfg(feature = "p2p-libp2p")]
             {
                 let state = store.state();
-                for (peer_id, id) in state.p2p.peer_rpc_timeouts(state.time()) {
+                for (peer_id, id) in state.p2p.peer_rpc_timeouts(meta.prev_time()) {
                     store.dispatch(P2pChannelsRpcAction::Timeout { peer_id, id });
                 }
             }

--- a/node/src/event_source/event_source_actions.rs
+++ b/node/src/event_source/event_source_actions.rs
@@ -24,7 +24,7 @@ pub enum EventSourceAction {
 }
 
 impl redux::EnablingCondition<crate::State> for EventSourceAction {
-    fn is_enabled(&self, _: &crate::State) -> bool {
+    fn is_enabled(&self, _: &crate::State, _time: redux::Timestamp) -> bool {
         match self {
             EventSourceAction::ProcessEvents => true,
             EventSourceAction::NewEvent { event: _ } => true,

--- a/node/src/external_snark_worker/external_snark_worker_actions.rs
+++ b/node/src/external_snark_worker/external_snark_worker_actions.rs
@@ -51,7 +51,7 @@ pub type ExternalSnarkWorkerActionWithMetaRef<'a> =
     redux::ActionWithMeta<&'a ExternalSnarkWorkerAction>;
 
 impl EnablingCondition<State> for ExternalSnarkWorkerAction {
-    fn is_enabled(&self, state: &State) -> bool {
+    fn is_enabled(&self, state: &State, _time: redux::Timestamp) -> bool {
         match self {
             ExternalSnarkWorkerAction::Start => {
                 state.config.snarker.is_some()

--- a/node/src/p2p/channels/best_tip/p2p_channels_best_tip_actions.rs
+++ b/node/src/p2p/channels/best_tip/p2p_channels_best_tip_actions.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 impl redux::EnablingCondition<crate::State> for P2pChannelsBestTipAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }

--- a/node/src/p2p/channels/p2p_channels_actions.rs
+++ b/node/src/p2p/channels/p2p_channels_actions.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 impl redux::EnablingCondition<crate::State> for P2pChannelsMessageReceivedAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }

--- a/node/src/p2p/channels/rpc/p2p_channels_rpc_actions.rs
+++ b/node/src/p2p/channels/rpc/p2p_channels_rpc_actions.rs
@@ -1,13 +1,7 @@
 use super::*;
 
 impl redux::EnablingCondition<crate::State> for P2pChannelsRpcAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        match self {
-            Self::Timeout { peer_id, id } => {
-                self.is_enabled(&state.p2p)
-                    && state.p2p.is_peer_rpc_timed_out(peer_id, *id, state.time())
-            }
-            _ => self.is_enabled(&state.p2p),
-        }
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }

--- a/node/src/p2p/channels/snark/p2p_channels_snark_actions.rs
+++ b/node/src/p2p/channels/snark/p2p_channels_snark_actions.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 impl redux::EnablingCondition<crate::State> for P2pChannelsSnarkAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }

--- a/node/src/p2p/channels/snark_job_commitment/p2p_channels_snark_job_commitment_actions.rs
+++ b/node/src/p2p/channels/snark_job_commitment/p2p_channels_snark_job_commitment_actions.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 impl redux::EnablingCondition<crate::State> for P2pChannelsSnarkJobCommitmentAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }

--- a/node/src/p2p/connection/incoming/p2p_connection_incoming_actions.rs
+++ b/node/src/p2p/connection/incoming/p2p_connection_incoming_actions.rs
@@ -1,16 +1,7 @@
 use super::*;
 
 impl redux::EnablingCondition<crate::State> for P2pConnectionIncomingAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        match self {
-            Self::Timeout { peer_id } => {
-                let peer = state.p2p.peers.get(peer_id);
-                let timed_out = peer
-                    .and_then(|peer| peer.status.as_connecting()?.as_incoming())
-                    .map_or(false, |s| s.is_timed_out(state.time()));
-                timed_out && self.is_enabled(&state.p2p)
-            }
-            _ => self.is_enabled(&state.p2p),
-        }
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }

--- a/node/src/p2p/connection/outgoing/p2p_connection_outgoing_actions.rs
+++ b/node/src/p2p/connection/outgoing/p2p_connection_outgoing_actions.rs
@@ -1,40 +1,7 @@
-use std::time::Duration;
-
-use crate::p2p::connection::P2pConnectionState;
-use crate::p2p::P2pPeerStatus;
-
 use super::*;
 
 impl redux::EnablingCondition<crate::State> for P2pConnectionOutgoingAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        match self {
-            P2pConnectionOutgoingAction::Reconnect { opts, .. } => {
-                if !self.is_enabled(&state.p2p) {
-                    return false;
-                }
-
-                let Some(peer) = state.p2p.peers.get(opts.peer_id()) else {
-                    return false;
-                };
-                let delay_passed = match &peer.status {
-                    P2pPeerStatus::Connecting(P2pConnectionState::Outgoing(
-                        P2pConnectionOutgoingState::Error { time, .. },
-                    ))
-                    | P2pPeerStatus::Disconnected { time, .. } => {
-                        state.time().checked_sub(*time) >= Some(Duration::from_secs(30))
-                    }
-                    _ => true,
-                };
-                delay_passed
-            }
-            P2pConnectionOutgoingAction::Timeout { peer_id } => {
-                let peer = state.p2p.peers.get(peer_id);
-                let timed_out = peer
-                    .and_then(|peer| peer.status.as_connecting()?.as_outgoing())
-                    .map_or(false, |s| s.is_timed_out(state.time()));
-                timed_out && self.is_enabled(&state.p2p)
-            }
-            _ => self.is_enabled(&state.p2p),
-        }
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }

--- a/node/src/p2p/disconnection/p2p_disconnection_actions.rs
+++ b/node/src/p2p/disconnection/p2p_disconnection_actions.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 impl redux::EnablingCondition<crate::State> for P2pDisconnectionAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }

--- a/node/src/p2p/discovery/mod.rs
+++ b/node/src/p2p/discovery/mod.rs
@@ -1,7 +1,7 @@
 pub use ::p2p::discovery::*;
 
 impl redux::EnablingCondition<crate::State> for P2pDiscoveryAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }

--- a/node/src/p2p/listen/p2p_listen_actions.rs
+++ b/node/src/p2p/listen/p2p_listen_actions.rs
@@ -4,7 +4,7 @@ use redux::EnablingCondition;
 use crate::State;
 
 impl EnablingCondition<State> for P2pListenAction {
-    fn is_enabled(&self, state: &State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }

--- a/node/src/p2p/mod.rs
+++ b/node/src/p2p/mod.rs
@@ -32,7 +32,7 @@ where
 
     fn dispatch<A>(&mut self, action: A) -> bool
     where
-        A: Into<P2pAction> + redux::EnablingCondition<crate::State>,
+        A: Into<P2pAction> + redux::EnablingCondition<P2pState>,
     {
         crate::Store::sub_dispatch(self, action)
     }

--- a/node/src/p2p/network/mod.rs
+++ b/node/src/p2p/network/mod.rs
@@ -1,211 +1,211 @@
 pub use ::p2p::network::*;
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkSchedulerInterfaceDetectedAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkSchedulerInterfaceExpiredAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkSchedulerIncomingConnectionIsReadyAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkSchedulerIncomingDidAcceptAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkSchedulerOutgoingDidConnectAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkSchedulerIncomingDataIsReadyAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkSchedulerIncomingDataDidReceiveAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkSchedulerSelectDoneAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkSchedulerSelectErrorAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkSchedulerYamuxDidInitAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkPnetIncomingDataAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkPnetOutgoingDataAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkPnetSetupNonceAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkSelectInitAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkSelectIncomingDataAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkSelectIncomingTokenAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkSelectOutgoingTokensAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkNoiseInitAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkNoiseIncomingDataAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkNoiseIncomingChunkAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkNoiseOutgoingChunkAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkNoiseOutgoingDataAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkNoiseDecryptedDataAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkNoiseHandshakeDoneAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkYamuxIncomingDataAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkYamuxOutgoingDataAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkYamuxIncomingFrameAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkYamuxOutgoingFrameAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkYamuxPingStreamAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkYamuxOpenStreamAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkRpcInitAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkRpcIncomingDataAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkRpcIncomingMessageAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkRpcOutgoingQueryAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkRpcOutgoingDataAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }

--- a/node/src/p2p/peer/p2p_peer_actions.rs
+++ b/node/src/p2p/peer/p2p_peer_actions.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 impl redux::EnablingCondition<crate::State> for P2pPeerAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.p2p)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.p2p, time)
     }
 }

--- a/node/src/rpc/rpc_actions.rs
+++ b/node/src/rpc/rpc_actions.rs
@@ -107,7 +107,7 @@ pub enum RpcAction {
 }
 
 impl redux::EnablingCondition<crate::State> for RpcAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
+    fn is_enabled(&self, state: &crate::State, _time: redux::Timestamp) -> bool {
         match self {
             RpcAction::GlobalStateGet { .. } => true,
             RpcAction::ActionStatsGet { .. } => true,

--- a/node/src/snark/block_verify/snark_block_verify_actions.rs
+++ b/node/src/snark/block_verify/snark_block_verify_actions.rs
@@ -1,8 +1,8 @@
 use super::*;
 
 impl redux::EnablingCondition<crate::State> for SnarkBlockVerifyAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.snark)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.snark, time)
     }
 }
 

--- a/node/src/snark/mod.rs
+++ b/node/src/snark/mod.rs
@@ -27,7 +27,7 @@ where
 
     fn dispatch<A>(&mut self, action: A) -> bool
     where
-        A: Into<SnarkAction> + redux::EnablingCondition<crate::State>,
+        A: Into<SnarkAction> + redux::EnablingCondition<SnarkState>,
     {
         crate::Store::sub_dispatch(self, action)
     }

--- a/node/src/snark/work_verify/snark_work_verify_actions.rs
+++ b/node/src/snark/work_verify/snark_work_verify_actions.rs
@@ -1,8 +1,8 @@
 use super::*;
 
 impl redux::EnablingCondition<crate::State> for SnarkWorkVerifyAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
-        self.is_enabled(&state.snark)
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        self.is_enabled(&state.snark, time)
     }
 }
 

--- a/node/src/snark_pool/candidate/snark_pool_candidate_actions.rs
+++ b/node/src/snark_pool/candidate/snark_pool_candidate_actions.rs
@@ -53,7 +53,7 @@ pub enum SnarkPoolCandidateAction {
 }
 
 impl redux::EnablingCondition<crate::State> for SnarkPoolCandidateAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
+    fn is_enabled(&self, state: &crate::State, _time: redux::Timestamp) -> bool {
         match self {
             SnarkPoolCandidateAction::InfoReceived { peer_id, info } => {
                 state.snark_pool.contains(&info.job_id)

--- a/node/src/snark_pool/snark_pool_actions.rs
+++ b/node/src/snark_pool/snark_pool_actions.rs
@@ -42,9 +42,9 @@ pub enum SnarkPoolAction {
 }
 
 impl redux::EnablingCondition<crate::State> for SnarkPoolAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
         match self {
-            SnarkPoolAction::Candidate(action) => action.is_enabled(state),
+            SnarkPoolAction::Candidate(action) => action.is_enabled(state, time),
             SnarkPoolAction::AutoCreateCommitment => state
                 .config
                 .snarker
@@ -98,13 +98,12 @@ impl redux::EnablingCondition<crate::State> for SnarkPoolAction {
                         last_index,
                     ) || check(p.channels.snark.next_send_index_and_limit(), last_index)
                 }),
-            SnarkPoolAction::CheckTimeouts => state
-                .time()
+            SnarkPoolAction::CheckTimeouts => time
                 .checked_sub(state.snark_pool.last_check_timeouts)
                 .map_or(false, |dur| dur.as_secs() >= 5),
-            SnarkPoolAction::JobCommitmentTimeout { job_id } => state
-                .snark_pool
-                .is_commitment_timed_out(job_id, state.time()),
+            SnarkPoolAction::JobCommitmentTimeout { job_id } => {
+                state.snark_pool.is_commitment_timed_out(job_id, time)
+            }
             SnarkPoolAction::JobsUpdate { .. } => true,
             SnarkPoolAction::P2pSendAll => true,
         }

--- a/node/src/transition_frontier/sync/ledger/snarked/transition_frontier_sync_ledger_snarked_actions.rs
+++ b/node/src/transition_frontier/sync/ledger/snarked/transition_frontier_sync_ledger_snarked_actions.rs
@@ -57,7 +57,7 @@ pub enum TransitionFrontierSyncLedgerSnarkedAction {
 }
 
 impl redux::EnablingCondition<crate::State> for TransitionFrontierSyncLedgerSnarkedAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
+    fn is_enabled(&self, state: &crate::State, _time: redux::Timestamp) -> bool {
         match self {
             TransitionFrontierSyncLedgerSnarkedAction::Pending => {
                 state.transition_frontier.sync.ledger().map_or(false, |s| {

--- a/node/src/transition_frontier/sync/ledger/staged/transition_frontier_sync_ledger_staged_actions.rs
+++ b/node/src/transition_frontier/sync/ledger/staged/transition_frontier_sync_ledger_staged_actions.rs
@@ -55,7 +55,7 @@ pub enum TransitionFrontierSyncLedgerStagedAction {
 }
 
 impl redux::EnablingCondition<crate::State> for TransitionFrontierSyncLedgerStagedAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
+    fn is_enabled(&self, state: &crate::State, _time: redux::Timestamp) -> bool {
         match self {
             TransitionFrontierSyncLedgerStagedAction::PartsFetchPending => state
                 .transition_frontier

--- a/node/src/transition_frontier/sync/ledger/transition_frontier_sync_ledger_actions.rs
+++ b/node/src/transition_frontier/sync/ledger/transition_frontier_sync_ledger_actions.rs
@@ -21,7 +21,7 @@ pub enum TransitionFrontierSyncLedgerAction {
 }
 
 impl redux::EnablingCondition<crate::State> for TransitionFrontierSyncLedgerAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
+    fn is_enabled(&self, state: &crate::State, _time: redux::Timestamp) -> bool {
         match self {
             TransitionFrontierSyncLedgerAction::Init => {
                 state.transition_frontier.sync.ledger().map_or(false, |s| {

--- a/node/src/transition_frontier/sync/transition_frontier_sync_actions.rs
+++ b/node/src/transition_frontier/sync/transition_frontier_sync_actions.rs
@@ -84,7 +84,7 @@ pub enum TransitionFrontierSyncAction {
 }
 
 impl redux::EnablingCondition<crate::State> for TransitionFrontierSyncAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
         match self {
             TransitionFrontierSyncAction::Init { best_tip, .. } => {
                 !state.transition_frontier.sync.is_pending()
@@ -296,7 +296,7 @@ impl redux::EnablingCondition<crate::State> for TransitionFrontierSyncAction {
                 }
                 _ => false,
             },
-            TransitionFrontierSyncAction::Ledger(action) => action.is_enabled(state),
+            TransitionFrontierSyncAction::Ledger(action) => action.is_enabled(state, time),
         }
     }
 }

--- a/node/src/transition_frontier/transition_frontier_actions.rs
+++ b/node/src/transition_frontier/transition_frontier_actions.rs
@@ -22,7 +22,7 @@ pub struct TransitionFrontierSyncedAction {
 }
 
 impl redux::EnablingCondition<crate::State> for TransitionFrontierSyncedAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
+    fn is_enabled(&self, state: &crate::State, _time: redux::Timestamp) -> bool {
         matches!(
             state.transition_frontier.sync,
             TransitionFrontierSyncState::BlocksSuccess { .. }

--- a/node/src/watched_accounts/watched_accounts_actions.rs
+++ b/node/src/watched_accounts/watched_accounts_actions.rs
@@ -84,7 +84,7 @@ fn should_request_ledger_initial_state(state: &crate::State, pub_key: &NonZeroCu
 }
 
 impl redux::EnablingCondition<crate::State> for WatchedAccountsAction {
-    fn is_enabled(&self, state: &crate::State) -> bool {
+    fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
         match self {
             WatchedAccountsAction::Add { pub_key } => state.watched_accounts.get(pub_key).is_none(),
             WatchedAccountsAction::LedgerInitialStateGetInit { pub_key } => {
@@ -105,10 +105,9 @@ impl redux::EnablingCondition<crate::State> for WatchedAccountsAction {
                 .watched_accounts
                 .get(pub_key)
                 .map_or(false, |a| match &a.initial_state {
-                    WatchedAccountLedgerInitialState::Error { time, .. } => state
-                        .time()
-                        .checked_sub(*time)
-                        .map_or(false, |d| d.as_secs() >= 3),
+                    WatchedAccountLedgerInitialState::Error { time: t, .. } => {
+                        time.checked_sub(*t).map_or(false, |d| d.as_secs() >= 3)
+                    }
                     _ => false,
                 }),
             WatchedAccountsAction::LedgerInitialStateGetSuccess { pub_key, .. } => {

--- a/node/testing/Cargo.toml
+++ b/node/testing/Cargo.toml
@@ -31,7 +31,7 @@ strum = "0.24.1"
 strum_macros = "0.24.3"
 tracing-log = "0.2.0"
 documented = { version = "0.1", optional = true }
-redux = { git = "https://github.com/openmina/redux-rs.git", branch="feat/global-time", features = ["serde"] }
+redux = { workspace = true }
 ledger = { workspace = true }
 mina-p2p-messages = { workspace = true }
 libp2p = { workspace = true, features = ["macros", "serde", "tcp", "dns", "tokio", "yamux", "pnet", "noise", "gossipsub"] }

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -37,7 +37,7 @@ blake2 = { version = "0.10.6" }
 chacha20poly1305 = { version = "0.10.1" }
 curve25519-dalek = { version = "4.1" }
 
-redux = { git = "https://github.com/openmina/redux-rs.git", branch="feat/global-time", features = ["serde"] }
+redux = { workspace = true }
 mina-p2p-messages = { workspace = true }
 
 openmina-core = { path = "../core" }

--- a/p2p/src/channels/best_tip/p2p_channels_best_tip_actions.rs
+++ b/p2p/src/channels/best_tip/p2p_channels_best_tip_actions.rs
@@ -53,7 +53,7 @@ impl P2pChannelsBestTipAction {
 }
 
 impl redux::EnablingCondition<P2pState> for P2pChannelsBestTipAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
+    fn is_enabled(&self, state: &P2pState, _time: redux::Timestamp) -> bool {
         match self {
             P2pChannelsBestTipAction::Init { peer_id } => {
                 state.get_ready_peer(peer_id).map_or(false, |p| {

--- a/p2p/src/channels/best_tip/p2p_channels_best_tip_effects.rs
+++ b/p2p/src/channels/best_tip/p2p_channels_best_tip_effects.rs
@@ -12,8 +12,6 @@ impl P2pChannelsBestTipAction {
     where
         Store: crate::P2pStore<S>,
         Store::Service: P2pChannelsService,
-        P2pChannelsBestTipAction: redux::EnablingCondition<S>,
-        P2pPeerAction: redux::EnablingCondition<S>,
     {
         match self {
             P2pChannelsBestTipAction::Init { peer_id } => {

--- a/p2p/src/channels/p2p_channels_actions.rs
+++ b/p2p/src/channels/p2p_channels_actions.rs
@@ -38,7 +38,7 @@ pub struct P2pChannelsMessageReceivedAction {
 }
 
 impl redux::EnablingCondition<P2pState> for P2pChannelsMessageReceivedAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
+    fn is_enabled(&self, state: &P2pState, _time: redux::Timestamp) -> bool {
         state.get_ready_peer(&self.peer_id).map_or(false, |p| {
             p.channels.is_channel_ready(self.message.channel_id())
         })

--- a/p2p/src/channels/p2p_channels_effects.rs
+++ b/p2p/src/channels/p2p_channels_effects.rs
@@ -17,11 +17,6 @@ impl P2pChannelsMessageReceivedAction {
     pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
     where
         Store: crate::P2pStore<S>,
-        P2pChannelsBestTipAction: redux::EnablingCondition<S>,
-        P2pChannelsSnarkAction: redux::EnablingCondition<S>,
-        P2pChannelsSnarkJobCommitmentAction: redux::EnablingCondition<S>,
-        P2pChannelsRpcAction: redux::EnablingCondition<S>,
-        P2pDisconnectionAction: redux::EnablingCondition<S>,
     {
         let peer_id = self.peer_id;
         let chan_id = self.message.channel_id();

--- a/p2p/src/channels/rpc/mod.rs
+++ b/p2p/src/channels/rpc/mod.rs
@@ -54,14 +54,15 @@ pub enum P2pRpcKind {
 
 impl P2pRpcKind {
     pub fn timeout(self) -> Option<Duration> {
-        match self {
-            Self::BestTipWithProof => Some(Duration::from_secs(10)),
-            Self::LedgerQuery => Some(Duration::from_secs(2)),
-            Self::StagedLedgerAuxAndPendingCoinbasesAtBlock => Some(Duration::from_secs(120)),
-            Self::Block => Some(Duration::from_secs(5)),
-            Self::Snark => Some(Duration::from_secs(5)),
-            Self::InitialPeers => Some(Duration::from_secs(5)),
-        }
+        None
+        // match self {
+        //     Self::BestTipWithProof => Some(Duration::from_secs(10)),
+        //     Self::LedgerQuery => Some(Duration::from_secs(2)),
+        //     Self::StagedLedgerAuxAndPendingCoinbasesAtBlock => Some(Duration::from_secs(120)),
+        //     Self::Block => Some(Duration::from_secs(5)),
+        //     Self::Snark => Some(Duration::from_secs(5)),
+        //     Self::InitialPeers => Some(Duration::from_secs(5)),
+        // }
     }
 
     pub fn supported_by_libp2p(self) -> bool {

--- a/p2p/src/channels/snark/p2p_channels_snark_actions.rs
+++ b/p2p/src/channels/snark/p2p_channels_snark_actions.rs
@@ -68,7 +68,7 @@ impl P2pChannelsSnarkAction {
 }
 
 impl redux::EnablingCondition<P2pState> for P2pChannelsSnarkAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
+    fn is_enabled(&self, state: &P2pState, _time: redux::Timestamp) -> bool {
         match self {
             P2pChannelsSnarkAction::Init { peer_id } => {
                 state.get_ready_peer(peer_id).map_or(false, |p| {

--- a/p2p/src/channels/snark/p2p_channels_snark_effects.rs
+++ b/p2p/src/channels/snark/p2p_channels_snark_effects.rs
@@ -9,7 +9,6 @@ impl P2pChannelsSnarkAction {
     where
         Store: crate::P2pStore<S>,
         Store::Service: P2pChannelsService,
-        Self: redux::EnablingCondition<S>,
     {
         match self {
             P2pChannelsSnarkAction::Init { peer_id } => {

--- a/p2p/src/channels/snark_job_commitment/p2p_channels_snark_job_commitment_actions.rs
+++ b/p2p/src/channels/snark_job_commitment/p2p_channels_snark_job_commitment_actions.rs
@@ -60,7 +60,7 @@ impl P2pChannelsSnarkJobCommitmentAction {
 }
 
 impl redux::EnablingCondition<P2pState> for P2pChannelsSnarkJobCommitmentAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
+    fn is_enabled(&self, state: &P2pState, _time: redux::Timestamp) -> bool {
         match self {
             P2pChannelsSnarkJobCommitmentAction::Init { peer_id } => {
                 state.get_ready_peer(peer_id).map_or(false, |p| {

--- a/p2p/src/channels/snark_job_commitment/p2p_channels_snark_job_commitment_effects.rs
+++ b/p2p/src/channels/snark_job_commitment/p2p_channels_snark_job_commitment_effects.rs
@@ -9,7 +9,6 @@ impl P2pChannelsSnarkJobCommitmentAction {
     where
         Store: crate::P2pStore<S>,
         Store::Service: P2pChannelsService,
-        P2pChannelsSnarkJobCommitmentAction: redux::EnablingCondition<S>,
     {
         match self {
             P2pChannelsSnarkJobCommitmentAction::Init { peer_id } => {

--- a/p2p/src/connection/incoming/p2p_connection_incoming_actions.rs
+++ b/p2p/src/connection/incoming/p2p_connection_incoming_actions.rs
@@ -79,7 +79,7 @@ impl P2pConnectionIncomingAction {
 }
 
 impl redux::EnablingCondition<P2pState> for P2pConnectionIncomingAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
+    fn is_enabled(&self, state: &P2pState, time: redux::Timestamp) -> bool {
         match self {
             P2pConnectionIncomingAction::Init { opts, .. } => {
                 state.incoming_accept(opts.peer_id, &opts.offer).is_ok()
@@ -160,7 +160,7 @@ impl redux::EnablingCondition<P2pState> for P2pConnectionIncomingAction {
                 .peers
                 .get(peer_id)
                 .and_then(|peer| peer.status.as_connecting()?.as_incoming())
-                .is_some(),
+                .map_or(false, |s| s.is_timed_out(time)),
             P2pConnectionIncomingAction::Error { peer_id, error } => state
                 .peers
                 .get(peer_id)

--- a/p2p/src/connection/incoming/p2p_connection_incoming_effects.rs
+++ b/p2p/src/connection/incoming/p2p_connection_incoming_effects.rs
@@ -11,9 +11,6 @@ impl P2pConnectionIncomingAction {
     where
         Store: crate::P2pStore<S>,
         Store::Service: P2pConnectionService,
-        P2pDisconnectionAction: redux::EnablingCondition<S>,
-        P2pPeerAction: redux::EnablingCondition<S>,
-        P2pConnectionIncomingAction: redux::EnablingCondition<S>,
     {
         match self {
             P2pConnectionIncomingAction::Init { opts, .. } => {

--- a/p2p/src/connection/outgoing/p2p_connection_outgoing_effects.rs
+++ b/p2p/src/connection/outgoing/p2p_connection_outgoing_effects.rs
@@ -16,8 +16,6 @@ impl P2pConnectionOutgoingAction {
     where
         Store: crate::P2pStore<S>,
         Store::Service: P2pConnectionService,
-        Self: redux::EnablingCondition<S>,
-        P2pPeerAction: redux::EnablingCondition<S>,
     {
         match self {
             P2pConnectionOutgoingAction::RandomInit => {

--- a/p2p/src/disconnection/p2p_disconnection_actions.rs
+++ b/p2p/src/disconnection/p2p_disconnection_actions.rs
@@ -17,7 +17,7 @@ pub enum P2pDisconnectionAction {
 }
 
 impl redux::EnablingCondition<P2pState> for P2pDisconnectionAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
+    fn is_enabled(&self, state: &P2pState, _time: redux::Timestamp) -> bool {
         match self {
             P2pDisconnectionAction::Init { peer_id, .. }
             | P2pDisconnectionAction::Finish { peer_id } => {

--- a/p2p/src/disconnection/p2p_disconnection_effects.rs
+++ b/p2p/src/disconnection/p2p_disconnection_effects.rs
@@ -7,7 +7,6 @@ impl P2pDisconnectionAction {
     where
         Store: crate::P2pStore<S>,
         Store::Service: P2pDisconnectionService,
-        P2pDisconnectionAction: redux::EnablingCondition<S>,
     {
         match self {
             P2pDisconnectionAction::Init { peer_id, .. } => {

--- a/p2p/src/discovery/p2p_discovery_actions.rs
+++ b/p2p/src/discovery/p2p_discovery_actions.rs
@@ -30,7 +30,7 @@ pub enum P2pDiscoveryAction {
 }
 
 impl redux::EnablingCondition<P2pState> for P2pDiscoveryAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
+    fn is_enabled(&self, state: &P2pState, _time: redux::Timestamp) -> bool {
         match self {
             Self::Init { peer_id } => state.get_ready_peer(peer_id).is_some(),
             Self::Success { .. } => true,

--- a/p2p/src/network/noise/p2p_network_noise_actions.rs
+++ b/p2p/src/network/noise/p2p_network_noise_actions.rs
@@ -122,57 +122,57 @@ impl From<P2pNetworkNoiseHandshakeDoneAction> for crate::P2pAction {
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkNoiseAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
+    fn is_enabled(&self, state: &P2pState, time: redux::Timestamp) -> bool {
         match self {
-            Self::Init(v) => v.is_enabled(state),
-            Self::IncomingData(v) => v.is_enabled(state),
-            Self::IncomingChunk(v) => v.is_enabled(state),
-            Self::OutgoingChunk(v) => v.is_enabled(state),
-            Self::OutgoingData(v) => v.is_enabled(state),
-            Self::DecryptedData(v) => v.is_enabled(state),
-            Self::HandshakeDone(v) => v.is_enabled(state),
+            Self::Init(v) => v.is_enabled(state, time),
+            Self::IncomingData(v) => v.is_enabled(state, time),
+            Self::IncomingChunk(v) => v.is_enabled(state, time),
+            Self::OutgoingChunk(v) => v.is_enabled(state, time),
+            Self::OutgoingData(v) => v.is_enabled(state, time),
+            Self::DecryptedData(v) => v.is_enabled(state, time),
+            Self::HandshakeDone(v) => v.is_enabled(state, time),
         }
     }
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkNoiseInitAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
         true
     }
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkNoiseIncomingDataAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
         true
     }
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkNoiseIncomingChunkAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
         true
     }
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkNoiseOutgoingChunkAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
         true
     }
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkNoiseOutgoingDataAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
         true
     }
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkNoiseDecryptedDataAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
         true
     }
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkNoiseHandshakeDoneAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
         true
     }
 }

--- a/p2p/src/network/p2p_network_actions.rs
+++ b/p2p/src/network/p2p_network_actions.rs
@@ -15,14 +15,14 @@ pub enum P2pNetworkAction {
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
+    fn is_enabled(&self, state: &P2pState, time: redux::Timestamp) -> bool {
         match self {
-            Self::Scheduler(v) => v.is_enabled(state),
-            Self::Pnet(v) => v.is_enabled(state),
-            Self::Select(v) => v.is_enabled(state),
-            Self::Noise(v) => v.is_enabled(state),
-            Self::Yamux(v) => v.is_enabled(state),
-            Self::Rpc(v) => v.is_enabled(state),
+            Self::Scheduler(v) => v.is_enabled(state, time),
+            Self::Pnet(v) => v.is_enabled(state, time),
+            Self::Select(v) => v.is_enabled(state, time),
+            Self::Noise(v) => v.is_enabled(state, time),
+            Self::Yamux(v) => v.is_enabled(state, time),
+            Self::Rpc(v) => v.is_enabled(state, time),
         }
     }
 }

--- a/p2p/src/network/pnet/p2p_network_pnet_actions.rs
+++ b/p2p/src/network/pnet/p2p_network_pnet_actions.rs
@@ -67,25 +67,25 @@ impl From<P2pNetworkPnetSetupNonceAction> for crate::P2pAction {
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkPnetAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
         true
     }
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkPnetIncomingDataAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
         true
     }
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkPnetOutgoingDataAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
         true
     }
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkPnetSetupNonceAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
         true
     }
 }

--- a/p2p/src/network/rpc/p2p_network_rpc_actions.rs
+++ b/p2p/src/network/rpc/p2p_network_rpc_actions.rs
@@ -114,43 +114,43 @@ impl From<P2pNetworkRpcOutgoingDataAction> for crate::P2pAction {
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkRpcAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
+    fn is_enabled(&self, state: &P2pState, time: redux::Timestamp) -> bool {
         match self {
-            Self::Init(v) => v.is_enabled(state),
-            Self::IncomingData(v) => v.is_enabled(state),
-            Self::IncomingMessage(v) => v.is_enabled(state),
-            Self::OutgoingQuery(v) => v.is_enabled(state),
-            Self::OutgoingData(v) => v.is_enabled(state),
+            Self::Init(v) => v.is_enabled(state, time),
+            Self::IncomingData(v) => v.is_enabled(state, time),
+            Self::IncomingMessage(v) => v.is_enabled(state, time),
+            Self::OutgoingQuery(v) => v.is_enabled(state, time),
+            Self::OutgoingData(v) => v.is_enabled(state, time),
         }
     }
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkRpcInitAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
         true
     }
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkRpcIncomingDataAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
         true
     }
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkRpcIncomingMessageAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
         true
     }
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkRpcOutgoingQueryAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
         true
     }
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkRpcOutgoingDataAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
         true
     }
 }

--- a/p2p/src/network/scheduler/p2p_network_scheduler_actions.rs
+++ b/p2p/src/network/scheduler/p2p_network_scheduler_actions.rs
@@ -141,78 +141,78 @@ impl From<P2pNetworkSchedulerYamuxDidInitAction> for crate::P2pAction {
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkSchedulerAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
+    fn is_enabled(&self, state: &P2pState, time: redux::Timestamp) -> bool {
         match self {
-            Self::InterfaceDetected(a) => a.is_enabled(state),
-            Self::InterfaceExpired(a) => a.is_enabled(state),
-            Self::IncomingConnectionIsReady(a) => a.is_enabled(state),
-            Self::IncomingDidAccept(a) => a.is_enabled(state),
-            Self::OutgoingDidConnect(a) => a.is_enabled(state),
-            Self::IncomingDataIsReady(a) => a.is_enabled(state),
-            Self::IncomingDataDidReceive(a) => a.is_enabled(state),
-            Self::SelectDone(a) => a.is_enabled(state),
-            Self::SelectError(a) => a.is_enabled(state),
-            Self::YamuxDidInit(a) => a.is_enabled(state),
+            Self::InterfaceDetected(a) => a.is_enabled(state, time),
+            Self::InterfaceExpired(a) => a.is_enabled(state, time),
+            Self::IncomingConnectionIsReady(a) => a.is_enabled(state, time),
+            Self::IncomingDidAccept(a) => a.is_enabled(state, time),
+            Self::OutgoingDidConnect(a) => a.is_enabled(state, time),
+            Self::IncomingDataIsReady(a) => a.is_enabled(state, time),
+            Self::IncomingDataDidReceive(a) => a.is_enabled(state, time),
+            Self::SelectDone(a) => a.is_enabled(state, time),
+            Self::SelectError(a) => a.is_enabled(state, time),
+            Self::YamuxDidInit(a) => a.is_enabled(state, time),
         }
     }
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkSchedulerInterfaceDetectedAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
         true
     }
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkSchedulerInterfaceExpiredAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
         true
     }
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkSchedulerIncomingConnectionIsReadyAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
         true
     }
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkSchedulerIncomingDidAcceptAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
         true
     }
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkSchedulerOutgoingDidConnectAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
         true
     }
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkSchedulerIncomingDataIsReadyAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
         true
     }
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkSchedulerIncomingDataDidReceiveAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
         true
     }
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkSchedulerSelectDoneAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
         true
     }
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkSchedulerSelectErrorAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
         true
     }
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkSchedulerYamuxDidInitAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
         true
     }
 }

--- a/p2p/src/network/select/p2p_network_select_actions.rs
+++ b/p2p/src/network/select/p2p_network_select_actions.rs
@@ -121,36 +121,36 @@ impl From<P2pNetworkSelectOutgoingTokensAction> for crate::P2pAction {
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkSelectAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
+    fn is_enabled(&self, state: &P2pState, time: redux::Timestamp) -> bool {
         match self {
-            Self::Init(v) => v.is_enabled(state),
-            Self::IncomingData(v) => v.is_enabled(state),
-            Self::IncomingToken(v) => v.is_enabled(state),
-            Self::OutgoingTokens(v) => v.is_enabled(state),
+            Self::Init(v) => v.is_enabled(state, time),
+            Self::IncomingData(v) => v.is_enabled(state, time),
+            Self::IncomingToken(v) => v.is_enabled(state, time),
+            Self::OutgoingTokens(v) => v.is_enabled(state, time),
         }
     }
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkSelectInitAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
         true
     }
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkSelectIncomingDataAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
         true
     }
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkSelectIncomingTokenAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
         true
     }
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkSelectOutgoingTokensAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
         true
     }
 }

--- a/p2p/src/network/yamux/p2p_network_yamux_actions.rs
+++ b/p2p/src/network/yamux/p2p_network_yamux_actions.rs
@@ -104,50 +104,50 @@ impl From<P2pNetworkYamuxOpenStreamAction> for crate::P2pAction {
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkYamuxAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
+    fn is_enabled(&self, state: &P2pState, time: redux::Timestamp) -> bool {
         match self {
-            Self::IncomingData(v) => v.is_enabled(state),
-            Self::OutgoingData(v) => v.is_enabled(state),
-            Self::IncomingFrame(v) => v.is_enabled(state),
-            Self::OutgoingFrame(v) => v.is_enabled(state),
-            Self::PingStream(v) => v.is_enabled(state),
-            Self::OpenStream(v) => v.is_enabled(state),
+            Self::IncomingData(v) => v.is_enabled(state, time),
+            Self::OutgoingData(v) => v.is_enabled(state, time),
+            Self::IncomingFrame(v) => v.is_enabled(state, time),
+            Self::OutgoingFrame(v) => v.is_enabled(state, time),
+            Self::PingStream(v) => v.is_enabled(state, time),
+            Self::OpenStream(v) => v.is_enabled(state, time),
         }
     }
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkYamuxIncomingDataAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
         true
     }
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkYamuxOutgoingDataAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
         true
     }
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkYamuxIncomingFrameAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
         true
     }
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkYamuxOutgoingFrameAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
         true
     }
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkYamuxPingStreamAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
         true
     }
 }
 
 impl redux::EnablingCondition<P2pState> for P2pNetworkYamuxOpenStreamAction {
-    fn is_enabled(&self, _state: &P2pState) -> bool {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
         true
     }
 }

--- a/p2p/src/peer/p2p_peer_actions.rs
+++ b/p2p/src/peer/p2p_peer_actions.rs
@@ -28,7 +28,7 @@ impl P2pPeerAction {
 }
 
 impl redux::EnablingCondition<P2pState> for P2pPeerAction {
-    fn is_enabled(&self, state: &P2pState) -> bool {
+    fn is_enabled(&self, state: &P2pState, _time: redux::Timestamp) -> bool {
         match self {
             Self::Ready { peer_id, .. } => state
                 .peers

--- a/p2p/src/peer/p2p_peer_effects.rs
+++ b/p2p/src/peer/p2p_peer_effects.rs
@@ -11,10 +11,6 @@ impl P2pPeerAction {
     pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
     where
         Store: crate::P2pStore<S>,
-        P2pChannelsBestTipAction: redux::EnablingCondition<S>,
-        P2pChannelsSnarkAction: redux::EnablingCondition<S>,
-        P2pChannelsSnarkJobCommitmentAction: redux::EnablingCondition<S>,
-        P2pChannelsRpcAction: redux::EnablingCondition<S>,
     {
         match self {
             P2pPeerAction::Ready { peer_id, .. } => {

--- a/snark/Cargo.toml
+++ b/snark/Cargo.toml
@@ -22,7 +22,7 @@ ark-ec = { git = "https://github.com/openmina/algebra", branch = "openmina", fea
 ark-poly = { git = "https://github.com/openmina/algebra", branch = "openmina", features = [ "parallel" ] }
 once_cell = "1.10"
 hex = "0.4"
-redux = { git = "https://github.com/openmina/redux-rs.git", branch="feat/global-time", features = ["serde"] }
+redux = { workspace = true }
 ledger = { workspace = true }
 mina-p2p-messages = { workspace = true }
 sha2 = "0.10"

--- a/snark/src/block_verify/snark_block_verify_actions.rs
+++ b/snark/src/block_verify/snark_block_verify_actions.rs
@@ -27,7 +27,7 @@ pub enum SnarkBlockVerifyAction {
 }
 
 impl redux::EnablingCondition<crate::SnarkState> for SnarkBlockVerifyAction {
-    fn is_enabled(&self, state: &crate::SnarkState) -> bool {
+    fn is_enabled(&self, state: &crate::SnarkState, _time: redux::Timestamp) -> bool {
         match self {
             SnarkBlockVerifyAction::Init { req_id, .. } => {
                 state.block_verify.jobs.next_req_id() == *req_id

--- a/snark/src/work_verify/snark_work_verify_actions.rs
+++ b/snark/src/work_verify/snark_work_verify_actions.rs
@@ -30,7 +30,7 @@ pub enum SnarkWorkVerifyAction {
 }
 
 impl redux::EnablingCondition<crate::SnarkState> for SnarkWorkVerifyAction {
-    fn is_enabled(&self, state: &crate::SnarkState) -> bool {
+    fn is_enabled(&self, state: &crate::SnarkState, _time: redux::Timestamp) -> bool {
         match self {
             SnarkWorkVerifyAction::Init { req_id, batch, .. } => {
                 !batch.is_empty() && state.work_verify.jobs.next_req_id() == *req_id


### PR DESCRIPTION
closes #253 

@binier ~Note that now time passed to enabling condition is slightly differ from what is in the `state.time()`, but I think this is more consistent, as `state.time()` might jump back, and time that comes from redux is monotonous.~ See discussion below.