### PR TITLE
feat(ledger-service): Non blocking version of `staged_ledger_reconstruct`

### DIFF
--- a/cli/src/commands/node/mod.rs
+++ b/cli/src/commands/node/mod.rs
@@ -227,11 +227,15 @@ impl Node {
 
         let record = self.record;
 
-        let ledger = if let Some(path) = &self.additional_ledgers_path {
+        let mut ledger = if let Some(path) = &self.additional_ledgers_path {
             LedgerCtx::new_with_additional_snarked_ledgers(path)
         } else {
             LedgerCtx::default()
         };
+
+        // TODO(tizoc): Only used for the current workaround to make staged ledger
+        // reconstruction async, can be removed when the ledger services are made async
+        ledger.set_event_sender(event_sender.clone());
 
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()

--- a/node/src/action_kind.rs
+++ b/node/src/action_kind.rs
@@ -1278,7 +1278,7 @@ impl ActionKindGet for TransitionFrontierSyncLedgerStagedAction {
             Self::ReconstructError { .. } => {
                 ActionKind::TransitionFrontierSyncLedgerStagedReconstructError
             }
-            Self::ReconstructSuccess => {
+            Self::ReconstructSuccess { .. } => {
                 ActionKind::TransitionFrontierSyncLedgerStagedReconstructSuccess
             }
             Self::Success => ActionKind::TransitionFrontierSyncLedgerStagedSuccess,

--- a/node/src/event_source/event.rs
+++ b/node/src/event_source/event.rs
@@ -1,3 +1,4 @@
+use mina_p2p_messages::v2::LedgerHash;
 use serde::{Deserialize, Serialize};
 
 pub use crate::block_producer::BlockProducerEvent;
@@ -15,6 +16,8 @@ pub enum Event {
     Rpc(RpcId, RpcRequest),
     ExternalSnarkWorker(ExternalSnarkWorkerEvent),
     BlockProducerEvent(BlockProducerEvent),
+
+    LedgerStagingReconstruct(Result<LedgerHash, String>),
 
     GenesisLoad(Result<GenesisConfigLoaded, String>),
 }
@@ -70,6 +73,17 @@ impl std::fmt::Display for Event {
                 }
             }
             Self::BlockProducerEvent(event) => event.fmt(f),
+            Self::LedgerStagingReconstruct(res) => {
+                write!(f, "LedgerStagingReconstruct, ")?;
+                match res {
+                    Err(_) => {
+                        write!(f, "Err")
+                    }
+                    Ok(hash) => {
+                        write!(f, "Ok, {}", hash)
+                    }
+                }
+            }
             Self::GenesisLoad(res) => {
                 write!(f, "GenesisLoad, ")?;
                 match res {

--- a/node/src/event_source/event_source_effects.rs
+++ b/node/src/event_source/event_source_effects.rs
@@ -25,6 +25,7 @@ use crate::snark::block_verify::SnarkBlockVerifyAction;
 use crate::snark::work_verify::SnarkWorkVerifyAction;
 use crate::snark::SnarkEvent;
 use crate::transition_frontier::genesis::TransitionFrontierGenesisAction;
+use crate::transition_frontier::sync::ledger::staged::TransitionFrontierSyncLedgerStagedAction;
 use crate::{BlockProducerAction, ExternalSnarkWorkerAction, Service, Store};
 
 use super::{Event, EventSourceAction, EventSourceActionWithMeta, P2pConnectionEvent, P2pEvent};
@@ -388,6 +389,21 @@ pub fn event_source_effects<S: Service>(store: &mut Store<S>, action: EventSourc
                     }
                 },
             },
+            Event::LedgerStagingReconstruct(res) => match res {
+                Err(error) => {
+                    store.dispatch(TransitionFrontierSyncLedgerStagedAction::ReconstructError {
+                        error,
+                    });
+                }
+                Ok(ledger_hash) => {
+                    store.dispatch(
+                        TransitionFrontierSyncLedgerStagedAction::ReconstructSuccess {
+                            ledger_hash,
+                        },
+                    );
+                }
+            },
+
             Event::GenesisLoad(res) => match res {
                 Err(err) => todo!("error while trying to load genesis config/ledger. - {err}"),
                 Ok(data) => {

--- a/node/src/transition_frontier/sync/ledger/staged/transition_frontier_sync_ledger_staged_actions.rs
+++ b/node/src/transition_frontier/sync/ledger/staged/transition_frontier_sync_ledger_staged_actions.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use mina_p2p_messages::v2;
+use mina_p2p_messages::v2::{self, LedgerHash};
 use serde::{Deserialize, Serialize};
 
 use crate::p2p::channels::rpc::{P2pRpcId, StagedLedgerAuxAndPendingCoinbases};
@@ -51,7 +51,9 @@ pub enum TransitionFrontierSyncLedgerStagedAction {
     ReconstructError {
         error: String,
     },
-    ReconstructSuccess,
+    ReconstructSuccess {
+        ledger_hash: LedgerHash,
+    },
     Success,
 }
 
@@ -190,7 +192,7 @@ impl redux::EnablingCondition<crate::State> for TransitionFrontierSyncLedgerStag
                         TransitionFrontierSyncLedgerStagedState::ReconstructPending { .. }
                     )
                 }),
-            TransitionFrontierSyncLedgerStagedAction::ReconstructSuccess => state
+            TransitionFrontierSyncLedgerStagedAction::ReconstructSuccess { .. } => state
                 .transition_frontier
                 .sync
                 .ledger()

--- a/node/src/transition_frontier/sync/ledger/staged/transition_frontier_sync_ledger_staged_effects.rs
+++ b/node/src/transition_frontier/sync/ledger/staged/transition_frontier_sync_ledger_staged_effects.rs
@@ -89,22 +89,17 @@ impl TransitionFrontierSyncLedgerStagedAction {
 
                 store.dispatch(TransitionFrontierSyncLedgerStagedAction::ReconstructPending);
 
-                match store
+                store
                     .service
-                    .staged_ledger_reconstruct(snarked_ledger_hash, parts)
-                {
-                    Err(error) => {
-                        store.dispatch(
-                            TransitionFrontierSyncLedgerStagedAction::ReconstructError { error },
-                        );
-                    }
-                    Ok(_) => {
-                        store
-                            .dispatch(TransitionFrontierSyncLedgerStagedAction::ReconstructSuccess);
-                    }
-                }
+                    .staged_ledger_reconstruct(snarked_ledger_hash, parts);
             }
-            TransitionFrontierSyncLedgerStagedAction::ReconstructSuccess => {
+            TransitionFrontierSyncLedgerStagedAction::ReconstructSuccess { ledger_hash } => {
+                // TODO: Only used for the current workaround to make staged ledger
+                // reconstruction async, can be removed when the ledger services are made async
+                store
+                    .service
+                    .staged_ledger_reconstruct_result_store(ledger_hash);
+
                 store.dispatch(TransitionFrontierSyncLedgerStagedAction::Success);
             }
             _ => {}

--- a/node/src/transition_frontier/sync/ledger/staged/transition_frontier_sync_ledger_staged_reducer.rs
+++ b/node/src/transition_frontier/sync/ledger/staged/transition_frontier_sync_ledger_staged_reducer.rs
@@ -139,7 +139,7 @@ impl TransitionFrontierSyncLedgerStagedState {
                     error: error.clone(),
                 };
             }
-            TransitionFrontierSyncLedgerStagedAction::ReconstructSuccess => {
+            TransitionFrontierSyncLedgerStagedAction::ReconstructSuccess { .. } => {
                 let Self::ReconstructPending { target, parts, .. } = self else {
                     return;
                 };

--- a/node/src/transition_frontier/sync/ledger/staged/transition_frontier_sync_ledger_staged_service.rs
+++ b/node/src/transition_frontier/sync/ledger/staged/transition_frontier_sync_ledger_staged_service.rs
@@ -5,9 +5,13 @@ use mina_p2p_messages::v2::LedgerHash;
 use super::StagedLedgerAuxAndPendingCoinbasesValid;
 
 pub trait TransitionFrontierSyncLedgerStagedService: redux::Service {
+    // TODO(tizoc): Only used for the current workaround to make staged ledger
+    // reconstruction async, can be removed when the ledger services are made async
+    fn staged_ledger_reconstruct_result_store(&mut self, staged_ledger_hash: LedgerHash);
+
     fn staged_ledger_reconstruct(
         &mut self,
         snarked_ledger_hash: LedgerHash,
         parts: Option<Arc<StagedLedgerAuxAndPendingCoinbasesValid>>,
-    ) -> Result<(), String>;
+    );
 }


### PR DESCRIPTION
This is just a temporary workaround until the ledger service has been made fully async.

Changes are:
- New event to notify that the reconstruction is complete
- The ledger ctx structure now stores a copy of the events channel sender.
- Service call to reconstruct the staged ledger doesn't return anything, it spawns a new thread that will perform the computation, and once done it will send the new event to the event channel.
- The reconstructed staged ledger is stored in a temporary place, and the Success action will pick it up and insert it in the staging ledgers map
