### PR TITLE
fix(kademlia): prune requests and streams

### DIFF
--- a/node/src/action_kind.rs
+++ b/node/src/action_kind.rs
@@ -223,8 +223,8 @@ pub enum ActionKind {
     P2pNetworkKademliaStreamOutgoingDataReady,
     P2pNetworkKademliaStreamPrune,
     P2pNetworkKademliaStreamRemoteClose,
-    P2pNetworkKademliaStreamSendReply,
     P2pNetworkKademliaStreamSendRequest,
+    P2pNetworkKademliaStreamSendResponse,
     P2pNetworkKademliaStreamWaitIncoming,
     P2pNetworkKademliaStreamWaitOutgoing,
     P2pNetworkNoiseDecryptedData,
@@ -1138,13 +1138,13 @@ impl ActionKindGet for P2pNetworkKademliaStreamAction {
         match self {
             Self::New { .. } => ActionKind::P2pNetworkKademliaStreamNew,
             Self::IncomingData { .. } => ActionKind::P2pNetworkKademliaStreamIncomingData,
+            Self::RemoteClose { .. } => ActionKind::P2pNetworkKademliaStreamRemoteClose,
+            Self::WaitIncoming { .. } => ActionKind::P2pNetworkKademliaStreamWaitIncoming,
             Self::WaitOutgoing { .. } => ActionKind::P2pNetworkKademliaStreamWaitOutgoing,
             Self::SendRequest { .. } => ActionKind::P2pNetworkKademliaStreamSendRequest,
-            Self::SendReply { .. } => ActionKind::P2pNetworkKademliaStreamSendReply,
+            Self::SendResponse { .. } => ActionKind::P2pNetworkKademliaStreamSendResponse,
             Self::OutgoingDataReady { .. } => ActionKind::P2pNetworkKademliaStreamOutgoingDataReady,
-            Self::WaitIncoming { .. } => ActionKind::P2pNetworkKademliaStreamWaitIncoming,
             Self::Close { .. } => ActionKind::P2pNetworkKademliaStreamClose,
-            Self::RemoteClose { .. } => ActionKind::P2pNetworkKademliaStreamRemoteClose,
             Self::Prune { .. } => ActionKind::P2pNetworkKademliaStreamPrune,
         }
     }

--- a/p2p/src/network/kad/p2p_network_kad_effects.rs
+++ b/p2p/src/network/kad/p2p_network_kad_effects.rs
@@ -54,7 +54,7 @@ impl P2pNetworkKademliaAction {
 
                 debug!(meta.time(); "found {} peers", closer_peers.len());
                 let message = P2pNetworkKademliaRpcReply::FindNode { closer_peers };
-                store.dispatch(P2pNetworkKademliaStreamAction::SendReply {
+                store.dispatch(P2pNetworkKademliaStreamAction::SendResponse {
                     addr,
                     peer_id,
                     stream_id,
@@ -66,13 +66,17 @@ impl P2pNetworkKademliaAction {
                 UpdateFindNodeRequest {
                     addr: _,
                     peer_id,
-                    stream_id: _,
+                    stream_id,
                     closest_peers,
                 },
                 _,
             ) => {
                 let data = closest_peers.clone();
-                store.dispatch(P2pNetworkKadRequestAction::ReplyReceived { peer_id, data });
+                store.dispatch(P2pNetworkKadRequestAction::ReplyReceived {
+                    peer_id,
+                    stream_id,
+                    data,
+                });
                 Ok(())
             }
             (StartBootstrap { .. }, _) => {

--- a/p2p/src/network/kad/p2p_network_kad_reducer.rs
+++ b/p2p/src/network/kad/p2p_network_kad_reducer.rs
@@ -39,13 +39,14 @@ impl super::P2pNetworkKadState {
                 .ok_or_else(|| format!("kademlia request for {} is not found", action.peer_id()))
                 .and_then(|request| request.reducer(meta.with_action(action))),
 
-            P2pNetworkKadAction::Stream(action @ P2pNetworkKademliaStreamAction::New { .. }) => {
-                self.create_kad_stream_state(action.peer_id(), action.stream_id())
-                    .map_err(|stream| {
-                        format!("kademlia stream already exists for action {action:?}: {stream:?}")
-                    })
-                    .and_then(|stream| stream.reducer(meta.with_action(action)))
-            }
+            P2pNetworkKadAction::Stream(
+                action @ P2pNetworkKademliaStreamAction::New { incoming, .. },
+            ) => self
+                .create_kad_stream_state(*incoming, action.peer_id(), action.stream_id())
+                .map_err(|stream| {
+                    format!("kademlia stream already exists for action {action:?}: {stream:?}")
+                })
+                .and_then(|stream| stream.reducer(meta.with_action(action))),
             P2pNetworkKadAction::Stream(action @ P2pNetworkKademliaStreamAction::Prune { .. }) => {
                 self.remove_kad_stream_state(action.peer_id(), action.stream_id())
                     .then_some(())

--- a/p2p/src/network/kad/p2p_network_kad_state.rs
+++ b/p2p/src/network/kad/p2p_network_kad_state.rs
@@ -111,6 +111,7 @@ impl P2pNetworkKadState {
 
     pub fn create_kad_stream_state(
         &mut self,
+        incoming: bool,
         peer_id: &PeerId,
         stream_id: &StreamId,
     ) -> Result<&mut P2pNetworkKadStreamState, &P2pNetworkKadStreamState> {
@@ -120,7 +121,9 @@ impl P2pNetworkKadState {
             .or_default()
             .entry(*stream_id)
         {
-            std::collections::btree_map::Entry::Vacant(e) => Ok(e.insert(Default::default())),
+            std::collections::btree_map::Entry::Vacant(e) => {
+                Ok(e.insert(P2pNetworkKadStreamState::new(incoming)))
+            }
             std::collections::btree_map::Entry::Occupied(e) => Err(e.into_mut()),
         }
     }

--- a/p2p/src/network/kad/request/p2p_network_kad_request_actions.rs
+++ b/p2p/src/network/kad/request/p2p_network_kad_request_actions.rs
@@ -33,6 +33,7 @@ pub enum P2pNetworkKadRequestAction {
     },
     ReplyReceived {
         peer_id: PeerId,
+        stream_id: StreamId,
         data: Vec<P2pNetworkKadEntry>,
     },
     Prune {

--- a/p2p/src/network/kad/stream/p2p_network_kad_stream_actions.rs
+++ b/p2p/src/network/kad/stream/p2p_network_kad_stream_actions.rs
@@ -18,6 +18,7 @@ pub enum P2pNetworkKademliaStreamAction {
         stream_id: StreamId,
         incoming: bool,
     },
+
     /// Handles incoming data from the stream.
     IncomingData {
         addr: SocketAddr,
@@ -25,12 +26,26 @@ pub enum P2pNetworkKademliaStreamAction {
         stream_id: StreamId,
         data: Data,
     },
+    /// Remote peer sent FIN to close the stream.
+    RemoteClose {
+        addr: SocketAddr,
+        peer_id: PeerId,
+        stream_id: StreamId,
+    },
+
+    /// Reinitializes existing stream state.
+    WaitIncoming {
+        addr: SocketAddr,
+        peer_id: PeerId,
+        stream_id: StreamId,
+    },
     /// Sets the state to wait for outgoing data.
     WaitOutgoing {
         addr: SocketAddr,
         peer_id: PeerId,
         stream_id: StreamId,
     },
+
     /// Sends request to the stream.
     SendRequest {
         addr: SocketAddr,
@@ -38,8 +53,8 @@ pub enum P2pNetworkKademliaStreamAction {
         stream_id: StreamId,
         data: P2pNetworkKademliaRpcRequest,
     },
-    /// Sends data to the stream.
-    SendReply {
+    /// Sends response to the stream.
+    SendResponse {
         addr: SocketAddr,
         peer_id: PeerId,
         stream_id: StreamId,
@@ -51,24 +66,14 @@ pub enum P2pNetworkKademliaStreamAction {
         peer_id: PeerId,
         stream_id: StreamId,
     },
-    /// Reinitializes existing stream state.
-    WaitIncoming {
-        addr: SocketAddr,
-        peer_id: PeerId,
-        stream_id: StreamId,
-    },
+
     /// Start closing outgoing stream (first closing our half of the stream)
     Close {
         addr: SocketAddr,
         peer_id: PeerId,
         stream_id: StreamId,
     },
-    /// Remote peer sent FIN to close the stream.
-    RemoteClose {
-        addr: SocketAddr,
-        peer_id: PeerId,
-        stream_id: StreamId,
-    },
+
     /// Removes the closed stream from the state.
     Prune {
         addr: SocketAddr,
@@ -85,7 +90,7 @@ macro_rules! enum_field {
                 | P2pNetworkKademliaStreamAction::IncomingData { $field, .. }
                 | P2pNetworkKademliaStreamAction::WaitOutgoing { $field, .. }
                 | P2pNetworkKademliaStreamAction::SendRequest { $field, .. }
-                | P2pNetworkKademliaStreamAction::SendReply { $field, .. }
+                | P2pNetworkKademliaStreamAction::SendResponse { $field, .. }
                 | P2pNetworkKademliaStreamAction::OutgoingDataReady { $field, .. }
                 | P2pNetworkKademliaStreamAction::WaitIncoming { $field, .. }
                 | P2pNetworkKademliaStreamAction::Close { $field, .. }

--- a/p2p/src/network/kad/stream/p2p_network_kad_stream_reducer.rs
+++ b/p2p/src/network/kad/stream/p2p_network_kad_stream_reducer.rs
@@ -4,42 +4,28 @@ use redux::ActionWithMeta;
 use crate::{P2pNetworkKademliaRpcReply, P2pNetworkKademliaRpcRequest};
 
 use super::{
-    super::Message, P2pNetworkKadStreamKind, P2pNetworkKadStreamState,
-    P2pNetworkKademliaStreamAction,
+    super::Message, P2pNetworkKadIncomingStreamState, P2pNetworkKadOutgoingStreamState,
+    P2pNetworkKadStreamState, P2pNetworkKademliaStreamAction,
 };
 
-impl P2pNetworkKadStreamState {
+impl P2pNetworkKadIncomingStreamState {
     pub fn reducer(
         &mut self,
         action: ActionWithMeta<&P2pNetworkKademliaStreamAction>,
     ) -> Result<(), String> {
-        use super::P2pNetworkKadStreamState as S;
+        use super::P2pNetworkKadIncomingStreamState as S;
         use super::P2pNetworkKademliaStreamAction as A;
+
         let (action, _meta) = action.split();
-        // println!("=== state:  {self:?}");
-        // println!("=== action: {action:?}");
+
         match (&self, action) {
-            (S::Default, A::New { incoming, .. }) => {
-                let kind = P2pNetworkKadStreamKind::from(*incoming);
-                *self = match kind {
-                    P2pNetworkKadStreamKind::Incoming => S::WaitingIncoming {
-                        kind,
-                        expect_data: true,
-                        expect_close: false,
-                    },
-                    P2pNetworkKadStreamKind::Outgoing => S::WaitingOutgoing {
-                        kind,
-                        expect_close: false,
-                    },
+            (S::Default, A::New { incoming, .. }) if *incoming == true => {
+                *self = S::WaitingForRequest {
+                    expect_close: false,
                 };
                 Ok(())
             }
-            (
-                S::WaitingIncoming {
-                    kind, expect_data, ..
-                },
-                A::IncomingData { data, .. },
-            ) if *expect_data => {
+            (S::WaitingForRequest { .. }, A::IncomingData { data, .. }) => {
                 let data = &data.0;
 
                 let mut reader = BytesReader::from_bytes(data);
@@ -49,127 +35,54 @@ impl P2pNetworkKadStreamState {
                 };
 
                 if len > reader.len() {
-                    *self = S::IncomingPartialData {
-                        kind: *kind,
+                    *self = S::PartialRequestReceived {
                         len,
                         data: data[(len - reader.len())..].to_vec(),
                     };
                     return Ok(());
                 }
 
-                self.handle_incoming_message(*kind, len, &data[data.len() - reader.len()..])
+                self.handle_incoming_request(len, &data[data.len() - reader.len()..])
             }
-            (
-                S::IncomingPartialData { kind, len, data },
-                A::IncomingData { data: new_data, .. },
-            ) => {
+            (S::PartialRequestReceived { len, data }, A::IncomingData { data: new_data, .. }) => {
                 let mut data = data.clone();
                 data.extend_from_slice(&new_data.0);
 
                 if *len > data.len() {
-                    *self = S::IncomingPartialData {
-                        kind: *kind,
-                        len: *len,
-                        data,
-                    };
+                    *self = S::PartialRequestReceived { len: *len, data };
                     return Ok(());
                 }
 
-                self.handle_incoming_message(*kind, *len, &data)
+                self.handle_incoming_request(*len, &data)
             }
-            (S::IncomingRequest { .. }, A::WaitOutgoing { .. }) => {
-                *self = S::WaitingOutgoing {
-                    kind: P2pNetworkKadStreamKind::Incoming,
-                    expect_close: false,
-                };
+            (S::RequestIsReady { .. }, A::WaitOutgoing { .. }) => {
+                *self = S::WaitingForReply;
                 Ok(())
             }
-            (S::IncomingReply { .. }, A::WaitOutgoing { .. }) => {
-                *self = S::WaitingOutgoing {
-                    kind: P2pNetworkKadStreamKind::Outgoing,
-                    expect_close: true,
-                };
-                Ok(())
-            }
-            (
-                S::WaitingOutgoing {
-                    kind: kind @ P2pNetworkKadStreamKind::Outgoing,
-                    expect_close,
-                },
-                A::SendRequest { data, .. },
-            ) if !*expect_close => {
+            (S::WaitingForReply, A::SendResponse { data, .. }) => {
                 let message = Message::from(data);
                 let bytes = serialize_into_vec(&message).map_err(|e| format!("{e}"))?;
-                *self = S::OutgoingBytes { kind: *kind, bytes };
+                *self = S::ResponseBytesAreReady { bytes };
                 Ok(())
             }
-            (
-                S::WaitingOutgoing {
-                    kind: kind @ P2pNetworkKadStreamKind::Incoming,
-                    expect_close,
-                },
-                A::SendReply { data, .. },
-            ) if !*expect_close => {
-                let message = Message::from(data);
-                let bytes = serialize_into_vec(&message).map_err(|e| format!("{e}"))?;
-                *self = S::OutgoingBytes { kind: *kind, bytes };
+            (S::ResponseBytesAreReady { .. }, A::WaitIncoming { .. }) => {
+                *self = S::WaitingForRequest { expect_close: true };
                 Ok(())
             }
-            (S::WaitingOutgoing { kind, expect_close }, A::Close { .. }) if *expect_close => {
-                *self = S::OutgoingBytes {
-                    kind: *kind,
-                    bytes: Vec::new(),
-                };
-                Ok(())
-            }
-            (S::OutgoingBytes { kind, bytes }, A::WaitIncoming { .. }) => {
-                let (expect_data, expect_close) = match kind {
-                    // for incoming connection, after the first round we expect both new request or close
-                    P2pNetworkKadStreamKind::Incoming => (true, true),
-                    // for outgoing connection, we expect data and not close iff we sent data
-                    P2pNetworkKadStreamKind::Outgoing => (!bytes.is_empty(), bytes.is_empty()),
-                };
-                *self = S::WaitingIncoming {
-                    kind: *kind,
-                    expect_data,
-                    expect_close,
-                };
-                Ok(())
-            }
-            (S::WaitingIncoming { expect_close, .. }, A::RemoteClose { .. }) if *expect_close => {
-                *self = S::Closed;
+            (S::WaitingForRequest { expect_close, .. }, A::RemoteClose { .. }) if *expect_close => {
+                *self = S::Closing;
                 Ok(())
             }
             _ => {
                 return Err(format!(
-                    "kademlia state {self:?} is incorrect for action {action:?}"
+                    "kademlia incoming stream state {self:?} is incorrect for action {action:?}",
                 ));
             }
         }
     }
 
-    fn handle_incoming_message(
-        &mut self,
-        kind: P2pNetworkKadStreamKind,
-        len: usize,
-        data: &[u8],
-    ) -> Result<(), String> {
-        match kind {
-            P2pNetworkKadStreamKind::Incoming => {
-                self._handle_incoming_message::<P2pNetworkKademliaRpcRequest>(len, data)
-            }
-            P2pNetworkKadStreamKind::Outgoing => {
-                self._handle_incoming_message::<P2pNetworkKademliaRpcReply>(len, data)
-            }
-        }
-    }
-
-    fn _handle_incoming_message<'a, T>(&mut self, len: usize, data: &'a [u8]) -> Result<(), String>
-    where
-        T: std::fmt::Debug + TryFrom<Message<'a>> + Into<super::P2pNetworkKadStreamState>,
-        T::Error: std::error::Error,
-    {
-        use super::P2pNetworkKadStreamState::*;
+    fn handle_incoming_request(&mut self, len: usize, data: &[u8]) -> Result<(), String> {
+        use super::P2pNetworkKadIncomingStreamState::*;
 
         let mut reader = BytesReader::from_bytes(data);
 
@@ -181,7 +94,7 @@ impl P2pNetworkKadStreamState {
             }
         };
 
-        let data = match T::try_from(message.clone()) {
+        let data = match P2pNetworkKademliaRpcRequest::try_from(message.clone()) {
             Ok(v) => v,
             Err(e) => {
                 *self = Error(format!("error converting protobuf message: {e}"));
@@ -189,7 +102,124 @@ impl P2pNetworkKadStreamState {
             }
         };
 
-        *self = data.into();
+        *self = P2pNetworkKadIncomingStreamState::RequestIsReady { data };
         Ok(())
+    }
+}
+
+impl P2pNetworkKadOutgoingStreamState {
+    pub fn reducer(
+        &mut self,
+        action: ActionWithMeta<&P2pNetworkKademliaStreamAction>,
+    ) -> Result<(), String> {
+        use super::P2pNetworkKadOutgoingStreamState as S;
+        use super::P2pNetworkKademliaStreamAction as A;
+        let (action, _meta) = action.split();
+        // println!("=== state:  {self:?}");
+        // println!("=== action: {action:?}");
+        match (&self, action) {
+            (S::Default, A::New { incoming, .. }) if !*incoming => {
+                *self = S::WaitingForRequest {
+                    expect_close: false,
+                };
+                Ok(())
+            }
+
+            (S::WaitingForRequest { .. }, A::SendRequest { data, .. }) => {
+                let message = Message::from(data);
+                let bytes = serialize_into_vec(&message).map_err(|e| format!("{e}"))?;
+                *self = S::RequestBytesAreReady { bytes };
+                Ok(())
+            }
+            (S::RequestBytesAreReady { .. }, A::WaitIncoming { .. }) => {
+                *self = S::WaitingForReply;
+                Ok(())
+            }
+
+            (S::WaitingForReply { .. }, A::IncomingData { data, .. }) => {
+                let data = &data.0;
+
+                let mut reader = BytesReader::from_bytes(data);
+                let Ok(len) = reader.read_varint32(data).map(|v| v as usize) else {
+                    *self = S::Error("error reading message length".to_owned());
+                    return Ok(());
+                };
+
+                if len > reader.len() {
+                    *self = S::PartialReplyReceived {
+                        len,
+                        data: data[(len - reader.len())..].to_vec(),
+                    };
+                    return Ok(());
+                }
+
+                self.handle_incoming_response(len, &data[data.len() - reader.len()..])
+            }
+            (S::PartialReplyReceived { len, data }, A::IncomingData { data: new_data, .. }) => {
+                let mut data = data.clone();
+                data.extend_from_slice(&new_data.0);
+
+                if *len > data.len() {
+                    *self = S::PartialReplyReceived { len: *len, data };
+                    return Ok(());
+                }
+
+                self.handle_incoming_response(*len, &data)
+            }
+            (S::ResponseIsReady { .. }, A::WaitOutgoing { .. }) => {
+                *self = S::WaitingForRequest { expect_close: true };
+                Ok(())
+            }
+            (S::WaitingForRequest { expect_close }, A::Close { .. }) if *expect_close => {
+                *self = S::RequestBytesAreReady { bytes: Vec::new() };
+                Ok(())
+            }
+            (S::Closing, A::RemoteClose { .. }) => {
+                *self = S::Closed;
+                Ok(())
+            }
+            _ => {
+                return Err(format!(
+                    "kademlia outgoing stream state {self:?} is incorrect for action {action:?}",
+                ));
+            }
+        }
+    }
+
+    fn handle_incoming_response(&mut self, len: usize, data: &[u8]) -> Result<(), String> {
+        use super::P2pNetworkKadOutgoingStreamState::*;
+
+        let mut reader = BytesReader::from_bytes(data);
+
+        let message = match reader.read_message_by_len::<Message>(data, len) {
+            Ok(v) => v,
+            Err(e) => {
+                *self = Error(format!("error reading protobuf message: {e}"));
+                return Ok(());
+            }
+        };
+
+        let data = match P2pNetworkKademliaRpcReply::try_from(message.clone()) {
+            Ok(v) => v,
+            Err(e) => {
+                *self = Error(format!("error converting protobuf message: {e}"));
+                return Ok(());
+            }
+        };
+
+        *self = P2pNetworkKadOutgoingStreamState::ResponseIsReady { data };
+        Ok(())
+    }
+}
+
+impl P2pNetworkKadStreamState {
+    pub fn reducer(
+        &mut self,
+        action: ActionWithMeta<&P2pNetworkKademliaStreamAction>,
+    ) -> Result<(), String> {
+        match self {
+            P2pNetworkKadStreamState::Incoming(i) => i.reducer(action),
+            P2pNetworkKadStreamState::Outgoing(o) => o.reducer(action),
+        }
     }
 }

--- a/p2p/src/network/p2p_network_effects.rs
+++ b/p2p/src/network/p2p_network_effects.rs
@@ -16,7 +16,7 @@ impl P2pNetworkAction {
             Self::Yamux(v) => v.effects(meta, store),
             Self::Kad(v) => match v.effects(meta, store) {
                 Ok(_) => {}
-                Err(e) => error!(meta.time(); "error dispatching Kademlia stream action: {e}"),
+                Err(e) => error!(meta.time(); "error dispatching Kademlia action: {e}"),
             },
             Self::Rpc(v) => v.effects(meta, store),
         }


### PR DESCRIPTION
Also streams reducer is simplified by splitting stream state into incoming and outgoing ones.

fixes: #315 