### PR TITLE
Create a separate service to manage a LedgerCtx in separate thread.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3866,6 +3866,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "thiserror",
+ "tokio",
  "vergen",
  "vrf",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4258,6 +4258,7 @@ dependencies = [
  "mina-tree",
  "nix 0.26.4",
  "node",
+ "openmina-core",
  "openmina-node-account",
  "rand 0.8.5",
  "rayon",

--- a/cli/src/commands/node/mod.rs
+++ b/cli/src/commands/node/mod.rs
@@ -17,7 +17,7 @@ use tokio::select;
 use node::core::channels::mpsc;
 use node::core::log::inner::Level;
 use node::event_source::EventSourceAction;
-use node::ledger::LedgerCtx;
+use node::ledger::{LedgerCtx, LedgerManager};
 use node::p2p::channels::ChannelId;
 use node::p2p::connection::outgoing::P2pConnectionOutgoingInitOpts;
 use node::p2p::identity::SecretKey;
@@ -242,6 +242,8 @@ impl Node {
         // reconstruction async, can be removed when the ledger services are made async
         ledger.set_event_sender(event_sender.clone());
 
+        let ledger_manager = LedgerManager::spawn(ledger);
+
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .thread_stack_size(64 * 1024 * 1024)
@@ -254,7 +256,7 @@ impl Node {
                 event_sender,
                 event_receiver: event_receiver.into(),
                 cmd_sender: p2p_service_ctx.webrtc.cmd_sender,
-                ledger,
+                ledger_manager,
                 peers: p2p_service_ctx.webrtc.peers,
                 #[cfg(feature = "p2p-libp2p")]
                 libp2p: p2p_service_ctx.libp2p,

--- a/cli/src/commands/replay/replay_state_with_input_actions.rs
+++ b/cli/src/commands/replay/replay_state_with_input_actions.rs
@@ -2,6 +2,7 @@ use std::cell::RefCell;
 
 use libp2p_identity::Keypair;
 use node::core::channels::mpsc;
+use node::ledger::LedgerManager;
 use node::recorder::{Recorder, StateWithInputActionsReader};
 use node::snark::VerifierKind;
 use node::{ActionWithMeta, BuildEnv, Store};
@@ -56,7 +57,7 @@ impl ReplayStateWithInputActions {
             event_sender: mpsc::unbounded_channel().0,
             event_receiver: mpsc::unbounded_channel().1.into(),
             cmd_sender: mpsc::unbounded_channel().0,
-            ledger: Default::default(),
+            ledger_manager: LedgerManager::spawn(Default::default()),
             peers: Default::default(),
             #[cfg(feature = "p2p-libp2p")]
             libp2p: node::p2p::service_impl::libp2p::Libp2pService::mocked().0,

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -27,6 +27,7 @@ openmina-core = { path = "../core" }
 snark = { path = "../snark" }
 p2p = { path = "../p2p" }
 openmina-node-account = { path = "./account" }
+tokio = { version = "1.26.0" }
 
 [build-dependencies]
 regex = "1"

--- a/node/native/Cargo.toml
+++ b/node/native/Cargo.toml
@@ -26,6 +26,7 @@ nix = { version = "0.26.2", features = ["signal"] }
 vrf = { workspace = true }
 getrandom = "0.2.11"
 jsonpath-rust = "0.5.0"
+openmina-core = { path = "../../core" }
 
 node = { path = "../../node", features = ["replay"] }
 openmina-node-account = { path = "../account"}

--- a/node/native/src/service.rs
+++ b/node/native/src/service.rs
@@ -1,21 +1,33 @@
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 use std::sync::{Arc, Mutex};
 
 use ledger::scan_state::scan_state::transaction_snark::{SokDigest, Statement};
 use libp2p::identity::Keypair;
-use mina_p2p_messages::v2::{LedgerProofProdStableV2, TransactionSnarkWorkTStableV2Proofs};
+use mina_p2p_messages::v2::{
+    LedgerHash, LedgerProofProdStableV2, MinaBaseAccountBinableArgStableV2,
+    MinaBaseSparseLedgerBaseStableV2, MinaLedgerSyncLedgerAnswerStableV2,
+    MinaLedgerSyncLedgerQueryStableV1, MinaStateProtocolStateValueStableV2, NonZeroCurvePoint,
+    StateHash, TransactionSnarkWorkTStableV2Proofs,
+};
 #[cfg(not(feature = "p2p-libp2p"))]
 use node::p2p::service_impl::mio::MioService;
+use openmina_core::block::ArcBlockWithHash;
 use rand::prelude::*;
 use redux::ActionMeta;
 use serde::Serialize;
 
+use node::block_producer::vrf_evaluator::{BlockProducerVrfEvaluatorLedgerService, DelegatorTable};
+use node::block_producer::{
+    BlockProducerLedgerService, BlockProducerWonSlot, StagedLedgerDiffCreateOutput,
+};
 use node::core::channels::{mpsc, oneshot};
 use node::core::invariants::InvariantsState;
 use node::core::snark::{Snark, SnarkJobId};
 use node::event_source::Event;
-use node::ledger::LedgerCtx;
+use node::ledger::ledger_manager::LedgerManager;
+use node::ledger::LedgerAddress;
+use node::p2p::channels::rpc::StagedLedgerAuxAndPendingCoinbases;
 use node::p2p::connection::outgoing::P2pConnectionOutgoingInitOpts;
 #[cfg(feature = "p2p-libp2p")]
 use node::p2p::service_impl::libp2p::Libp2pService;
@@ -23,7 +35,9 @@ use node::p2p::service_impl::webrtc::{Cmd, P2pServiceWebrtc, PeerState};
 use node::p2p::service_impl::webrtc_with_libp2p::P2pServiceWebrtcWithLibp2p;
 use node::p2p::service_impl::TaskSpawner;
 use node::p2p::{P2pCryptoService, PeerId};
-use node::rpc::{RpcP2pConnectionOutgoingResponse, RpcRequest};
+use node::rpc::{
+    RpcLedgerService, RpcP2pConnectionOutgoingResponse, RpcRequest, RpcScanStateSummaryScanStateJob,
+};
 use node::service::{EventSourceService, Recorder, TransitionFrontierGenesisService};
 use node::snark::block_verify::{
     SnarkBlockVerifyError, SnarkBlockVerifyId, SnarkBlockVerifyService, VerifiableBlockWithHash,
@@ -33,7 +47,18 @@ use node::snark::{SnarkEvent, VerifierIndex, VerifierSRS};
 use node::snark_pool::{JobState, SnarkPoolService};
 use node::stats::Stats;
 use node::transition_frontier::genesis::GenesisConfig;
+use node::transition_frontier::sync::{
+    ledger::{
+        snarked::TransitionFrontierSyncLedgerSnarkedService,
+        staged::{
+            StagedLedgerAuxAndPendingCoinbasesValid, TransitionFrontierSyncLedgerStagedService,
+        },
+    },
+    TransitionFrontierRootSnarkedLedgerUpdates,
+};
+use node::transition_frontier::{CommitResult, TransitionFrontierService};
 use node::ActionKind;
+use openmina_node_account::AccountPublicKey;
 
 use crate::block_producer::BlockProducerService;
 use crate::ext_snark_worker;
@@ -46,7 +71,7 @@ pub struct NodeService {
     pub event_sender: mpsc::UnboundedSender<Event>,
     pub event_receiver: EventReceiver,
     pub cmd_sender: mpsc::UnboundedSender<Cmd>,
-    pub ledger: LedgerCtx,
+    pub ledger_manager: LedgerManager,
     pub peers: BTreeMap<PeerId, PeerState>,
     #[cfg(feature = "p2p-libp2p")]
     pub libp2p: Libp2pService,
@@ -82,13 +107,156 @@ impl ReplayerState {
     }
 }
 
-impl node::ledger::LedgerService for NodeService {
-    fn ctx(&self) -> &LedgerCtx {
-        &self.ledger
+impl TransitionFrontierSyncLedgerSnarkedService for NodeService {
+    fn compute_snarked_ledger_hashes(
+        &self,
+        snarked_ledger_hash: &LedgerHash,
+    ) -> Result<(), String> {
+        self.ledger_manager
+            .compute_snarked_ledger_hashes(snarked_ledger_hash)
     }
 
-    fn ctx_mut(&mut self) -> &mut LedgerCtx {
-        &mut self.ledger
+    fn copy_snarked_ledger_contents_for_sync(
+        &self,
+        origin_snarked_ledger_hash: LedgerHash,
+        target_snarked_ledger_hash: LedgerHash,
+        overwrite: bool,
+    ) -> Result<bool, String> {
+        self.ledger_manager.copy_snarked_ledger_contents_for_sync(
+            origin_snarked_ledger_hash,
+            target_snarked_ledger_hash,
+            overwrite,
+        )
+    }
+
+    fn child_hashes_get(
+        &self,
+        snarked_ledger_hash: LedgerHash,
+        parent: &LedgerAddress,
+    ) -> Result<(LedgerHash, LedgerHash), String> {
+        self.ledger_manager
+            .child_hashes_get(snarked_ledger_hash, parent)
+    }
+
+    fn accounts_set(
+        &self,
+        snarked_ledger_hash: LedgerHash,
+        parent: &LedgerAddress,
+        accounts: Vec<MinaBaseAccountBinableArgStableV2>,
+    ) -> Result<LedgerHash, String> {
+        self.ledger_manager
+            .accounts_set(snarked_ledger_hash, parent, accounts)
+    }
+}
+
+impl TransitionFrontierSyncLedgerStagedService for NodeService {
+    // TODO(tizoc): Only used for the current workaround to make staged ledger
+    // reconstruction async, can be removed when the ledger services are made async
+    fn staged_ledger_reconstruct_result_store(&self, staged_ledger_hash: LedgerHash) {
+        self.ledger_manager
+            .staged_ledger_reconstruct_result_store(staged_ledger_hash)
+    }
+
+    fn staged_ledger_reconstruct(
+        &self,
+        snarked_ledger_hash: LedgerHash,
+        parts: Option<Arc<StagedLedgerAuxAndPendingCoinbasesValid>>,
+    ) {
+        self.ledger_manager
+            .staged_ledger_reconstruct(snarked_ledger_hash, parts)
+    }
+}
+
+impl TransitionFrontierService for NodeService {
+    fn block_apply(
+        &self,
+        block: ArcBlockWithHash,
+        pred_block: ArcBlockWithHash,
+    ) -> Result<(), String> {
+        self.ledger_manager.block_apply(block, pred_block)
+    }
+
+    fn commit(
+        &self,
+        ledgers_to_keep: BTreeSet<LedgerHash>,
+        root_snarked_ledger_updates: TransitionFrontierRootSnarkedLedgerUpdates,
+        needed_protocol_states: BTreeMap<StateHash, MinaStateProtocolStateValueStableV2>,
+        new_root: &ArcBlockWithHash,
+        new_best_tip: &ArcBlockWithHash,
+    ) -> CommitResult {
+        self.ledger_manager.commit(
+            ledgers_to_keep,
+            root_snarked_ledger_updates,
+            needed_protocol_states,
+            new_root,
+            new_best_tip,
+        )
+    }
+
+    fn answer_ledger_query(
+        &self,
+        ledger_hash: LedgerHash,
+        query: MinaLedgerSyncLedgerQueryStableV1,
+    ) -> Option<MinaLedgerSyncLedgerAnswerStableV2> {
+        self.ledger_manager.answer_ledger_query(ledger_hash, query)
+    }
+
+    fn staged_ledger_aux_and_pending_coinbase(
+        &self,
+        ledger_hash: LedgerHash,
+        protocol_states: BTreeMap<StateHash, MinaStateProtocolStateValueStableV2>,
+    ) -> Option<Arc<StagedLedgerAuxAndPendingCoinbases>> {
+        self.ledger_manager
+            .staged_ledger_aux_and_pending_coinbase(ledger_hash, protocol_states)
+    }
+}
+
+impl BlockProducerLedgerService for NodeService {
+    fn staged_ledger_diff_create(
+        &self,
+        pred_block: &ArcBlockWithHash,
+        won_slot: &BlockProducerWonSlot,
+        coinbase_receiver: &NonZeroCurvePoint,
+        completed_snarks: BTreeMap<SnarkJobId, Snark>,
+        supercharge_coinbase: bool,
+    ) -> Result<StagedLedgerDiffCreateOutput, String> {
+        self.ledger_manager.staged_ledger_diff_create(
+            pred_block,
+            won_slot,
+            coinbase_receiver,
+            completed_snarks,
+            supercharge_coinbase,
+        )
+    }
+
+    fn stake_proof_sparse_ledger(
+        &self,
+        staking_ledger: LedgerHash,
+        producer: NonZeroCurvePoint,
+        delegator: NonZeroCurvePoint,
+    ) -> Option<MinaBaseSparseLedgerBaseStableV2> {
+        self.ledger_manager
+            .stake_proof_sparse_ledger(staking_ledger, producer, delegator)
+    }
+}
+
+impl RpcLedgerService for NodeService {
+    fn scan_state_summary(
+        &self,
+        ledger_hash: LedgerHash,
+    ) -> Vec<Vec<RpcScanStateSummaryScanStateJob>> {
+        self.ledger_manager.scan_state_summary(ledger_hash)
+    }
+}
+
+impl BlockProducerVrfEvaluatorLedgerService for NodeService {
+    fn get_producer_and_delegates(
+        &self,
+        ledger_hash: LedgerHash,
+        producer: AccountPublicKey,
+    ) -> DelegatorTable {
+        self.ledger_manager
+            .get_producer_and_delegates(ledger_hash, producer)
     }
 }
 
@@ -326,7 +494,7 @@ impl TransitionFrontierGenesisService for NodeService {
         let res = match config.load() {
             Err(err) => Err(err.to_string()),
             Ok((mask, data)) => {
-                self.ledger.insert_genesis_ledger(mask);
+                self.ledger_manager.insert_genesis_ledger(mask);
                 Ok(data)
             }
         };

--- a/node/src/block_producer/block_producer_service.rs
+++ b/node/src/block_producer/block_producer_service.rs
@@ -29,7 +29,7 @@ pub struct StagedLedgerDiffCreateOutput {
 
 pub trait BlockProducerLedgerService: redux::Service {
     fn staged_ledger_diff_create(
-        &mut self,
+        &self,
         pred_block: &ArcBlockWithHash,
         won_slot: &BlockProducerWonSlot,
         coinbase_receiver: &NonZeroCurvePoint,
@@ -38,7 +38,7 @@ pub trait BlockProducerLedgerService: redux::Service {
     ) -> Result<StagedLedgerDiffCreateOutput, String>;
 
     fn stake_proof_sparse_ledger(
-        &mut self,
+        &self,
         staking_ledger: LedgerHash,
         producer: NonZeroCurvePoint,
         delegator: NonZeroCurvePoint,

--- a/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_service.rs
+++ b/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_service.rs
@@ -11,7 +11,7 @@ pub trait BlockProducerVrfEvaluatorService: redux::Service {
 
 pub trait BlockProducerVrfEvaluatorLedgerService: redux::Service {
     fn get_producer_and_delegates(
-        &mut self,
+        &self,
         ledger_hash: LedgerHash,
         producer: AccountPublicKey,
     ) -> DelegatorTable;

--- a/node/src/ledger/ledger_manager.rs
+++ b/node/src/ledger/ledger_manager.rs
@@ -1,0 +1,144 @@
+use mina_p2p_messages::v2::{
+    LedgerHash, MinaBaseAccountBinableArgStableV2, MinaBaseSparseLedgerBaseStableV2,
+    MinaLedgerSyncLedgerAnswerStableV2, MinaLedgerSyncLedgerQueryStableV1,
+    MinaStateProtocolStateValueStableV2, NonZeroCurvePoint, StateHash,
+};
+use openmina_core::block::ArcBlockWithHash;
+use openmina_core::channels::mpsc;
+use openmina_core::snark::{Snark, SnarkJobId};
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::mpsc::{channel, RecvError, Sender};
+use std::sync::Arc;
+use std::thread;
+
+use super::ledger_service::LedgerCtx;
+use crate::block_producer::vrf_evaluator::{
+    BlockProducerVrfEvaluatorLedgerService, DelegatorTable,
+};
+use crate::block_producer::{
+    BlockProducerLedgerService, BlockProducerWonSlot, StagedLedgerDiffCreateOutput,
+};
+use crate::ledger::LedgerAddress;
+use crate::p2p::channels::rpc::StagedLedgerAuxAndPendingCoinbases;
+use crate::rpc::{RpcLedgerService, RpcScanStateSummaryScanStateJob};
+use crate::transition_frontier::sync::{
+    ledger::snarked::TransitionFrontierSyncLedgerSnarkedService,
+    ledger::staged::{
+        StagedLedgerAuxAndPendingCoinbasesValid, TransitionFrontierSyncLedgerStagedService,
+    },
+    TransitionFrontierRootSnarkedLedgerUpdates,
+};
+use crate::transition_frontier::{CommitResult, TransitionFrontierService};
+use ledger::Mask;
+use mina_signer::CompressedPubKey;
+use openmina_node_account::AccountPublicKey;
+
+/// The type enumerating different requests that can be made to the
+/// service. Each specific constructor has a specific response
+/// constructor associated with it. Unfortunately, this relationship
+/// can't be expressed in the Rust type system at the moment. For this
+/// reason this type is private while functions wrapping the whole call
+/// to the service are exposed as the service's methods.
+enum LedgerRequest {
+    AccountsSet {
+        snarked_ledger_hash: LedgerHash,
+        parent: LedgerAddress,
+        accounts: Vec<MinaBaseAccountBinableArgStableV2>,
+    }, // expected response: LedgerHash
+    BlockApply {
+        block: ArcBlockWithHash,
+        pred_block: ArcBlockWithHash,
+    }, // expected response: Success
+    ChildHashesGet {
+        snarked_ledger_hash: LedgerHash,
+        parent: LedgerAddress,
+    }, // expected response: ChildHashes
+    Commit {
+        ledgers_to_keep: BTreeSet<LedgerHash>,
+        root_snarked_ledger_updates: TransitionFrontierRootSnarkedLedgerUpdates,
+        needed_protocol_states: BTreeMap<StateHash, MinaStateProtocolStateValueStableV2>,
+        new_root: ArcBlockWithHash,
+        new_best_tip: ArcBlockWithHash,
+    }, // expected response: CommitResult
+    ComputeSnarkedLedgerHashes {
+        snarked_ledger_hash: LedgerHash,
+    }, // expected response: Success
+    CopySnarkedLedgerContentsForSync {
+        origin_snarked_ledger_hash: LedgerHash,
+        target_snarked_ledger_hash: LedgerHash,
+        overwrite: bool,
+    }, // expected response: SnarkedLedgerContentsCopied
+    GetProducerAndDelegates {
+        ledger_hash: LedgerHash,
+        producer: AccountPublicKey,
+    }, // expected response: ProducerAndDelegates
+    GetProducersWithDelegates {
+        ledger_hash: LedgerHash,
+        filter: fn(&CompressedPubKey) -> bool,
+    }, // expected response: ProducersWithDelegatesMap
+    GetMask {
+        ledger_hash: LedgerHash,
+    }, // expected response: LedgerMask
+    GetScanStateSummary {
+        ledger_hash: LedgerHash,
+    }, // expected response: ScanStateSummary
+    InsertGenesisLedger {
+        mask: Mask,
+    }, // expected response: Success
+    LedgerQuery {
+        ledger_hash: LedgerHash,
+        query: MinaLedgerSyncLedgerQueryStableV1,
+    }, // expected response: LedgerQueryResult
+    StagedLedgerAuxAndPendingCoinbase {
+        ledger_hash: LedgerHash,
+        protocol_states: BTreeMap<StateHash, MinaStateProtocolStateValueStableV2>,
+    }, // expected response: LedgerAuxAndCoinbaseResult
+    StagedLedgerDiffCreate {
+        pred_block: ArcBlockWithHash,
+        won_slot: BlockProducerWonSlot,
+        coinbase_receiver: NonZeroCurvePoint,
+        completed_snarks: BTreeMap<SnarkJobId, Snark>,
+        supercharge_coinbase: bool,
+    }, // expected response: StagedLedgerDiff
+    StagedLedgerReconstruct {
+        snarked_ledger_hash: LedgerHash,
+        parts: Option<Arc<StagedLedgerAuxAndPendingCoinbasesValid>>,
+    }, // expected response: Success
+    StagedLedgerReconstructResultStore {
+        staged_ledger_hash: LedgerHash,
+    }, // expected response: Success
+    StakeProofSparseLedger {
+        staking_ledger: LedgerHash,
+        producer: NonZeroCurvePoint,
+        delegator: NonZeroCurvePoint,
+    }, // expected response: SparseLedgerBase
+}
+
+#[derive(Debug)]
+pub enum LedgerResponse {
+    ChildHashes(LedgerHash, LedgerHash),
+    CommitResult(CommitResult),
+    LedgerAuxAndCoinbaseResult(Option<Arc<StagedLedgerAuxAndPendingCoinbases>>),
+    LedgerHash(LedgerHash),
+    LedgerMask(Option<(Mask, bool)>),
+    LedgerQueryResult(Option<MinaLedgerSyncLedgerAnswerStableV2>),
+    ProducerAndDelegates(DelegatorTable),
+    ProducersWithDelegatesMap(
+        Option<BTreeMap<AccountPublicKey, Vec<(ledger::AccountIndex, AccountPublicKey, u64)>>>,
+    ),
+    ScanStateSummary(Vec<Vec<RpcScanStateSummaryScanStateJob>>),
+    SnarkedLedgerContentsCopied(bool),
+    SparseLedgerBase(Option<MinaBaseSparseLedgerBaseStableV2>),
+    StagedLedgerDiff(StagedLedgerDiffCreateOutput),
+    Success, // operation was performed and result stored; nothing to return.
+}
+
+struct LedgerRequestWithChan {
+    request: LedgerRequest,
+    responder: Sender<Result<LedgerResponse, String>>,
+}
+
+pub struct LedgerManager {
+    sender: mpsc::UnboundedSender<LedgerRequestWithChan>,
+    join_handle: thread::JoinHandle<LedgerCtx>,
+}

--- a/node/src/ledger/ledger_manager.rs
+++ b/node/src/ledger/ledger_manager.rs
@@ -133,6 +133,132 @@ pub enum LedgerResponse {
     Success, // operation was performed and result stored; nothing to return.
 }
 
+impl LedgerRequest {
+    fn handle(self, ledger_ctx: &mut LedgerCtx) -> Result<LedgerResponse, String> {
+        match self {
+            LedgerRequest::AccountsSet {
+                snarked_ledger_hash,
+                parent,
+                accounts,
+            } => ledger_ctx
+                .accounts_set(snarked_ledger_hash, &parent, accounts)
+                .map(LedgerResponse::LedgerHash),
+            LedgerRequest::BlockApply { block, pred_block } => ledger_ctx
+                .block_apply(block, pred_block)
+                .map(|()| LedgerResponse::Success),
+            LedgerRequest::ChildHashesGet {
+                snarked_ledger_hash,
+                parent,
+            } => ledger_ctx
+                .child_hashes_get(snarked_ledger_hash, &parent)
+                .map(|(left, right)| LedgerResponse::ChildHashes(left, right)),
+            LedgerRequest::Commit {
+                ledgers_to_keep,
+                root_snarked_ledger_updates,
+                needed_protocol_states,
+                new_root,
+                new_best_tip,
+            } => {
+                let res = ledger_ctx.commit(
+                    ledgers_to_keep,
+                    root_snarked_ledger_updates,
+                    needed_protocol_states,
+                    &new_root,
+                    &new_best_tip,
+                );
+                Ok(LedgerResponse::CommitResult(res))
+            }
+            LedgerRequest::ComputeSnarkedLedgerHashes {
+                snarked_ledger_hash,
+            } => ledger_ctx
+                .compute_snarked_ledger_hashes(&snarked_ledger_hash)
+                .map(|()| LedgerResponse::Success),
+            LedgerRequest::CopySnarkedLedgerContentsForSync {
+                origin_snarked_ledger_hash,
+                target_snarked_ledger_hash,
+                overwrite,
+            } => ledger_ctx
+                .copy_snarked_ledger_contents_for_sync(
+                    origin_snarked_ledger_hash,
+                    target_snarked_ledger_hash,
+                    overwrite,
+                )
+                .map(LedgerResponse::SnarkedLedgerContentsCopied),
+            LedgerRequest::GetMask { ledger_hash } => {
+                Ok(LedgerResponse::LedgerMask(ledger_ctx.mask(&ledger_hash)))
+            }
+            LedgerRequest::GetProducerAndDelegates {
+                ledger_hash,
+                producer,
+            } => {
+                let res = ledger_ctx.get_producer_and_delegates(ledger_hash, producer);
+                Ok(LedgerResponse::ProducerAndDelegates(res))
+            }
+            LedgerRequest::GetProducersWithDelegates {
+                ledger_hash,
+                filter,
+            } => {
+                let res = ledger_ctx.producers_with_delegates(&ledger_hash, filter);
+                Ok(LedgerResponse::ProducersWithDelegatesMap(res))
+            }
+            LedgerRequest::GetScanStateSummary { ledger_hash } => {
+                let res = ledger_ctx.scan_state_summary(ledger_hash);
+                Ok(LedgerResponse::ScanStateSummary(res))
+            }
+            LedgerRequest::InsertGenesisLedger { mask } => {
+                ledger_ctx.insert_genesis_ledger(mask);
+                Ok(LedgerResponse::Success)
+            }
+            LedgerRequest::LedgerQuery { ledger_hash, query } => {
+                let res = ledger_ctx.answer_ledger_query(ledger_hash, query);
+                Ok(LedgerResponse::LedgerQueryResult(res))
+            }
+            LedgerRequest::StagedLedgerAuxAndPendingCoinbase {
+                ledger_hash,
+                protocol_states,
+            } => {
+                let res =
+                    ledger_ctx.staged_ledger_aux_and_pending_coinbase(ledger_hash, protocol_states);
+                Ok(LedgerResponse::LedgerAuxAndCoinbaseResult(res))
+            }
+            LedgerRequest::StagedLedgerDiffCreate {
+                pred_block,
+                won_slot,
+                coinbase_receiver,
+                completed_snarks,
+                supercharge_coinbase,
+            } => ledger_ctx
+                .staged_ledger_diff_create(
+                    &pred_block,
+                    &won_slot,
+                    &coinbase_receiver,
+                    completed_snarks,
+                    supercharge_coinbase,
+                )
+                .map(LedgerResponse::StagedLedgerDiff),
+            LedgerRequest::StagedLedgerReconstruct {
+                snarked_ledger_hash,
+                parts,
+            } => {
+                ledger_ctx.staged_ledger_reconstruct(snarked_ledger_hash, parts);
+                Ok(LedgerResponse::Success)
+            }
+            LedgerRequest::StagedLedgerReconstructResultStore { staged_ledger_hash } => {
+                ledger_ctx.staged_ledger_reconstruct_result_store(staged_ledger_hash);
+                Ok(LedgerResponse::Success)
+            }
+            LedgerRequest::StakeProofSparseLedger {
+                staking_ledger,
+                producer,
+                delegator,
+            } => {
+                let res = ledger_ctx.stake_proof_sparse_ledger(staking_ledger, producer, delegator);
+                Ok(LedgerResponse::SparseLedgerBase(res))
+            }
+        }
+    }
+}
+
 struct LedgerRequestWithChan {
     request: LedgerRequest,
     responder: Sender<Result<LedgerResponse, String>>,
@@ -141,4 +267,365 @@ struct LedgerRequestWithChan {
 pub struct LedgerManager {
     sender: mpsc::UnboundedSender<LedgerRequestWithChan>,
     join_handle: thread::JoinHandle<LedgerCtx>,
+}
+
+impl LedgerManager {
+    pub fn spawn(mut ledger_ctx: LedgerCtx) -> LedgerManager {
+        let (sender, mut receiver) = mpsc::unbounded_channel();
+        let runtime = thread::spawn(move || {
+            loop {
+                match receiver.blocking_recv() {
+                    Some(LedgerRequestWithChan { request, responder }) => responder
+                        .send(request.handle(&mut ledger_ctx))
+                        .unwrap_or(()),
+                    None => {
+                        break;
+                    }
+                }
+            }
+            ledger_ctx
+        });
+        LedgerManager {
+            sender,
+            join_handle: runtime,
+        }
+    }
+
+    fn call(&self, request: LedgerRequest) -> Result<LedgerResponse, String> {
+        let (responder, receiver) = channel();
+        self.sender
+            .send(LedgerRequestWithChan { request, responder })
+            .unwrap();
+        result_join(receiver.recv())
+    }
+
+    pub async fn wait_for_stop(self) -> std::thread::Result<LedgerCtx> {
+        self.join_handle.join()
+    }
+
+    pub fn insert_genesis_ledger(&self, mask: Mask) {
+        self.call(LedgerRequest::InsertGenesisLedger { mask })
+            .unwrap();
+    }
+
+    pub fn get_mask(&self, ledger_hash: &LedgerHash) -> Option<(Mask, bool)> {
+        match self.call(LedgerRequest::GetMask {
+            ledger_hash: ledger_hash.clone(),
+        }) {
+            Ok(LedgerResponse::LedgerMask(mask)) => mask,
+            _ => panic!("get_mask failed"),
+        }
+    }
+    pub fn producers_with_delegates(
+        &self,
+        ledger_hash: &LedgerHash,
+        filter: fn(&CompressedPubKey) -> bool,
+    ) -> Option<BTreeMap<AccountPublicKey, Vec<(ledger::AccountIndex, AccountPublicKey, u64)>>>
+    {
+        match self.call(LedgerRequest::GetProducersWithDelegates {
+            ledger_hash: ledger_hash.clone(),
+            filter,
+        }) {
+            Ok(LedgerResponse::ProducersWithDelegatesMap(map)) => map,
+            _ => panic!("producers_with_delegates failed"),
+        }
+    }
+}
+
+fn result_join<T>(r: Result<Result<T, String>, RecvError>) -> Result<T, String> {
+    match r {
+        Ok(Ok(v)) => Ok(v),
+        Ok(Err(e)) => Err(e),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+fn format_response_error(method: &str, res: LedgerResponse) -> String {
+    format!("LedgerManager::{method}: unexpected response: {res:?}")
+}
+
+impl redux::TimeService for LedgerManager {}
+
+impl redux::Service for LedgerManager {}
+
+impl TransitionFrontierSyncLedgerSnarkedService for LedgerManager {
+    fn compute_snarked_ledger_hashes(
+        &self,
+        snarked_ledger_hash: &LedgerHash,
+    ) -> Result<(), String> {
+        self.call(LedgerRequest::ComputeSnarkedLedgerHashes {
+            snarked_ledger_hash: snarked_ledger_hash.clone(),
+        })
+        .and_then(|res| {
+            if let LedgerResponse::Success = res {
+                Ok(())
+            } else {
+                Err(format_response_error("compute_snarked_ledger_hashes", res))
+            }
+        })
+    }
+
+    fn copy_snarked_ledger_contents_for_sync(
+        &self,
+        origin_snarked_ledger_hash: LedgerHash,
+        target_snarked_ledger_hash: LedgerHash,
+        overwrite: bool,
+    ) -> Result<bool, String> {
+        self.call(LedgerRequest::CopySnarkedLedgerContentsForSync {
+            origin_snarked_ledger_hash,
+            target_snarked_ledger_hash,
+            overwrite,
+        })
+        .and_then(|res| {
+            if let LedgerResponse::SnarkedLedgerContentsCopied(copied) = res {
+                Ok(copied)
+            } else {
+                Err(format_response_error(
+                    "copy_snarked_ledger_contents_for_sync",
+                    res,
+                ))
+            }
+        })
+    }
+
+    fn child_hashes_get(
+        &self,
+        snarked_ledger_hash: LedgerHash,
+        parent: &LedgerAddress,
+    ) -> Result<(LedgerHash, LedgerHash), String> {
+        self.call(LedgerRequest::ChildHashesGet {
+            snarked_ledger_hash,
+            parent: parent.clone(),
+        })
+        .and_then(|res| {
+            if let LedgerResponse::ChildHashes(left, right) = res {
+                Ok((left, right))
+            } else {
+                Err(format_response_error("child_hashes_get", res))
+            }
+        })
+    }
+
+    fn accounts_set(
+        &self,
+        snarked_ledger_hash: LedgerHash,
+        parent: &LedgerAddress,
+        accounts: Vec<MinaBaseAccountBinableArgStableV2>,
+    ) -> Result<LedgerHash, String> {
+        self.call(LedgerRequest::AccountsSet {
+            snarked_ledger_hash,
+            parent: parent.clone(),
+            accounts,
+        })
+        .and_then(|res| {
+            if let LedgerResponse::LedgerHash(hash) = res {
+                Ok(hash)
+            } else {
+                Err(format_response_error("accounts_set", res))
+            }
+        })
+    }
+}
+
+impl TransitionFrontierSyncLedgerStagedService for LedgerManager {
+    // TODO(tizoc): Only used for the current workaround to make staged ledger
+    // reconstruction async, can be removed when the ledger services are made async
+    fn staged_ledger_reconstruct_result_store(&self, staged_ledger_hash: LedgerHash) {
+        self.call(LedgerRequest::StagedLedgerReconstructResultStore { staged_ledger_hash })
+            .and_then(|res| {
+                if let LedgerResponse::Success = res {
+                    Ok(())
+                } else {
+                    Err(format_response_error(
+                        "staged_ledger_reconstruct_result_store",
+                        res,
+                    ))
+                }
+            })
+            .expect("LedgerManager::staged_ledger_reconstruct_result_store: failed")
+    }
+
+    fn staged_ledger_reconstruct(
+        &self,
+        snarked_ledger_hash: LedgerHash,
+        parts: Option<Arc<StagedLedgerAuxAndPendingCoinbasesValid>>,
+    ) {
+        self.call(LedgerRequest::StagedLedgerReconstruct {
+            snarked_ledger_hash,
+            parts,
+        })
+        .and_then(|res| {
+            if let LedgerResponse::Success = res {
+                Ok(())
+            } else {
+                Err(format_response_error("staged_ledger_reconstruct", res))
+            }
+        })
+        .expect("LedgerManager::staged_ledger_reconstruct: failed")
+    }
+}
+
+impl TransitionFrontierService for LedgerManager {
+    fn block_apply(
+        &self,
+        block: ArcBlockWithHash,
+        pred_block: ArcBlockWithHash,
+    ) -> Result<(), String> {
+        self.call(LedgerRequest::BlockApply { block, pred_block })
+            .and_then(|res| {
+                if let LedgerResponse::Success = res {
+                    Ok(())
+                } else {
+                    Err(format_response_error("block_apply", res))
+                }
+            })
+    }
+
+    fn commit(
+        &self,
+        ledgers_to_keep: BTreeSet<LedgerHash>,
+        root_snarked_ledger_updates: TransitionFrontierRootSnarkedLedgerUpdates,
+        needed_protocol_states: BTreeMap<StateHash, MinaStateProtocolStateValueStableV2>,
+        new_root: &ArcBlockWithHash,
+        new_best_tip: &ArcBlockWithHash,
+    ) -> CommitResult {
+        self.call(LedgerRequest::Commit {
+            ledgers_to_keep,
+            root_snarked_ledger_updates,
+            needed_protocol_states,
+            new_root: new_root.clone(),
+            new_best_tip: new_best_tip.clone(),
+        })
+        .and_then(|res| {
+            if let LedgerResponse::CommitResult(result) = res {
+                Ok(result)
+            } else {
+                Err(format_response_error("commit", res))
+            }
+        })
+        .expect("LedgerManager::commit: unexpected error")
+    }
+
+    fn answer_ledger_query(
+        &self,
+        ledger_hash: LedgerHash,
+        query: MinaLedgerSyncLedgerQueryStableV1,
+    ) -> Option<MinaLedgerSyncLedgerAnswerStableV2> {
+        self.call(LedgerRequest::LedgerQuery { ledger_hash, query })
+            .and_then(|res| {
+                if let LedgerResponse::LedgerQueryResult(answer) = res {
+                    Ok(answer)
+                } else {
+                    Err(format_response_error("ledger_query", res))
+                }
+            })
+            .expect("LedgerManager::ledger_query: unexpected error")
+    }
+
+    fn staged_ledger_aux_and_pending_coinbase(
+        &self,
+        ledger_hash: LedgerHash,
+        protocol_states: BTreeMap<StateHash, MinaStateProtocolStateValueStableV2>,
+    ) -> Option<Arc<StagedLedgerAuxAndPendingCoinbases>> {
+        self.call(LedgerRequest::StagedLedgerAuxAndPendingCoinbase {
+            ledger_hash,
+            protocol_states,
+        })
+        .and_then(|res| {
+            if let LedgerResponse::LedgerAuxAndCoinbaseResult(result) = res {
+                Ok(result)
+            } else {
+                Err(format_response_error(
+                    "staged_ledger_aux_and_pending_coinbase",
+                    res,
+                ))
+            }
+        })
+        .expect("LedgerManager::staged_ledger_aux_and_pending_coinbase: unexpected error")
+    }
+}
+
+impl BlockProducerLedgerService for LedgerManager {
+    fn staged_ledger_diff_create(
+        &self,
+        pred_block: &ArcBlockWithHash,
+        won_slot: &BlockProducerWonSlot,
+        coinbase_receiver: &NonZeroCurvePoint,
+        completed_snarks: BTreeMap<SnarkJobId, Snark>,
+        supercharge_coinbase: bool,
+    ) -> Result<StagedLedgerDiffCreateOutput, String> {
+        self.call(LedgerRequest::StagedLedgerDiffCreate {
+            pred_block: pred_block.clone(),
+            won_slot: won_slot.clone(),
+            coinbase_receiver: coinbase_receiver.clone(),
+            completed_snarks,
+            supercharge_coinbase,
+        })
+        .and_then(|res| {
+            if let LedgerResponse::StagedLedgerDiff(result) = res {
+                Ok(result)
+            } else {
+                Err(format_response_error("staged_ledger_diff_create", res))
+            }
+        })
+    }
+
+    fn stake_proof_sparse_ledger(
+        &self,
+        staking_ledger: LedgerHash,
+        producer: NonZeroCurvePoint,
+        delegator: NonZeroCurvePoint,
+    ) -> Option<MinaBaseSparseLedgerBaseStableV2> {
+        self.call(LedgerRequest::StakeProofSparseLedger {
+            staking_ledger,
+            producer,
+            delegator,
+        })
+        .and_then(|res| {
+            if let LedgerResponse::SparseLedgerBase(result) = res {
+                Ok(result)
+            } else {
+                Err(format_response_error("stake_proof_sparse_ledger", res))
+            }
+        })
+        .expect("LedgerManager::stake_proof_sparse_ledger: unexpected error")
+    }
+}
+
+impl RpcLedgerService for LedgerManager {
+    fn scan_state_summary(
+        &self,
+        ledger_hash: LedgerHash,
+    ) -> Vec<Vec<RpcScanStateSummaryScanStateJob>> {
+        self.call(LedgerRequest::GetScanStateSummary { ledger_hash })
+            .and_then(|res| {
+                if let LedgerResponse::ScanStateSummary(summary) = res {
+                    Ok(summary)
+                } else {
+                    Err(format_response_error("scan_state_summary", res))
+                }
+            })
+            .expect("LedgerManager::scan_state_summary: unexpected error")
+    }
+}
+
+impl BlockProducerVrfEvaluatorLedgerService for LedgerManager {
+    fn get_producer_and_delegates(
+        &self,
+        ledger_hash: LedgerHash,
+        producer: AccountPublicKey,
+    ) -> DelegatorTable {
+        self.call(LedgerRequest::GetProducerAndDelegates {
+            ledger_hash,
+            producer,
+        })
+        .and_then(|res| {
+            if let LedgerResponse::ProducerAndDelegates(table) = res {
+                Ok(table)
+            } else {
+                Err(format_response_error("get_producer_and_delegates", res))
+            }
+        })
+        .expect("LedgerManager::get_producer_and_delegates: unexpected error")
+    }
 }

--- a/node/src/ledger/mod.rs
+++ b/node/src/ledger/mod.rs
@@ -4,9 +4,11 @@ pub use ledger_config::*;
 
 mod ledger_service;
 pub use ledger_service::*;
+pub mod ledger_manager;
 
 pub use ledger::AccountIndex as LedgerAccountIndex;
 pub use ledger::Address as LedgerAddress;
+pub use ledger_manager::LedgerManager;
 
 use mina_p2p_messages::v2::LedgerHash;
 

--- a/node/src/transition_frontier/sync/ledger/snarked/transition_frontier_sync_ledger_snarked_service.rs
+++ b/node/src/transition_frontier/sync/ledger/snarked/transition_frontier_sync_ledger_snarked_service.rs
@@ -5,16 +5,14 @@ use crate::ledger::LedgerAddress;
 pub trait TransitionFrontierSyncLedgerSnarkedService: redux::Service {
     /// For the given ledger, compute the merkle root hash, forcing
     /// all pending hashes to be computed too.
-    fn compute_snarked_ledger_hashes(
-        &mut self,
-        snarked_ledger_hash: &LedgerHash,
-    ) -> Result<(), String>;
+    fn compute_snarked_ledger_hashes(&self, snarked_ledger_hash: &LedgerHash)
+        -> Result<(), String>;
 
     /// Creates a new copy of the ledger stored under the `origin` hash
     /// and stores it under the `target` hash. If `overwrite` is false,
     /// only copy the ledger if the target doesn't exist already.
     fn copy_snarked_ledger_contents_for_sync(
-        &mut self,
+        &self,
         origin: LedgerHash,
         target: LedgerHash,
         overwrite: bool,
@@ -23,7 +21,7 @@ pub trait TransitionFrontierSyncLedgerSnarkedService: redux::Service {
     /// For the given ledger, get the two children hashes at the `parent`
     /// address.
     fn child_hashes_get(
-        &mut self,
+        &self,
         snarked_ledger_hash: LedgerHash,
         parent: &LedgerAddress,
     ) -> Result<(LedgerHash, LedgerHash), String>;
@@ -32,7 +30,7 @@ pub trait TransitionFrontierSyncLedgerSnarkedService: redux::Service {
     /// the subtree starting at the `parent` address. The result
     /// is the hash computed for that subtree.
     fn accounts_set(
-        &mut self,
+        &self,
         snarked_ledger_hash: LedgerHash,
         parent: &LedgerAddress,
         accounts: Vec<MinaBaseAccountBinableArgStableV2>,

--- a/node/src/transition_frontier/sync/ledger/staged/transition_frontier_sync_ledger_staged_service.rs
+++ b/node/src/transition_frontier/sync/ledger/staged/transition_frontier_sync_ledger_staged_service.rs
@@ -7,10 +7,10 @@ use super::StagedLedgerAuxAndPendingCoinbasesValid;
 pub trait TransitionFrontierSyncLedgerStagedService: redux::Service {
     // TODO(tizoc): Only used for the current workaround to make staged ledger
     // reconstruction async, can be removed when the ledger services are made async
-    fn staged_ledger_reconstruct_result_store(&mut self, staged_ledger_hash: LedgerHash);
+    fn staged_ledger_reconstruct_result_store(&self, staged_ledger_hash: LedgerHash);
 
     fn staged_ledger_reconstruct(
-        &mut self,
+        &self,
         snarked_ledger_hash: LedgerHash,
         parts: Option<Arc<StagedLedgerAuxAndPendingCoinbasesValid>>,
     );

--- a/node/src/transition_frontier/transition_frontier_service.rs
+++ b/node/src/transition_frontier/transition_frontier_service.rs
@@ -22,12 +22,12 @@ pub struct CommitResult {
 
 pub trait TransitionFrontierService: redux::Service {
     fn block_apply(
-        &mut self,
+        &self,
         block: ArcBlockWithHash,
         pred_block: ArcBlockWithHash,
     ) -> Result<(), String>;
     fn commit(
-        &mut self,
+        &self,
         ledgers_to_keep: BTreeSet<LedgerHash>,
         root_snarked_ledger_updates: TransitionFrontierRootSnarkedLedgerUpdates,
         needed_protocol_states: BTreeMap<StateHash, MinaStateProtocolStateValueStableV2>,
@@ -35,12 +35,12 @@ pub trait TransitionFrontierService: redux::Service {
         new_best_tip: &ArcBlockWithHash,
     ) -> CommitResult;
     fn answer_ledger_query(
-        &mut self,
+        &self,
         ledger_hash: LedgerHash,
         query: MinaLedgerSyncLedgerQueryStableV1,
     ) -> Option<MinaLedgerSyncLedgerAnswerStableV2>;
     fn staged_ledger_aux_and_pending_coinbase(
-        &mut self,
+        &self,
         ledger_hash: LedgerHash,
         protocol_states: BTreeMap<StateHash, MinaStateProtocolStateValueStableV2>,
     ) -> Option<Arc<StagedLedgerAuxAndPendingCoinbases>>;

--- a/node/src/transition_frontier/transition_frontier_service.rs
+++ b/node/src/transition_frontier/transition_frontier_service.rs
@@ -14,7 +14,7 @@ use crate::p2p::channels::rpc::StagedLedgerAuxAndPendingCoinbases;
 
 use super::sync::TransitionFrontierRootSnarkedLedgerUpdates;
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct CommitResult {
     pub available_jobs: Vec<OneOrTwo<AvailableJobMessage>>,
     pub needed_protocol_states: BTreeSet<StateHash>,

--- a/node/testing/src/cluster/mod.rs
+++ b/node/testing/src/cluster/mod.rs
@@ -29,7 +29,7 @@ use node::p2p::{P2pConnectionEvent, P2pDiscoveryEvent, P2pEvent, PeerId};
 use node::snark::{VerifierIndex, VerifierSRS};
 use node::{
     event_source::Event,
-    ledger::LedgerCtx,
+    ledger::{LedgerCtx, LedgerManager},
     p2p::{channels::ChannelId, identity::SecretKey as P2pSecretKey},
     service::Recorder,
     snark::{get_srs, get_verifier_index, VerifierKind},
@@ -345,7 +345,7 @@ impl Cluster {
             event_sender,
             event_receiver: event_receiver.into(),
             cmd_sender,
-            ledger,
+            ledger_manager: LedgerManager::spawn(ledger),
             peers,
             #[cfg(feature = "p2p-libp2p")]
             libp2p: p2p_service_ctx.libp2p,

--- a/node/testing/src/scenarios/cluster_runner.rs
+++ b/node/testing/src/scenarios/cluster_runner.rs
@@ -378,7 +378,7 @@ impl<'a> ClusterRunner<'a> {
             // genesis block.
             const GENESIS_PRODUCER: &'static str =
                 "B62qiy32p8kAKnny8ZFwoMhYpBppM1DWVCqAPBYNcXnsAHhnfAAuXgg";
-            LedgerService::ctx(node.service())
+            LedgerService::ledger_manager(node.service())
                 .producers_with_delegates(staking_ledger_hash, |pub_key| {
                     pub_key.into_address() != GENESIS_PRODUCER
                 })
@@ -409,7 +409,7 @@ impl<'a> ClusterRunner<'a> {
         let Some(mask) = self.node(node_id).and_then(|node| {
             let best_tip = node.state().transition_frontier.best_tip()?;
             let ledger_hash = best_tip.staged_ledger_hash();
-            let (mask, _) = LedgerService::ctx(node.service()).mask(ledger_hash)?;
+            let (mask, _) = LedgerService::ledger_manager(node.service()).get_mask(ledger_hash)?;
             Some(mask)
         }) else {
             return Box::new(std::iter::empty());

--- a/node/testing/src/service/mod.rs
+++ b/node/testing/src/service/mod.rs
@@ -40,7 +40,6 @@ use node::transition_frontier::genesis::GenesisConfig;
 use node::{
     event_source::Event,
     external_snark_worker::{ExternalSnarkWorkerService, SnarkWorkSpec},
-    ledger::LedgerCtx,
     p2p::{
         connection::outgoing::P2pConnectionOutgoingInitOpts,
         service_impl::webrtc::{Cmd, P2pServiceWebrtc, PeerState},
@@ -202,7 +201,10 @@ impl NodeTestingService {
     }
 
     pub fn ledger(&self, ledger_hash: &LedgerHash) -> Option<Mask> {
-        self.real.ledger.mask(ledger_hash).map(|(mask, _)| mask)
+        self.real
+            .ledger_manager
+            .get_mask(ledger_hash)
+            .map(|(mask, _)| mask)
     }
 }
 
@@ -237,12 +239,8 @@ impl P2pCryptoService for NodeTestingService {
 }
 
 impl node::ledger::LedgerService for NodeTestingService {
-    fn ctx(&self) -> &LedgerCtx {
-        &self.real.ledger
-    }
-
-    fn ctx_mut(&mut self) -> &mut LedgerCtx {
-        &mut self.real.ledger
+    fn ledger_manager(&self) -> &node::ledger::LedgerManager {
+        &self.real.ledger_manager
     }
 }
 


### PR DESCRIPTION
This PR adds `ledger_manager` module, which defines `LedgerManager`, a service which launches a thread keeping track of a `LedgetCtx` and handling requests querying its state and making changes. All operations are performed asyncronously in a thread separate from the caller's, but syncronous wrappers for these calls are provided to avoid dramatic changes to ledger service API yet.

This new service is created along with `NodeService` instance and the latter has a handle on the former, so it can redirect incoming requests to the new service. This way we avoid big changes to `NodeService`'s API at this point. Once this is merged, we can consider updating call sites to asynchronous workflow on case-by-case basis.