### PR TITLE
Add config option to enable block producer + small fix for VRF evaluator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,6 +281,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
 name = "ark-ec"
 version = "0.3.0"
 source = "git+https://github.com/openmina/algebra?branch=openmina#017531e7aaa15a2c856532b0843876e371b01122"
@@ -618,6 +630,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
 
 [[package]]
 name = "base64ct"
@@ -1242,6 +1260,21 @@ checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
 dependencies = [
  "generic-array",
  "subtle",
+]
+
+[[package]]
+name = "crypto_secretbox"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d6cf87adf719ddf43a805e92c6870a531aedda35ff640442cbaf8674e141e1"
+dependencies = [
+ "aead 0.5.2",
+ "cipher 0.4.4",
+ "generic-array",
+ "poly1305 0.8.0",
+ "salsa20",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3811,8 +3844,11 @@ name = "node"
 version = "0.3.1"
 dependencies = [
  "anyhow",
+ "argon2",
+ "base64 0.22.0",
  "bincode",
  "bs58 0.4.0",
+ "crypto_secretbox",
  "derive_more",
  "hex",
  "lazy_static",
@@ -4453,6 +4489,17 @@ dependencies = [
  "redox_syscall 0.4.1",
  "smallvec",
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -19,6 +19,9 @@ bs58 = "0.4.0"
 bincode = "1.3.3"
 hex = "0.4.3"
 rand = "0.8"
+argon2 = { version = "0.5.3", features = ["std"] }
+crypto_secretbox = { version = "0.1.1", features = ["std"] }
+base64 = "0.22"
 redux = { workspace = true }
 mina-hasher = { workspace = true }
 mina-signer = { workspace = true }

--- a/node/src/account/secret_key.rs
+++ b/node/src/account/secret_key.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::{fmt, str::FromStr};
 
 use mina_p2p_messages::{bigint::BigInt, v2::SignatureLibPrivateKeyStableV1};
-use mina_signer::{keypair::KeypairError, Keypair, CompressedPubKey};
+use mina_signer::{keypair::KeypairError, CompressedPubKey, Keypair};
 use openmina_core::constants::GENESIS_PRODUCER_SK;
 
 use super::AccountPublicKey;

--- a/node/src/account/secret_key.rs
+++ b/node/src/account/secret_key.rs
@@ -216,7 +216,7 @@ impl EncryptedSecretKey {
 
     pub fn try_decrypt(&self) -> Result<AccountSecretKey, EncryptionError> {
         // prepare inputs to cipher
-        let password = std::env::var("MINA_PRIVKEY_PASS")
+        let password = env::var("MINA_PRIVKEY_PASS")
             .map_err(|_| EncryptionError::PasswordEnvVarMissing)?;
         let password = password.as_bytes();
         let pwsalt = self.pwsalt.try_decode(Self::ENCRYPTION_DATA_VERSION_BYTE)?;
@@ -251,7 +251,7 @@ impl EncryptedSecretKey {
         // add the prefix byt to the key
         let mut key_prefixed = vec![Self::SECRET_KEY_PREFIX_BYTE];
         key_prefixed.extend(key);
-        let password = std::env::var("MINA_PRIVKEY_PASS")
+        let password = env::var("MINA_PRIVKEY_PASS")
             .map_err(|_| EncryptionError::PasswordEnvVarMissing)?;
 
         let salt = SaltString::generate(&mut OsRng);

--- a/node/src/account/secret_key.rs
+++ b/node/src/account/secret_key.rs
@@ -216,8 +216,8 @@ impl EncryptedSecretKey {
 
     pub fn try_decrypt(&self) -> Result<AccountSecretKey, EncryptionError> {
         // prepare inputs to cipher
-        let password = env::var("MINA_PRIVKEY_PASS")
-            .map_err(|_| EncryptionError::PasswordEnvVarMissing)?;
+        let password =
+            env::var("MINA_PRIVKEY_PASS").map_err(|_| EncryptionError::PasswordEnvVarMissing)?;
         let password = password.as_bytes();
         let pwsalt = self.pwsalt.try_decode(Self::ENCRYPTION_DATA_VERSION_BYTE)?;
         let nonce = self.nonce.try_decode(Self::ENCRYPTION_DATA_VERSION_BYTE)?;
@@ -251,8 +251,8 @@ impl EncryptedSecretKey {
         // add the prefix byt to the key
         let mut key_prefixed = vec![Self::SECRET_KEY_PREFIX_BYTE];
         key_prefixed.extend(key);
-        let password = env::var("MINA_PRIVKEY_PASS")
-            .map_err(|_| EncryptionError::PasswordEnvVarMissing)?;
+        let password =
+            env::var("MINA_PRIVKEY_PASS").map_err(|_| EncryptionError::PasswordEnvVarMissing)?;
 
         let salt = SaltString::generate(&mut OsRng);
         let password_hash = argon2

--- a/node/src/account/secret_key.rs
+++ b/node/src/account/secret_key.rs
@@ -145,7 +145,6 @@ impl<'de> serde::Deserialize<'de> for AccountSecretKey {
     }
 }
 
-// TODO(adonagy):
 #[derive(Serialize, Deserialize, Debug)]
 struct Base58String(String);
 

--- a/node/src/account/secret_key.rs
+++ b/node/src/account/secret_key.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::{fmt, str::FromStr};
 
 use mina_p2p_messages::{bigint::BigInt, v2::SignatureLibPrivateKeyStableV1};
-use mina_signer::{keypair::KeypairError, Keypair};
+use mina_signer::{keypair::KeypairError, Keypair, CompressedPubKey};
 use openmina_core::constants::GENESIS_PRODUCER_SK;
 
 use super::AccountPublicKey;
@@ -52,6 +52,10 @@ impl AccountSecretKey {
 
     pub fn public_key(&self) -> AccountPublicKey {
         self.0.public.clone().into()
+    }
+
+    pub fn public_key_compressed(&self) -> CompressedPubKey {
+        self.0.public.clone().into_compressed()
     }
 }
 

--- a/node/src/account/secret_key.rs
+++ b/node/src/account/secret_key.rs
@@ -1,5 +1,11 @@
 use serde::{Deserialize, Serialize};
-use std::{fmt, str::FromStr};
+use std::{env, fmt, fs, path::PathBuf, str::FromStr};
+
+use argon2::{password_hash::SaltString, Argon2, Params, PasswordHasher};
+
+use base64::Engine;
+use crypto_secretbox::aead::{Aead, OsRng};
+use crypto_secretbox::{AeadCore, KeyInit, XSalsa20Poly1305};
 
 use mina_p2p_messages::{bigint::BigInt, v2::SignatureLibPrivateKeyStableV1};
 use mina_signer::{keypair::KeypairError, CompressedPubKey, Keypair};
@@ -56,6 +62,24 @@ impl AccountSecretKey {
 
     pub fn public_key_compressed(&self) -> CompressedPubKey {
         self.0.public.clone().into_compressed()
+    }
+
+    pub fn from_encrypted_file(path: PathBuf) -> Result<Self, EncryptionError> {
+        let key_file = fs::File::open(path)?;
+        let encrypted: EncryptedSecretKey = serde_json::from_reader(key_file)?;
+        Ok(encrypted.try_decrypt()?)
+    }
+
+    pub fn to_encrypted_file(&self, path: PathBuf) -> Result<(), EncryptionError> {
+        if path.exists() {
+            panic!("File {} already exists", path.display())
+        }
+
+        let f = fs::File::create(path)?;
+        let encrypted = EncryptedSecretKey::encrypt(&self.to_bytes())?;
+
+        serde_json::to_writer(f, &encrypted)?;
+        Ok(())
     }
 }
 
@@ -121,6 +145,141 @@ impl<'de> serde::Deserialize<'de> for AccountSecretKey {
     }
 }
 
+// TODO(adonagy):
+#[derive(Serialize, Deserialize, Debug)]
+struct Base58String(String);
+
+impl Base58String {
+    pub fn new(raw: &[u8], version: u8) -> Self {
+        Base58String(bs58::encode(raw).with_check_version(version).into_string())
+    }
+
+    pub fn try_decode(&self, version: u8) -> Result<Vec<u8>, EncryptionError> {
+        let decoded = bs58::decode(&self.0).with_check(Some(version)).into_vec()?;
+        Ok(decoded[1..].to_vec())
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum EncryptionError {
+    #[error(transparent)]
+    SecretBox(#[from] crypto_secretbox::aead::Error),
+    #[error(transparent)]
+    ArgonError(#[from] argon2::Error),
+    #[error(transparent)]
+    PasswordHash(#[from] argon2::password_hash::Error),
+    #[error(transparent)]
+    Base58DecodeError(#[from] bs58::decode::Error),
+    #[error(transparent)]
+    CipherKeyInvalidLength(#[from] crypto_secretbox::cipher::InvalidLength),
+    #[error("Password hash missing after hash_password")]
+    HashMissing,
+    #[error(transparent)]
+    Keypair(#[from] KeypairError),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    SerdeJson(#[from] serde_json::Error),
+    #[error("MINA_PRIVKEY_PASS environment variable must be set!")]
+    PasswordEnvVarMissing,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct EncryptedSecretKey {
+    box_primitive: String,
+    pw_primitive: String,
+    nonce: Base58String,
+    pwsalt: Base58String,
+    pwdiff: (u32, u32),
+    ciphertext: Base58String,
+}
+
+impl EncryptedSecretKey {
+    const ENCRYPTION_DATA_VERSION_BYTE: u8 = 2;
+    const SECRET_KEY_PREFIX_BYTE: u8 = 1;
+
+    // Based on the ocaml implementation
+    const BOX_PRIMITIVE: &'static str = "xsalsa20poly1305";
+    const PW_PRIMITIVE: &'static str = "argon2i";
+    // Note: Only used for enryption, for decryption use the pwdiff from the file
+    const PW_DIFF: (u32, u32) = (134217728, 6);
+
+    fn setup_argon(pwdiff: (u32, u32)) -> Result<Argon2<'static>, EncryptionError> {
+        let params = Params::new(pwdiff.0 / 1024, pwdiff.1, Params::DEFAULT_P_COST, None)?;
+
+        Ok(Argon2::new(
+            argon2::Algorithm::Argon2i,
+            Default::default(),
+            params,
+        ))
+    }
+
+    pub fn try_decrypt(&self) -> Result<AccountSecretKey, EncryptionError> {
+        // prepare inputs to cipher
+        let password = std::env::var("MINA_PRIVKEY_PASS")
+            .map_err(|_| EncryptionError::PasswordEnvVarMissing)?;
+        let password = password.as_bytes();
+        let pwsalt = self.pwsalt.try_decode(Self::ENCRYPTION_DATA_VERSION_BYTE)?;
+        let nonce = self.nonce.try_decode(Self::ENCRYPTION_DATA_VERSION_BYTE)?;
+        let ciphertext = self
+            .ciphertext
+            .try_decode(Self::ENCRYPTION_DATA_VERSION_BYTE)?;
+
+        // The argon crate's SaltString can only be built from base64 string, ocaml node encodes the salt in base58
+        // So we decoded it from base58 first, then convert to base64 and lastly to SaltString
+        let pwsalt_encoded = base64::engine::general_purpose::STANDARD_NO_PAD.encode(pwsalt);
+        let salt = SaltString::from_b64(&pwsalt_encoded)?;
+
+        let argon2 = Self::setup_argon(self.pwdiff)?;
+        let password_hash = argon2
+            .hash_password(password, &salt)?
+            .hash
+            .ok_or(EncryptionError::HashMissing)?;
+        let password_bytes = password_hash.as_bytes();
+
+        // decrypt cipher
+        let cipher = XSalsa20Poly1305::new_from_slice(password_bytes)?;
+        let decrypted = cipher.decrypt(nonce.as_slice().into(), ciphertext.as_ref())?;
+
+        // strip the prefix and create keypair
+        Ok(AccountSecretKey::from_bytes(&decrypted[1..])?)
+    }
+
+    pub fn encrypt(key: &[u8]) -> Result<Self, EncryptionError> {
+        let argon2 = Self::setup_argon(Self::PW_DIFF)?;
+
+        // add the prefix byt to the key
+        let mut key_prefixed = vec![Self::SECRET_KEY_PREFIX_BYTE];
+        key_prefixed.extend(key);
+        let password = std::env::var("MINA_PRIVKEY_PASS")
+            .map_err(|_| EncryptionError::PasswordEnvVarMissing)?;
+
+        let salt = SaltString::generate(&mut OsRng);
+        let password_hash = argon2
+            .hash_password(password.as_bytes(), &salt)?
+            .hash
+            .ok_or(EncryptionError::HashMissing)?;
+
+        let nonce = XSalsa20Poly1305::generate_nonce(&mut OsRng);
+        let cipher = XSalsa20Poly1305::new_from_slice(password_hash.as_bytes())?;
+
+        let ciphertext = cipher.encrypt(&nonce, key_prefixed.as_slice())?;
+
+        // Same reason as in decrypt, we ned to decode the SaltString from base64 then encode it to base58 bellow
+        let mut salt_bytes = [0; 32];
+        let salt_portion = salt.decode_b64(&mut salt_bytes)?;
+
+        Ok(Self {
+            box_primitive: Self::BOX_PRIMITIVE.to_string(),
+            pw_primitive: Self::PW_PRIMITIVE.to_string(),
+            nonce: Base58String::new(&nonce, Self::ENCRYPTION_DATA_VERSION_BYTE),
+            pwsalt: Base58String::new(salt_portion, Self::ENCRYPTION_DATA_VERSION_BYTE),
+            pwdiff: (argon2.params().m_cost() * 1024, argon2.params().t_cost()),
+            ciphertext: Base58String::new(&ciphertext, Self::ENCRYPTION_DATA_VERSION_BYTE),
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -145,5 +304,42 @@ mod tests {
             &parsed.to_string(),
             "EKFWgzXsoMYcP1Hnj7dBhsefxNucZ6wyz676Qg5uMFNzytXAi2Ww"
         );
+    }
+
+    #[test]
+    fn test_encrypt_decrypt() {
+        env::set_var("MINA_PRIVKEY_PASS", "not-very-secure-pass");
+        let new_key = AccountSecretKey::rand();
+        let tmp_dir = env::temp_dir();
+        let tmp_path = format!("{}/{}-key", tmp_dir.display(), new_key.public_key());
+
+        // dump encrypted file
+        new_key
+            .to_encrypted_file(tmp_path.clone().into())
+            .expect("Failed to encrypt secret key");
+
+        // load and decrypt
+        let decrypted = AccountSecretKey::from_encrypted_file(tmp_path.into())
+            .expect("Failed to decrypt secret key file");
+
+        assert_eq!(
+            new_key.public_key(),
+            decrypted.public_key(),
+            "Encrypted and decrypted public keys do not match"
+        );
+    }
+
+    #[test]
+    fn test_ocaml_key_decrypt() {
+        env::set_var("MINA_PRIVKEY_PASS", "not-very-secure-pass");
+        let key_path = "../tests/files/accounts/test-key-1";
+        let expected_public_key = "B62qmg7n4XqU3SFwx9KD9B7gxsKwxJP5GmxtBpHp1uxyN3grujii9a1";
+        let decrypted = AccountSecretKey::from_encrypted_file(key_path.into())
+            .expect("Failed to decrypt secret key file");
+
+        assert_eq!(
+            expected_public_key.to_string(),
+            decrypted.public_key().to_string()
+        )
     }
 }

--- a/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_effects.rs
+++ b/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_effects.rs
@@ -72,6 +72,7 @@ impl BlockProducerVrfEvaluatorAction {
                             &best_tip.consensus_state().curr_global_slot_since_hard_fork,
                         );
                         let last_height = if slot < k {
+                            // TODO(adonagy): error handling
                             store
                                 .state()
                                 .transition_frontier
@@ -82,13 +83,8 @@ impl BlockProducerVrfEvaluatorAction {
                                 .unwrap()
                                 .height()
                         } else {
-                            store
-                                .state()
-                                .transition_frontier
-                                .sync
-                                .root_block()
-                                .unwrap()
-                                .height()
+                            // TODO(adonagy): error handling
+                            store.state().transition_frontier.root().unwrap().height()
                         };
                         store.dispatch(
                             BlockProducerVrfEvaluatorAction::FinalizeEvaluatorInitialization {

--- a/node/src/transition_frontier/transition_frontier_state.rs
+++ b/node/src/transition_frontier/transition_frontier_state.rs
@@ -39,6 +39,10 @@ impl TransitionFrontierState {
         self.best_chain.last()
     }
 
+    pub fn root(&self) -> Option<&ArcBlockWithHash> {
+        self.best_chain.first()
+    }
+
     /// Looks up state body by state hash.
     pub fn get_state_body(
         &self,


### PR DESCRIPTION
Adds a config option `--producer-key <sk>` to enable the block producer in a non-test run

Also including a small fix for the VRF evaluator initialisation. 