### PR TITLE
fix(transition-frontier): Ensure that by the time the staged ledger reconstruct is complete, the target has not changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix incorrect condition when deciding which snarked ledgers need to be synchronize during bootstrap which would result in a failure when bootstrapping the node during the second epoch.
+- Correctly handle the situation in which the best tip changes during staged ledger reconstruction, causing the reconstruct to produce a stale result.
 
 ## [0.3.1] - 2024-04-05
 

--- a/node/src/transition_frontier/sync/ledger/mod.rs
+++ b/node/src/transition_frontier/sync/ledger/mod.rs
@@ -40,6 +40,7 @@ pub struct SyncLedgerTargetWithStaged {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SyncStagedLedgerTarget {
     pub block_hash: StateHash,
+    pub staged_ledger_hash: LedgerHash,
     pub hashes: MinaBaseStagedLedgerHashStableV1,
 }
 
@@ -51,6 +52,7 @@ impl SyncLedgerTarget {
             snarked_ledger_hash: root_block.snarked_ledger_hash().clone(),
             staged: Some(SyncStagedLedgerTarget {
                 block_hash: root_block.hash().clone(),
+                staged_ledger_hash: root_block.staged_ledger_hash().clone(),
                 hashes: root_block.staged_ledger_hashes().clone(),
             }),
         }


### PR DESCRIPTION
(fixes #331)