### PR TITLE
Bugfix for #361

### DIFF
--- a/p2p/src/network/kad/stream/p2p_network_kad_stream_effects.rs
+++ b/p2p/src/network/kad/stream/p2p_network_kad_stream_effects.rs
@@ -48,16 +48,17 @@ impl P2pNetworkKademliaStreamAction {
                     data: P2pNetworkKademliaRpcRequest::FindNode { key },
                 }),
             ) => {
-                store.dispatch(P2pNetworkKademliaAction::AnswerFindNodeRequest {
-                    addr,
-                    peer_id,
-                    stream_id,
-                    key: *key,
-                });
+                let key = *key;
                 store.dispatch(A::WaitOutgoing {
                     addr,
                     peer_id,
                     stream_id,
+                });
+                store.dispatch(P2pNetworkKademliaAction::AnswerFindNodeRequest {
+                    addr,
+                    peer_id,
+                    stream_id,
+                    key,
                 });
                 Ok(())
             }

--- a/p2p/testing/src/event.rs
+++ b/p2p/testing/src/event.rs
@@ -48,6 +48,7 @@ pub enum RustNodeEvent {
     P2p {
         event: P2pEvent,
     },
+    KadBootstrapFinished,
 }
 
 pub(super) trait RustNodeEventStore {
@@ -109,7 +110,11 @@ pub(super) fn event_mapper_effect(store: &mut super::redux::Store, action: P2pAc
                 reason: reason.to_string(),
             },
         ),
-
+        P2pAction::Network(p2p::P2pNetworkAction::Kad(p2p::P2pNetworkKadAction::System(
+            p2p::P2pNetworkKademliaAction::BootstrapFinished,
+        ))) => {
+            store_event(store, RustNodeEvent::KadBootstrapFinished);
+        }
         P2pAction::Channels(action) => match action {
             P2pChannelsAction::Rpc(action) => match action {
                 P2pChannelsRpcAction::Ready { peer_id } => {

--- a/p2p/testing/src/predicates.rs
+++ b/p2p/testing/src/predicates.rs
@@ -24,6 +24,16 @@ pub fn listener_is_ready(id: RustNodeId) -> impl FnMut(ClusterEvent) -> Ready<bo
     }
 }
 
+/// Predicate if kademlia has finished bootstrap
+pub fn kad_finished_bootstrap(id: RustNodeId) -> impl FnMut(ClusterEvent) -> Ready<bool> {
+    move |event| {
+        ready(matches!(
+            event.rust(),
+            Some((event_id, RustNodeEvent::KadBootstrapFinished)) if *event_id == id
+        ))
+    }
+}
+
 /// Predicate returning true for a cluster event corresponging to the specified node started listening.
 pub fn listeners_are_ready<I>(ids: I) -> impl FnMut(ClusterEvent) -> Ready<bool>
 where

--- a/p2p/tests/kademlia.rs
+++ b/p2p/tests/kademlia.rs
@@ -20,11 +20,15 @@ async fn kademlia() {
         .expect("should build cluster");
 
     let node1 = cluster
-        .add_rust_node(RustNodeConfig::default())
+        .add_rust_node(RustNodeConfig {
+            discovery: true,
+            ..Default::default()
+        })
         .expect("node1");
 
     let config = RustNodeConfig {
         initial_peers: vec![Listener::Rust(node1)],
+        discovery: true,
         ..Default::default()
     };
 
@@ -59,6 +63,7 @@ async fn kademlia() {
     let node3 = cluster
         .add_rust_node(RustNodeConfig {
             initial_peers: vec![Listener::Rust(node2)],
+            discovery: true,
             ..Default::default()
         })
         .expect("Error creating node 3");

--- a/p2p/tests/kademlia.rs
+++ b/p2p/tests/kademlia.rs
@@ -1,0 +1,171 @@
+use p2p::P2pNetworkKadBucket;
+use p2p_testing::{
+    cluster::{Cluster, ClusterBuilder, Listener},
+    futures::TryStreamExt,
+    predicates::kad_finished_bootstrap,
+    rust_node::{RustNodeConfig, RustNodeId},
+    stream::ClusterStreamExt,
+};
+use std::time::Duration;
+
+#[tokio::test]
+async fn kademlia() {
+    std::env::set_var("OPENMINA_DISCOVERY_FILTER_ADDR", "false");
+
+    let mut cluster = ClusterBuilder::new()
+        .ports(11000..11200)
+        .idle_duration(Duration::from_millis(100))
+        .start()
+        .await
+        .expect("should build cluster");
+
+    let node1 = cluster
+        .add_rust_node(RustNodeConfig::default())
+        .expect("node1");
+
+    let config = RustNodeConfig {
+        initial_peers: vec![Listener::Rust(node1)],
+        ..Default::default()
+    };
+
+    let node2 = cluster.add_rust_node(config).expect("node2");
+
+    let peer_id1 = cluster.rust_node(node1).state().my_id();
+    let peer_id2 = cluster.rust_node(node2).state().my_id();
+
+    let bootstrap_finished = cluster
+        .try_stream()
+        .take_during(Duration::from_secs(2))
+        .try_any(kad_finished_bootstrap(node2))
+        .await
+        .expect("unexpected error");
+
+    assert!(bootstrap_finished, "Bootstrap should have finished");
+
+    let bucket = get_kad_bucket(&cluster, node2);
+
+    assert_eq!(
+        bucket.len(),
+        2,
+        "There must be 2 items in bucket self and seed node"
+    );
+
+    let self_peer = bucket.iter().find(|peer| peer.peer_id == peer_id2);
+    assert!(self_peer.is_some(), "Self peer not found");
+
+    let seed_peer = bucket.iter().find(|peer| peer.peer_id == peer_id1);
+    assert!(seed_peer.is_some(), "Seed peer not found");
+
+    let node3 = cluster
+        .add_rust_node(RustNodeConfig {
+            initial_peers: vec![Listener::Rust(node2)],
+            ..Default::default()
+        })
+        .expect("Error creating node 3");
+
+    let peer_id3 = cluster.rust_node(node3).state().my_id();
+
+    let bootstrap_finished = cluster
+        .try_stream()
+        .take_during(Duration::from_secs(2))
+        .try_any(kad_finished_bootstrap(node3))
+        .await
+        .expect("unexpected error");
+
+    assert!(bootstrap_finished, "Bootstrap should have finished");
+    let bucket = get_kad_bucket(&cluster, node3);
+
+    assert_eq!(
+        bucket.len(),
+        3,
+        "There must be 2 items in bucket self and seed node, and node1"
+    );
+
+    let self_peer = bucket.iter().find(|peer| peer.peer_id == peer_id3);
+    assert!(self_peer.is_some(), "Self peer not found");
+
+    let seed_peer = bucket.iter().find(|peer| peer.peer_id == peer_id2);
+    assert!(seed_peer.is_some(), "Seed peer not found");
+
+    let seed_peer = bucket.iter().find(|peer| peer.peer_id == peer_id1);
+    assert!(seed_peer.is_some(), "Node1 peer not found");
+}
+
+#[tokio::test]
+#[ignore]
+async fn kademlia_incoming() {
+    std::env::set_var("OPENMINA_DISCOVERY_FILTER_ADDR", "false");
+
+    let mut cluster = ClusterBuilder::new()
+        .ports(11000..11200)
+        .idle_duration(Duration::from_millis(100))
+        .start()
+        .await
+        .expect("should build cluster");
+
+    let node1 = cluster
+        .add_rust_node(RustNodeConfig::default())
+        .expect("node1");
+
+    let node2 = cluster
+        .add_rust_node(RustNodeConfig {
+            initial_peers: vec![Listener::Rust(node1)],
+            ..Default::default()
+        })
+        .expect("node2");
+
+    let peer_id1 = cluster.rust_node(node1).state().my_id();
+    let peer_id2 = cluster.rust_node(node2).state().my_id();
+
+    let bootstrap_finished = cluster
+        .try_stream()
+        .take_during(Duration::from_secs(2))
+        .try_any(kad_finished_bootstrap(node2))
+        .await
+        .expect("unexpected error");
+
+    assert!(bootstrap_finished, "Bootstrap should have finished");
+
+    let bucket = get_kad_bucket(&cluster, node2);
+
+    assert_eq!(
+        bucket.len(),
+        2,
+        "There must be 2 items in bucket self and seed node"
+    );
+
+    let self_peer = bucket.iter().find(|peer| peer.peer_id == peer_id2);
+    assert!(self_peer.is_some(), "Self peer not found");
+
+    let seed_peer = bucket.iter().find(|peer| peer.peer_id == peer_id1);
+    assert!(seed_peer.is_some(), "Seed peer not found");
+
+    let bucket = get_kad_bucket(&cluster, node1);
+
+    assert_eq!(
+        bucket.len(),
+        2,
+        "There must be 2 items in bucket self and connecting node"
+    );
+
+    let self_peer = bucket.iter().find(|peer| peer.peer_id == peer_id1);
+    assert!(self_peer.is_some(), "Self peer not found");
+
+    let connecting_peer = bucket.iter().find(|peer| peer.peer_id == peer_id2);
+    assert!(connecting_peer.is_some(), "Connecting peer not found");
+}
+
+/// Returns only first bucket from node
+fn get_kad_bucket(cluster: &Cluster, node: RustNodeId) -> &P2pNetworkKadBucket<20> {
+    cluster
+        .rust_node(node)
+        .state()
+        .network
+        .scheduler
+        .discovery_state()
+        .expect("Must be ready")
+        .routing_table
+        .buckets
+        .first()
+        .expect("Must have at least one bucket")
+}


### PR DESCRIPTION
I have code to handle action being `SendResponse` and state being `Incoming(RequestIsReady)` in kademlia stream effects, this allows for node to respond to incoming requests.

@akoptelov, Could you take a look