### PR TITLE
 Fix order of successful snarked ledger sync actions and enabling conditions

### DIFF
--- a/node/src/transition_frontier/sync/ledger/snarked/transition_frontier_sync_ledger_snarked_actions.rs
+++ b/node/src/transition_frontier/sync/ledger/snarked/transition_frontier_sync_ledger_snarked_actions.rs
@@ -275,11 +275,13 @@ impl redux::EnablingCondition<crate::State> for TransitionFrontierSyncLedgerSnar
                 .sync
                 .ledger()
                 .and_then(|s| s.snarked())
-                .map_or(false, |s| {
-                    matches!(
-                        s,
-                        TransitionFrontierSyncLedgerSnarkedState::MerkleTreeSyncPending { .. }
-                    )
+                .map_or(false, |s| match s {
+                    TransitionFrontierSyncLedgerSnarkedState::MerkleTreeSyncPending {
+                        queue,
+                        pending_addresses: pending,
+                        ..
+                    } => queue.is_empty() && pending.is_empty(),
+                    _ => false,
                 }),
 
             // hashes and contents
@@ -445,13 +447,11 @@ impl redux::EnablingCondition<crate::State> for TransitionFrontierSyncLedgerSnar
                 .sync
                 .ledger()
                 .and_then(|s| s.snarked())
-                .map_or(false, |s| match s {
-                    TransitionFrontierSyncLedgerSnarkedState::MerkleTreeSyncPending {
-                        queue,
-                        pending_addresses: pending,
-                        ..
-                    } => queue.is_empty() && pending.is_empty(),
-                    _ => false,
+                .map_or(false, |s| {
+                    matches!(
+                        s,
+                        TransitionFrontierSyncLedgerSnarkedState::MerkleTreeSyncSuccess { .. }
+                    )
                 }),
         }
     }

--- a/node/src/transition_frontier/sync/ledger/snarked/transition_frontier_sync_ledger_snarked_effects.rs
+++ b/node/src/transition_frontier/sync/ledger/snarked/transition_frontier_sync_ledger_snarked_effects.rs
@@ -370,7 +370,8 @@ impl TransitionFrontierSyncLedgerSnarkedAction {
             }
             TransitionFrontierSyncLedgerSnarkedAction::ChildHashesAccepted { .. } => {
                 if !store.dispatch(TransitionFrontierSyncLedgerSnarkedAction::PeersQuery) {
-                    store.dispatch(TransitionFrontierSyncLedgerSnarkedAction::Success);
+                    store
+                        .dispatch(TransitionFrontierSyncLedgerSnarkedAction::MerkleTreeSyncSuccess);
                 }
             }
             TransitionFrontierSyncLedgerSnarkedAction::ChildHashesRejected { .. } => {
@@ -435,7 +436,8 @@ impl TransitionFrontierSyncLedgerSnarkedAction {
             }
             TransitionFrontierSyncLedgerSnarkedAction::ChildAccountsAccepted { .. } => {
                 if !store.dispatch(TransitionFrontierSyncLedgerSnarkedAction::PeersQuery) {
-                    store.dispatch(TransitionFrontierSyncLedgerSnarkedAction::Success);
+                    store
+                        .dispatch(TransitionFrontierSyncLedgerSnarkedAction::MerkleTreeSyncSuccess);
                 }
             }
             TransitionFrontierSyncLedgerSnarkedAction::ChildAccountsRejected { .. } => {

--- a/node/src/transition_frontier/sync/ledger/snarked/transition_frontier_sync_ledger_snarked_reducer.rs
+++ b/node/src/transition_frontier/sync/ledger/snarked/transition_frontier_sync_ledger_snarked_reducer.rs
@@ -320,7 +320,7 @@ impl TransitionFrontierSyncLedgerSnarkedState {
                 // TODO(tizoc): should this be reflected in the state somehow?
             }
             TransitionFrontierSyncLedgerSnarkedAction::Success => {
-                let Self::MerkleTreeSyncPending { target, .. } = self else {
+                let Self::MerkleTreeSyncSuccess { target, .. } = self else {
                     return;
                 };
                 *self = Self::Success {


### PR DESCRIPTION
In some cases `Success` was being dispatched directly without going through `MerkleTreeSyncSuccess` first.