### PR TITLE
fix(ledger-service) Use `supercharge_coinbase` value from the block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- When applying blocks, use the `supercharge_coinbase` value from the block which was being ignored before.
+
 ## [0.4.0] - 2024-04-30
 
 ### Fixed

--- a/node/src/ledger/ledger_service.rs
+++ b/node/src/ledger/ledger_service.rs
@@ -516,10 +516,7 @@ impl LedgerCtx {
 
         let consensus_state = &block.header().protocol_state.body.consensus_state;
         let coinbase_receiver: CompressedPubKey = (&consensus_state.coinbase_receiver).into();
-        let _supercharge_coinbase = consensus_state.supercharge_coinbase;
-
-        // FIXME: Using `supercharge_coinbase` (from block) above does not work
-        let supercharge_coinbase = false;
+        let supercharge_coinbase = consensus_state.supercharge_coinbase;
 
         let diff: Diff = (&block.block.body.staged_ledger_diff).into();
 


### PR DESCRIPTION
This used to fail before because the `supercharged_coinbase_factor` value in the constants used to be `2`, but now that the correct value `1` is used the issue is solved.

re: #386