### PR TITLE
fix(node): Fix zero value for the empty coinbase stack data hash

### DIFF
--- a/mina-p2p-messages/src/v2/manual.rs
+++ b/mina-p2p-messages/src/v2/manual.rs
@@ -257,7 +257,10 @@ impl EpochSeed {
 
 impl CoinbaseStackData {
     pub fn zero() -> Self {
-        MinaBasePendingCoinbaseCoinbaseStackStableV1(BigInt::zero()).into()
+        // In OCaml: https://github.com/MinaProtocol/mina/blob/68b49fdaafabed0f2cd400c4c69f91e81db681e7/src/lib/mina_base/pending_coinbase.ml#L186
+        // let empty = Random_oracle.salt "CoinbaseStack" |> Random_oracle.digest
+        let empty = super::hash_noinputs("CoinbaseStack");
+        MinaBasePendingCoinbaseCoinbaseStackStableV1(empty.into()).into()
     }
 }
 


### PR DESCRIPTION
This was causing the genesis protocol state hash to be computed incorrectly.