### PR TITLE
tweak: Rename `zero` methods to `empty`

### DIFF
--- a/core/src/block/genesis.rs
+++ b/core/src/block/genesis.rs
@@ -100,7 +100,7 @@ fn blockchain_state(
     let stmt_registers = v2::MinaStateBlockchainStateValueStableV2LedgerProofStatementSource {
         first_pass_ledger: genesis_ledger_hash.clone(),
         second_pass_ledger: genesis_ledger_hash.clone(),
-        pending_coinbase_stack: v2::MinaBasePendingCoinbaseStackVersionedStableV1::zero(),
+        pending_coinbase_stack: v2::MinaBasePendingCoinbaseStackVersionedStableV1::empty(),
         local_state: empty_local_state,
     };
     let empty_fee_excess = v2::TokenFeeExcess {

--- a/mina-p2p-messages/src/v2/manual.rs
+++ b/mina-p2p-messages/src/v2/manual.rs
@@ -256,7 +256,7 @@ impl EpochSeed {
 }
 
 impl CoinbaseStackData {
-    pub fn zero() -> Self {
+    pub fn empty() -> Self {
         // In OCaml: https://github.com/MinaProtocol/mina/blob/68b49fdaafabed0f2cd400c4c69f91e81db681e7/src/lib/mina_base/pending_coinbase.ml#L186
         // let empty = Random_oracle.salt "CoinbaseStack" |> Random_oracle.digest
         let empty = super::hash_noinputs("CoinbaseStack");
@@ -320,9 +320,9 @@ impl super::MinaBasePendingCoinbaseUpdateStableV1 {
 }
 
 impl super::MinaBasePendingCoinbaseStackVersionedStableV1 {
-    pub fn zero() -> Self {
+    pub fn empty() -> Self {
         Self {
-            data: CoinbaseStackData::zero(),
+            data: CoinbaseStackData::empty(),
             state: super::MinaBasePendingCoinbaseStateStackStableV1 {
                 init: CoinbaseStackHash::zero(),
                 curr: CoinbaseStackHash::zero(),


### PR DESCRIPTION
As suggested in https://github.com/openmina/openmina/pull/390#pullrequestreview-2048600830