### PR TITLE
Integrate Kademlia with Identify protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4560,6 +4560,8 @@ dependencies = [
  "getrandom 0.2.14",
  "lazy_static",
  "libp2p",
+ "libp2p-rpc-behaviour",
+ "mina-p2p-messages",
  "openmina-core",
  "p2p",
  "pin-project-lite",
@@ -4568,6 +4570,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "tracing-log",
  "tracing-subscriber",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4567,6 +4567,7 @@ dependencies = [
  "pin-project-lite",
  "rand 0.8.5",
  "redux",
+ "serde_json",
  "thiserror",
  "tokio",
  "tracing",

--- a/node/src/action_kind.rs
+++ b/node/src/action_kind.rs
@@ -180,6 +180,7 @@ pub enum ActionKind {
     P2pConnectionIncomingError,
     P2pConnectionIncomingFinalizeError,
     P2pConnectionIncomingFinalizePending,
+    P2pConnectionIncomingFinalizePendingLibp2p,
     P2pConnectionIncomingFinalizeSuccess,
     P2pConnectionIncomingInit,
     P2pConnectionIncomingLibp2pReceived,
@@ -271,6 +272,7 @@ pub enum ActionKind {
     P2pNetworkSchedulerOutgoingConnect,
     P2pNetworkSchedulerOutgoingDidConnect,
     P2pNetworkSchedulerPrune,
+    P2pNetworkSchedulerPruneStreams,
     P2pNetworkSchedulerSelectDone,
     P2pNetworkSchedulerSelectError,
     P2pNetworkSchedulerYamuxDidInit,
@@ -431,7 +433,7 @@ pub enum ActionKind {
 }
 
 impl ActionKind {
-    pub const COUNT: u16 = 359;
+    pub const COUNT: u16 = 361;
 }
 
 impl std::fmt::Display for ActionKind {
@@ -982,6 +984,9 @@ impl ActionKindGet for P2pConnectionIncomingAction {
             Self::Timeout { .. } => ActionKind::P2pConnectionIncomingTimeout,
             Self::Error { .. } => ActionKind::P2pConnectionIncomingError,
             Self::Success { .. } => ActionKind::P2pConnectionIncomingSuccess,
+            Self::FinalizePendingLibp2p { .. } => {
+                ActionKind::P2pConnectionIncomingFinalizePendingLibp2p
+            }
             Self::Libp2pReceived { .. } => ActionKind::P2pConnectionIncomingLibp2pReceived,
         }
     }
@@ -1083,6 +1088,7 @@ impl ActionKindGet for P2pNetworkSchedulerAction {
             Self::Error { .. } => ActionKind::P2pNetworkSchedulerError,
             Self::Disconnected { .. } => ActionKind::P2pNetworkSchedulerDisconnected,
             Self::Prune { .. } => ActionKind::P2pNetworkSchedulerPrune,
+            Self::PruneStreams { .. } => ActionKind::P2pNetworkSchedulerPruneStreams,
         }
     }
 }

--- a/node/src/action_kind.rs
+++ b/node/src/action_kind.rs
@@ -229,6 +229,7 @@ pub enum ActionKind {
     P2pNetworkKademliaBootstrapFinished,
     P2pNetworkKademliaStartBootstrap,
     P2pNetworkKademliaUpdateFindNodeRequest,
+    P2pNetworkKademliaUpdateRoutingTable,
     P2pNetworkKademliaStreamClose,
     P2pNetworkKademliaStreamIncomingData,
     P2pNetworkKademliaStreamNew,
@@ -430,7 +431,7 @@ pub enum ActionKind {
 }
 
 impl ActionKind {
-    pub const COUNT: u16 = 358;
+    pub const COUNT: u16 = 359;
 }
 
 impl std::fmt::Display for ActionKind {
@@ -1201,6 +1202,7 @@ impl ActionKindGet for P2pNetworkKademliaAction {
             }
             Self::StartBootstrap { .. } => ActionKind::P2pNetworkKademliaStartBootstrap,
             Self::BootstrapFinished => ActionKind::P2pNetworkKademliaBootstrapFinished,
+            Self::UpdateRoutingTable { .. } => ActionKind::P2pNetworkKademliaUpdateRoutingTable,
         }
     }
 }

--- a/node/src/event_source/event_source_effects.rs
+++ b/node/src/event_source/event_source_effects.rs
@@ -172,9 +172,6 @@ pub fn event_source_effects<S: Service>(store: &mut Store<S>, action: EventSourc
                                 .dispatch(P2pConnectionOutgoingAction::FinalizeSuccess { peer_id })
                                 || store.dispatch(P2pConnectionIncomingAction::FinalizeSuccess {
                                     peer_id,
-                                })
-                                || store.dispatch(P2pConnectionIncomingAction::Libp2pReceived {
-                                    peer_id,
                                 });
                         }
                     },

--- a/node/testing/src/scenarios/p2p/basic_connection_handling.rs
+++ b/node/testing/src/scenarios/p2p/basic_connection_handling.rs
@@ -239,7 +239,7 @@ impl MaxNumberOfPeersIncoming {
             )
             .await
             .unwrap();
-            assert!(connected, "node {peer} is not connected");
+            assert!(connected, "connection to node {peer} is not finalized");
         }
 
         println!("running cluster...");

--- a/node/testing/src/scenarios/p2p/basic_connection_handling.rs
+++ b/node/testing/src/scenarios/p2p/basic_connection_handling.rs
@@ -230,7 +230,7 @@ impl MaxNumberOfPeersIncoming {
 
         println!("connecting nodes....");
 
-        for (peer, _peer_id) in &peers {
+        for (peer, peer_id) in &peers {
             connect_rust_nodes(driver.inner_mut(), *peer, node_ut).await;
             let connected = wait_for_connection_event(
                 &mut driver,

--- a/node/testing/src/scenarios/p2p/basic_incoming_connections.rs
+++ b/node/testing/src/scenarios/p2p/basic_incoming_connections.rs
@@ -3,8 +3,8 @@ use std::{collections::BTreeSet, time::Duration};
 use crate::{
     node::RustNodeTestingConfig,
     scenarios::{
-        add_rust_nodes, peer_is_ready, wait_for_connection_established, wait_for_connection_event,
-        wait_for_nodes_listening_on_localhost, ClusterRunner, ConnectionPredicates, Driver,
+        add_rust_nodes, peer_is_ready, wait_for_connection_established,
+        wait_for_nodes_listening_on_localhost, ClusterRunner, Driver,
     },
 };
 
@@ -103,45 +103,5 @@ impl AcceptMultipleIncomingConnections {
             "did not accept connection from peers: {:?}",
             peer_ids
         );
-    }
-}
-
-/// Node should not accept connection from itself.
-#[derive(documented::Documented, Default, Clone, Copy)]
-pub struct DoesNotAcceptConnectionFromSelf;
-
-impl DoesNotAcceptConnectionFromSelf {
-    pub async fn run<'cluster>(self, runner: ClusterRunner<'cluster>) {
-        let mut driver = Driver::new(runner);
-        let (node_ut, node_ut_peer_id) =
-            driver.add_rust_node(RustNodeTestingConfig::berkeley_default());
-
-        assert!(
-            wait_for_nodes_listening_on_localhost(&mut driver, Duration::from_secs(60), [node_ut])
-                .await
-                .unwrap(),
-            "node should be listening"
-        );
-
-        driver
-            .exec_step(crate::scenario::ScenarioStep::ConnectNodes {
-                dialer: node_ut,
-                listener: crate::scenario::ListenerNode::Rust(node_ut),
-            })
-            .await
-            .expect("connect event should be dispatched"); // should it?
-
-        // wait for node under test receives connection event
-        let reached = wait_for_connection_event(
-            &mut driver,
-            Duration::from_secs(10),
-            (
-                node_ut,
-                ConnectionPredicates::peer_with_error_status(node_ut_peer_id),
-            ),
-        )
-        .await
-        .expect("connected event");
-        assert!(reached, "expecting connection event that result error");
     }
 }

--- a/node/testing/src/scenarios/p2p/basic_outgoing_connections.rs
+++ b/node/testing/src/scenarios/p2p/basic_outgoing_connections.rs
@@ -196,7 +196,7 @@ impl DontConnectToSelfInitialPeer {
         );
 
         let connected =
-            wait_for_connection_established(&mut driver, Duration::from_secs(3 * 60), node_ut)
+            wait_for_connection_established(&mut driver, Duration::from_secs(10), node_ut)
                 .await
                 .unwrap();
         assert!(!connected, "the node sholdn't try to connect to itself");

--- a/node/testing/tests/p2p_basic_incoming.rs
+++ b/node/testing/tests/p2p_basic_incoming.rs
@@ -1,5 +1,5 @@
 use openmina_node_testing::scenarios::p2p::basic_incoming_connections::{
-    AcceptIncomingConnection, AcceptMultipleIncomingConnections, DoesNotAcceptConnectionFromSelf,
+    AcceptIncomingConnection, AcceptMultipleIncomingConnections,
 };
 
 mod common;
@@ -13,9 +13,4 @@ scenario_test!(
     accept_multiple_connections,
     AcceptMultipleIncomingConnections,
     AcceptMultipleIncomingConnections
-);
-scenario_test!(
-    does_not_accept_self_connection,
-    DoesNotAcceptConnectionFromSelf,
-    DoesNotAcceptConnectionFromSelf
 );

--- a/p2p/src/connection/incoming/p2p_connection_incoming_effects.rs
+++ b/p2p/src/connection/incoming/p2p_connection_incoming_effects.rs
@@ -1,13 +1,16 @@
+use openmina_core::{debug, error, warn};
 use redux::ActionMeta;
 
+use crate::connection::RejectionReason;
 use crate::disconnection::{P2pDisconnectionAction, P2pDisconnectionReason};
 use crate::peer::P2pPeerAction;
+use crate::P2pNetworkSchedulerAction;
 use crate::{connection::P2pConnectionService, webrtc};
 
-use super::{P2pConnectionIncomingAction, P2pConnectionIncomingError};
+use super::{P2pConnectionIncomingAction, P2pConnectionIncomingError, P2pConnectionIncomingState};
 
 impl P2pConnectionIncomingAction {
-    pub fn effects<Store, S>(self, _: &ActionMeta, store: &mut Store)
+    pub fn effects<Store, S>(self, meta: &ActionMeta, store: &mut Store)
     where
         Store: crate::P2pStore<S>,
         Store::Service: P2pConnectionService,
@@ -59,18 +62,64 @@ impl P2pConnectionIncomingAction {
                     incoming: true,
                 });
             }
-            P2pConnectionIncomingAction::Libp2pReceived { peer_id } => {
-                if let Err(err) = store.state().libp2p_incoming_accept(peer_id) {
-                    store.dispatch(P2pDisconnectionAction::Init {
-                        peer_id,
-                        reason: P2pDisconnectionReason::Libp2pIncomingRejected(err),
-                    });
+            P2pConnectionIncomingAction::FinalizePendingLibp2p { peer_id, addr } => {
+                let Some(peer_state) = store.state().peers.get(&peer_id) else {
+                    error!(meta.time(); "no peer state for incoming connection from: {peer_id}");
+                    return;
+                };
+
+                if let Some(P2pConnectionIncomingState::FinalizePendingLibp2p {
+                    close_duplicates,
+                    ..
+                }) = peer_state
+                    .status
+                    .as_connecting()
+                    .and_then(|connecting| connecting.as_incoming())
+                {
+                    if let Err(reason) = store.state().libp2p_incoming_accept(peer_id) {
+                        warn!(meta.time(); node_id = display(store.state().my_id()), summary = "rejecting incoming conection", peer_id = display(peer_id), reason = display(&reason));
+                        store.dispatch(P2pDisconnectionAction::Init {
+                            peer_id,
+                            reason: P2pDisconnectionReason::Libp2pIncomingRejected(reason),
+                        });
+                    } else {
+                        debug!(meta.time(); "accepting incoming conection from {peer_id}");
+                        if !close_duplicates.is_empty() {
+                            let duplicates = store
+                                .state()
+                                .network
+                                .scheduler
+                                .connections
+                                .keys()
+                                .filter(|a| *a != &addr && close_duplicates.contains(a))
+                                .cloned()
+                                .collect::<Vec<_>>();
+                            for addr in duplicates {
+                                warn!(meta.time(); node_id = display(store.state().my_id()), summary = "closing duplicate connection", addr = display(addr));
+                                store.dispatch(P2pNetworkSchedulerAction::Disconnect {
+                                    addr,
+                                    reason: P2pDisconnectionReason::Libp2pIncomingRejected(
+                                        RejectionReason::AlreadyConnected,
+                                    ),
+                                });
+                            }
+                        }
+                    }
                 } else {
-                    store.dispatch(P2pPeerAction::Ready {
-                        peer_id,
-                        incoming: true,
+                    warn!(meta.time(); node_id = display(store.state().my_id()), summary = "rejecting incoming conection as duplicate", peer_id = display(peer_id));
+                    store.dispatch(P2pNetworkSchedulerAction::Disconnect {
+                        addr,
+                        reason: P2pDisconnectionReason::Libp2pIncomingRejected(
+                            RejectionReason::AlreadyConnected,
+                        ),
                     });
                 }
+            }
+            P2pConnectionIncomingAction::Libp2pReceived { peer_id } => {
+                store.dispatch(P2pPeerAction::Ready {
+                    peer_id,
+                    incoming: true,
+                });
             }
             P2pConnectionIncomingAction::AnswerSdpCreatePending { .. } => {}
             P2pConnectionIncomingAction::FinalizePending { .. } => {}

--- a/p2p/src/connection/incoming/p2p_connection_incoming_reducer.rs
+++ b/p2p/src/connection/incoming/p2p_connection_incoming_reducer.rs
@@ -147,8 +147,13 @@ impl P2pConnectionIncomingState {
                     };
                 }
             }
-            P2pConnectionIncomingAction::Libp2pReceived { .. } => {
+            P2pConnectionIncomingAction::FinalizePendingLibp2p { .. } => {
                 // handled in the parent reducer.
+            }
+            P2pConnectionIncomingAction::Libp2pReceived { .. } => {
+                if let Self::FinalizePendingLibp2p { time, .. } = self {
+                    *self = Self::Libp2pReceived { time: *time };
+                }
             }
         }
     }

--- a/p2p/src/connection/incoming/p2p_connection_incoming_state.rs
+++ b/p2p/src/connection/incoming/p2p_connection_incoming_state.rs
@@ -1,3 +1,5 @@
+use std::net::SocketAddr;
+
 use redux::Timestamp;
 use serde::{Deserialize, Serialize};
 
@@ -68,6 +70,11 @@ pub enum P2pConnectionIncomingState {
         answer: webrtc::Answer,
         rpc_id: Option<RpcId>,
     },
+    FinalizePendingLibp2p {
+        addr: SocketAddr,
+        close_duplicates: Vec<SocketAddr>,
+        time: redux::Timestamp,
+    },
     Libp2pReceived {
         time: redux::Timestamp,
     },
@@ -85,6 +92,7 @@ impl P2pConnectionIncomingState {
             Self::FinalizeSuccess { time, .. } => *time,
             Self::Error { time, .. } => *time,
             Self::Success { time, .. } => *time,
+            Self::FinalizePendingLibp2p { time, .. } => *time,
             Self::Libp2pReceived { time } => *time,
         }
     }
@@ -100,7 +108,7 @@ impl P2pConnectionIncomingState {
             Self::FinalizeSuccess { rpc_id, .. } => *rpc_id,
             Self::Error { rpc_id, .. } => *rpc_id,
             Self::Success { rpc_id, .. } => *rpc_id,
-            Self::Libp2pReceived { .. } => None,
+            Self::FinalizePendingLibp2p { .. } | Self::Libp2pReceived { .. } => None,
         }
     }
 

--- a/p2p/src/connection/outgoing/p2p_connection_outgoing_actions.rs
+++ b/p2p/src/connection/outgoing/p2p_connection_outgoing_actions.rs
@@ -122,6 +122,7 @@ impl redux::EnablingCondition<P2pState> for P2pConnectionOutgoingAction {
             }
             P2pConnectionOutgoingAction::Init { opts, .. } => {
                 !state.already_has_min_peers() &&
+                &state.my_id() != opts.peer_id() &&
                 state
                     .peers
                     .get(opts.peer_id())

--- a/p2p/src/connection/p2p_connection_reducer.rs
+++ b/p2p/src/connection/p2p_connection_reducer.rs
@@ -1,19 +1,28 @@
-use crate::{P2pPeerState, P2pPeerStatus};
+use std::net::{IpAddr, SocketAddr};
+
+use multiaddr::Protocol;
+
+use crate::{P2pPeerState, P2pPeerStatus, PeerId};
 
 use super::{
     incoming::{P2pConnectionIncomingAction, P2pConnectionIncomingState},
-    outgoing::{P2pConnectionOutgoingAction, P2pConnectionOutgoingState},
+    outgoing::{
+        P2pConnectionOutgoingAction, P2pConnectionOutgoingInitOpts, P2pConnectionOutgoingState,
+    },
     P2pConnectionAction, P2pConnectionActionWithMetaRef, P2pConnectionState,
 };
 
 pub fn p2p_connection_reducer(
     state: &mut P2pPeerState,
+    my_id: PeerId,
     action: P2pConnectionActionWithMetaRef<'_>,
 ) {
     let (action, meta) = action.split();
     match action {
         P2pConnectionAction::Outgoing(action) => {
-            if let P2pConnectionOutgoingAction::Reconnect { opts, rpc_id } = action {
+            if let P2pConnectionOutgoingAction::Reconnect { opts, rpc_id }
+            | P2pConnectionOutgoingAction::Init { opts, rpc_id } = action
+            {
                 state.status = P2pPeerStatus::Connecting(P2pConnectionState::Outgoing(
                     P2pConnectionOutgoingState::Init {
                         time: meta.time(),
@@ -38,10 +47,67 @@ pub fn p2p_connection_reducer(
                         rpc_id: *rpc_id,
                     },
                 ))
-            } else if let P2pConnectionIncomingAction::Libp2pReceived { .. } = action {
-                state.status = P2pPeerStatus::Connecting(P2pConnectionState::Incoming(
-                    P2pConnectionIncomingState::Libp2pReceived { time: meta.time() },
-                ))
+            } else if let P2pConnectionIncomingAction::FinalizePendingLibp2p {
+                peer_id, addr, ..
+            } = action
+            {
+                let incoming_state = match &state.status {
+                    // No duplicate connection
+                    P2pPeerStatus::Disconnected { .. } => {
+                        Some(P2pConnectionIncomingState::FinalizePendingLibp2p {
+                            addr: *addr,
+                            close_duplicates: Vec::new(),
+                            time: meta.time(),
+                        })
+                    }
+                    P2pPeerStatus::Connecting(P2pConnectionState::Outgoing(_))
+                        if &my_id < peer_id =>
+                    {
+                        // connection from lesser peer_id to greater one is kept in favour of the opposite one (incoming in this case)
+                        None
+                    }
+                    P2pPeerStatus::Connecting(P2pConnectionState::Outgoing(_)) => {
+                        let mut close_duplicates = Vec::new();
+                        if let Some(identify) = state.identify.as_ref() {
+                            close_duplicates.extend(identify.listen_addrs.iter().filter_map(
+                                |maddr| {
+                                    let mut iter = maddr.iter();
+                                    let ip: IpAddr = match iter.next()? {
+                                        Protocol::Ip4(ip4) => ip4.into(),
+                                        Protocol::Ip6(ip6) => ip6.into(),
+                                        _ => return None,
+                                    };
+                                    let port = match iter.next()? {
+                                        Protocol::Tcp(port) => port,
+                                        _ => return None,
+                                    };
+                                    Some(SocketAddr::from((ip, port)))
+                                },
+                            ))
+                        }
+                        match state.dial_opts.as_ref() {
+                            Some(P2pConnectionOutgoingInitOpts::LibP2P(libp2p)) => {
+                                match libp2p.try_into() {
+                                    Ok(addr) if !close_duplicates.contains(&addr) => {
+                                        close_duplicates.push(addr)
+                                    }
+                                    _ => {}
+                                }
+                            }
+                            _ => {}
+                        };
+                        Some(P2pConnectionIncomingState::FinalizePendingLibp2p {
+                            addr: *addr,
+                            close_duplicates,
+                            time: meta.time(),
+                        })
+                    }
+                    _ => None,
+                };
+                if let Some(incoming_state) = incoming_state {
+                    state.status =
+                        P2pPeerStatus::Connecting(P2pConnectionState::Incoming(incoming_state));
+                }
             }
             let P2pPeerStatus::Connecting(P2pConnectionState::Incoming(state)) = &mut state.status
             else {

--- a/p2p/src/connection/p2p_connection_reducer.rs
+++ b/p2p/src/connection/p2p_connection_reducer.rs
@@ -85,16 +85,15 @@ pub fn p2p_connection_reducer(
                                 },
                             ))
                         }
-                        match state.dial_opts.as_ref() {
-                            Some(P2pConnectionOutgoingInitOpts::LibP2P(libp2p)) => {
-                                match libp2p.try_into() {
-                                    Ok(addr) if !close_duplicates.contains(&addr) => {
-                                        close_duplicates.push(addr)
-                                    }
-                                    _ => {}
+                        if let Some(P2pConnectionOutgoingInitOpts::LibP2P(libp2p)) =
+                            state.dial_opts.as_ref()
+                        {
+                            match libp2p.try_into() {
+                                Ok(addr) if !close_duplicates.contains(&addr) => {
+                                    close_duplicates.push(addr)
                                 }
+                                _ => {}
                             }
-                            _ => {}
                         };
                         Some(P2pConnectionIncomingState::FinalizePendingLibp2p {
                             addr: *addr,

--- a/p2p/src/disconnection/mod.rs
+++ b/p2p/src/disconnection/mod.rs
@@ -31,4 +31,7 @@ pub enum P2pDisconnectionReason {
 
     #[error("failed to verify snark pool diff")]
     SnarkPoolVerifyError,
+
+    #[error("duplicate connection")]
+    DuplicateConnection,
 }

--- a/p2p/src/identify/p2p_identify_effects.rs
+++ b/p2p/src/identify/p2p_identify_effects.rs
@@ -28,7 +28,7 @@ impl P2pIdentifyAction {
                     })
                     .and_then(|(P2pNetworkConnectionMuxState::Yamux(yamux), incoming)| {
                         yamux
-                            .next_stream_id(!incoming)
+                            .next_stream_id(crate::YamuxStreamKind::Identify, incoming)
                             .ok_or_else(|| format!("cannot get next stream for {addr}"))
                     });
 

--- a/p2p/src/identify/p2p_identify_effects.rs
+++ b/p2p/src/identify/p2p_identify_effects.rs
@@ -1,5 +1,6 @@
 use crate::{
-    connection::P2pConnectionService, P2pNetworkConnectionMuxState, P2pNetworkYamuxAction, P2pStore,
+    connection::P2pConnectionService, P2pNetworkConnectionMuxState, P2pNetworkKademliaAction,
+    P2pNetworkYamuxAction, P2pStore,
 };
 use openmina_core::error;
 use redux::ActionMeta;
@@ -46,7 +47,12 @@ impl P2pIdentifyAction {
                     }
                 }
             }
-            P2pIdentifyAction::UpdatePeerInformation { .. } => {}
+            P2pIdentifyAction::UpdatePeerInformation { peer_id, info } => {
+                store.dispatch(P2pNetworkKademliaAction::UpdateRoutingTable {
+                    peer_id,
+                    addrs: info.listen_addrs,
+                });
+            }
         }
     }
 }

--- a/p2p/src/network/kad/p2p_network_kad_actions.rs
+++ b/p2p/src/network/kad/p2p_network_kad_actions.rs
@@ -1,5 +1,6 @@
 use std::net::SocketAddr;
 
+use multiaddr::Multiaddr;
 use openmina_core::ActionEvent;
 use redux::EnablingCondition;
 use serde::{Deserialize, Serialize};
@@ -44,7 +45,8 @@ impl From<P2pNetworkKadAction> for P2pAction {
     display(peer_id),
     stream_id,
     display(key),
-    debug(closest_peers)
+    debug(closest_peers),
+    debug(addrs)
 ))]
 pub enum P2pNetworkKademliaAction {
     /// Answer `FIND_NODE` request.
@@ -71,6 +73,13 @@ pub enum P2pNetworkKademliaAction {
     /// Bootstrap is finished.
     #[action_event(level = info)]
     BootstrapFinished,
+
+    /// Update routing table with peer addresses
+    #[action_event(level = info)]
+    UpdateRoutingTable {
+        peer_id: PeerId,
+        addrs: Vec<Multiaddr>,
+    },
 }
 
 impl EnablingCondition<P2pState> for P2pNetworkKademliaAction {
@@ -99,6 +108,7 @@ impl EnablingCondition<P2pState> for P2pNetworkKademliaAction {
                 // TODO: also can run bootstrap on timely basis.
                 matches!(state.status, super::P2pNetworkKadStatus::Bootstrapping(_))
             }
+            P2pNetworkKademliaAction::UpdateRoutingTable { .. } => true,
         }
     }
 }

--- a/p2p/src/network/kad/p2p_network_kad_effects.rs
+++ b/p2p/src/network/kad/p2p_network_kad_effects.rs
@@ -95,6 +95,7 @@ impl P2pNetworkKademliaAction {
                 Ok(())
             }
             (BootstrapFinished {}, _) => Ok(()),
+            (UpdateRoutingTable { .. }, _) => Ok(()),
         }
     }
 }

--- a/p2p/src/network/kad/p2p_network_kad_internals.rs
+++ b/p2p/src/network/kad/p2p_network_kad_internals.rs
@@ -476,7 +476,7 @@ impl<'a, const K: usize> Iterator for ClosestPeers<'a, K> {
             self.bucket_index = self.index_iter.next()?;
             self.bucket_iterator = Self::get_bucket_iter(
                 &self.table.buckets[self.bucket_index],
-                &self.key,
+                self.key,
                 &self.table.this_key,
             );
         })
@@ -560,7 +560,7 @@ impl<'a, const K: usize> IntoIterator for &'a P2pNetworkKadBucket<K> {
     type IntoIter = std::slice::Iter<'a, P2pNetworkKadEntry>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.0.as_slice().into_iter()
+        self.0.as_slice().iter()
     }
 }
 

--- a/p2p/src/network/kad/p2p_network_kad_reducer.rs
+++ b/p2p/src/network/kad/p2p_network_kad_reducer.rs
@@ -1,5 +1,7 @@
 use redux::ActionWithMeta;
 
+use crate::P2pNetworkKadEntry;
+
 use super::{P2pNetworkKadAction, P2pNetworkKadLatestRequestPeerKind, P2pNetworkKadStatus};
 
 use super::stream::P2pNetworkKademliaStreamAction;
@@ -91,6 +93,12 @@ impl super::P2pNetworkKadState {
                     time: meta.time(),
                     stats: state.stats.clone(),
                 };
+                Ok(())
+            }
+            (_, UpdateRoutingTable { peer_id, addrs }) => {
+                let _ = self
+                    .routing_table
+                    .insert(P2pNetworkKadEntry::new(*peer_id, addrs.clone()));
                 Ok(())
             }
             (state, action) => Err(format!("invalid action {action:?} for state {state:?}")),

--- a/p2p/src/network/kad/stream/p2p_network_kad_stream_effects.rs
+++ b/p2p/src/network/kad/stream/p2p_network_kad_stream_effects.rs
@@ -147,8 +147,8 @@ impl P2pNetworkKademliaStreamAction {
                     peer_id,
                     stream_id,
                 },
-                D::Incoming(I::WaitingForRequest { expect_close }),
-            ) if *expect_close => {
+                D::Incoming(I::Closing),
+            ) => {
                 // send FIN to the network
                 store.dispatch(P2pNetworkYamuxAction::OutgoingData {
                     addr,

--- a/p2p/src/network/noise/p2p_network_noise_actions.rs
+++ b/p2p/src/network/noise/p2p_network_noise_actions.rs
@@ -8,7 +8,7 @@ use crate::{Data, P2pNetworkAction, P2pState, PeerId};
 use super::p2p_network_noise_state::{Pk, Sk};
 
 #[derive(Serialize, Deserialize, Debug, Clone, ActionEvent)]
-#[action_event(level = trace, fields(display(addr), incoming, debug(data), display(peer_id)))]
+#[action_event(level = debug, fields(display(addr), incoming, debug(data), display(peer_id)))]
 pub enum P2pNetworkNoiseAction {
     Init {
         addr: SocketAddr,

--- a/p2p/src/network/noise/p2p_network_noise_reducer.rs
+++ b/p2p/src/network/noise/p2p_network_noise_reducer.rs
@@ -89,17 +89,12 @@ impl P2pNetworkNoiseState {
                 if let Some(mut chunk) = self.incoming_chunks.pop_front() {
                     match state {
                         P2pNetworkNoiseStateInner::Initiator(i) => match i.consume(&mut chunk) {
-                            Ok(_) if i.remote_pk.as_ref() == Some(&self.local_pk) => {
-                                *state = P2pNetworkNoiseStateInner::Error(dbg!(
-                                    NoiseError::SelfConnection
-                                ));
-                            }
-                            Ok(remote_payload) => {
-                                self.handshake_optimized = remote_payload.is_some();
-                                if let Some(remote_payload) = remote_payload {
-                                    self.decrypted_chunks
-                                        .push_back(remote_payload.to_vec().into());
-                                }
+                            Ok(_) => {
+                                // self.handshake_optimized = remote_payload.is_some();
+                                // if let Some(remote_payload) = remote_payload {
+                                //     self.decrypted_chunks
+                                //         .push_back(remote_payload.to_vec().into());
+                                // }
                             }
                             Err(err) => *state = P2pNetworkNoiseStateInner::Error(dbg!(err)),
                         },
@@ -121,7 +116,7 @@ impl P2pNetworkNoiseState {
                                         remote_pk,
                                         ..
                                     },
-                                payload: remote_payload,
+                                payload: _,
                             })) => {
                                 let remote_peer_id = remote_pk.peer_id();
                                 *state = P2pNetworkNoiseStateInner::Done {
@@ -133,11 +128,11 @@ impl P2pNetworkNoiseState {
                                     remote_pk,
                                     remote_peer_id,
                                 };
-                                self.handshake_optimized = remote_payload.is_some();
-                                if let Some(remote_payload) = remote_payload {
-                                    self.decrypted_chunks
-                                        .push_back(remote_payload.to_vec().into());
-                                }
+                                // self.handshake_optimized = remote_payload.is_some();
+                                // if let Some(remote_payload) = remote_payload {
+                                //     self.decrypted_chunks
+                                //         .push_back(remote_payload.to_vec().into());
+                                // }
                             }
                             Err(err) => {
                                 *state = P2pNetworkNoiseStateInner::Error(dbg!(err));

--- a/p2p/src/network/noise/p2p_network_noise_reducer.rs
+++ b/p2p/src/network/noise/p2p_network_noise_reducer.rs
@@ -101,14 +101,6 @@ impl P2pNetworkNoiseState {
                         P2pNetworkNoiseStateInner::Responder(o) => match o.consume(&mut chunk) {
                             Ok(None) => {}
                             Ok(Some(ResponderConsumeOutput {
-                                output: ResponderOutput { remote_pk, .. },
-                                ..
-                            })) if remote_pk == self.local_pk => {
-                                *state = P2pNetworkNoiseStateInner::Error(dbg!(
-                                    NoiseError::SelfConnection
-                                ));
-                            }
-                            Ok(Some(ResponderConsumeOutput {
                                 output:
                                     ResponderOutput {
                                         send_key,

--- a/p2p/src/network/scheduler/p2p_network_scheduler_effects.rs
+++ b/p2p/src/network/scheduler/p2p_network_scheduler_effects.rs
@@ -247,7 +247,7 @@ impl P2pNetworkSchedulerAction {
                     // for each negotiated yamux conenction open a new outgoing RPC stream
                     // TODO(akoptelov,vlad): should we do that? shouldn't upper layer decide when to open RPC streams?
                     // Also rpc streams are short-living -- they only persist for a single request-response (?)
-                    let stream_id = if incoming { 2 } else { 1 };
+                    let stream_id = YamuxStreamKind::Rpc.stream_id(incoming);
                     store.dispatch(P2pNetworkYamuxAction::OpenStream {
                         addr,
                         stream_id,

--- a/p2p/src/network/scheduler/p2p_network_scheduler_reducer.rs
+++ b/p2p/src/network/scheduler/p2p_network_scheduler_reducer.rs
@@ -74,7 +74,7 @@ impl P2pNetworkSchedulerState {
                 match protocol {
                     Some(token::Protocol::Auth(token::AuthKind::Noise)) => {
                         connection.auth = Some(P2pNetworkAuthState::Noise(
-                            P2pNetworkNoiseState::new(self.local_pk.clone(), true),
+                            P2pNetworkNoiseState::new(self.local_pk.clone(), false),
                         ));
                     }
                     Some(token::Protocol::Mux(
@@ -169,17 +169,16 @@ impl P2pNetworkSchedulerState {
                     error!(meta.time(); "P2pNetworkSchedulerAction::Disconnect: {addr} is not disconnecting");
                     return;
                 }
-                cn.streams.clear();
-                if let Some(peer_id) = cn.peer_id() {
-                    self.rpc_incoming_streams.remove(peer_id);
-                    self.rpc_outgoing_streams.remove(peer_id);
-                    if let Some(discovery_state) = self.discovery_state.as_mut() {
-                        discovery_state.streams.remove(peer_id);
-                    }
-                }
             }
             P2pNetworkSchedulerAction::Prune { addr } => {
                 let _ = self.connections.remove(addr);
+            }
+            P2pNetworkSchedulerAction::PruneStreams { peer_id } => {
+                self.rpc_incoming_streams.remove(peer_id);
+                self.rpc_outgoing_streams.remove(peer_id);
+                if let Some(discovery_state) = self.discovery_state.as_mut() {
+                    discovery_state.streams.remove(peer_id);
+                }
             }
         }
     }

--- a/p2p/src/network/scheduler/p2p_network_scheduler_reducer.rs
+++ b/p2p/src/network/scheduler/p2p_network_scheduler_reducer.rs
@@ -167,7 +167,6 @@ impl P2pNetworkSchedulerState {
                 };
                 if cn.closed.is_none() {
                     error!(meta.time(); "P2pNetworkSchedulerAction::Disconnect: {addr} is not disconnecting");
-                    return;
                 }
             }
             P2pNetworkSchedulerAction::Prune { addr } => {

--- a/p2p/src/network/select/p2p_network_select_actions.rs
+++ b/p2p/src/network/select/p2p_network_select_actions.rs
@@ -51,15 +51,6 @@ pub enum SelectKind {
 }
 
 impl SelectKind {
-    pub fn peer_id(&self) -> Option<PeerId> {
-        match self {
-            Self::Authentication => None,
-            Self::MultiplexingNoPeerId => None,
-            Self::Multiplexing(v) => Some(*v),
-            Self::Stream(v, _) => Some(*v),
-        }
-    }
-
     pub fn stream_id(&self) -> Option<StreamId> {
         match self {
             Self::Authentication => None,

--- a/p2p/src/network/yamux/mod.rs
+++ b/p2p/src/network/yamux/mod.rs
@@ -2,7 +2,9 @@ mod p2p_network_yamux_actions;
 pub use self::p2p_network_yamux_actions::*;
 
 mod p2p_network_yamux_state;
-pub use self::p2p_network_yamux_state::{P2pNetworkYamuxState, StreamId, YamuxPing};
+pub use self::p2p_network_yamux_state::{
+    P2pNetworkYamuxState, StreamId, YamuxPing, YamuxStreamKind,
+};
 
 mod p2p_network_yamux_reducer;
 

--- a/p2p/src/network/yamux/p2p_network_yamux_state.rs
+++ b/p2p/src/network/yamux/p2p_network_yamux_state.rs
@@ -16,17 +16,9 @@ pub struct P2pNetworkYamuxState {
 impl P2pNetworkYamuxState {
     /// Calculates and returns the next available stream ID for outgoing
     /// communication.
-    pub fn next_stream_id(&self, client: bool) -> Option<StreamId> {
-        // client side should select odd stream IDs
-        let suitable_stream_id = move |stream_id: &&StreamId| ((**stream_id & 0x1) == 1) == client;
+    pub fn next_stream_id(&self, kind: YamuxStreamKind, incoming: bool) -> Option<StreamId> {
         if self.init && self.terminated.is_none() {
-            let next_stream_id = self
-                .streams
-                .keys()
-                .filter(suitable_stream_id)
-                .max()
-                .map_or_else(|| if client { 1 } else { 2 }, |stream_id| stream_id + 2);
-            Some(next_stream_id)
+            Some(kind.stream_id(incoming))
         } else {
             None
         }
@@ -184,4 +176,30 @@ pub enum YamuxFrameInner {
 pub enum YamuxSessionError {
     Protocol,
     Internal,
+}
+
+#[derive(Debug)]
+pub enum YamuxStreamKind {
+    Rpc,
+    Gossipsub,
+    Kademlia,
+    Identify,
+}
+
+impl YamuxStreamKind {
+    pub fn stream_id(self, incoming: bool) -> StreamId {
+        (self as StreamId) * 2 + 1 + (incoming as StreamId)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn yamux_stream_id() {
+        use super::YamuxStreamKind::*;
+        assert_eq!(Rpc.stream_id(false), 1);
+        assert_eq!(Rpc.stream_id(true), 2);
+        assert_eq!(Kademlia.stream_id(false), 5);
+        assert_eq!(Kademlia.stream_id(true), 6);
+    }
 }

--- a/p2p/src/p2p_state.rs
+++ b/p2p/src/p2p_state.rs
@@ -32,9 +32,14 @@ impl P2pState {
             .into_iter()
             .collect();
 
-        let known_peers = config
+        let my_id = config.identity_pub_key.peer_id();
+        let initial_peers = config
             .initial_peers
             .iter()
+            .filter(|peer| peer.peer_id() != &my_id);
+
+        let known_peers = initial_peers
+            .clone()
             .filter_map(|peer| {
                 if let P2pConnectionOutgoingInitOpts::LibP2P(peer) = peer {
                     Some(peer.into())
@@ -44,9 +49,7 @@ impl P2pState {
             })
             .collect();
 
-        let peers = config
-            .initial_peers
-            .iter()
+        let peers = initial_peers
             .map(|peer| {
                 (
                     *peer.peer_id(),

--- a/p2p/testing/Cargo.toml
+++ b/p2p/testing/Cargo.toml
@@ -8,8 +8,11 @@ edition = "2021"
 [dependencies]
 redux = { workspace = true }
 p2p = { path = ".." }
+mina-p2p-messages = { path = "../../mina-p2p-messages" }
+
 tokio = { version = "1.26.0", features = [ "sync", "macros" ] }
 libp2p = { workspace = true, features = ["macros", "serde", "tcp", "dns", "tokio", "yamux", "pnet", "noise", "gossipsub", "identify", "kad"] }
+libp2p-rpc-behaviour = { path = "../libp2p-rpc-behaviour" }
 futures = "0.3.30"
 rand = "0.8.5"
 derive_more = "0.99.17"
@@ -22,3 +25,4 @@ lazy_static = "1.4.0"
 tracing-subscriber = "0.3.18"
 tracing = "0.1.40"
 getrandom = "0.2.14"
+tracing-log = "0.2.0"

--- a/p2p/testing/Cargo.toml
+++ b/p2p/testing/Cargo.toml
@@ -26,3 +26,4 @@ tracing-subscriber = "0.3.18"
 tracing = "0.1.40"
 getrandom = "0.2.14"
 tracing-log = "0.2.0"
+serde_json.workspace = true

--- a/p2p/testing/src/lib.rs
+++ b/p2p/testing/src/lib.rs
@@ -12,3 +12,4 @@ pub mod stream;
 pub mod utils;
 
 pub use futures;
+pub use libp2p;

--- a/p2p/testing/src/lib.rs
+++ b/p2p/testing/src/lib.rs
@@ -12,5 +12,5 @@ pub mod stream;
 pub mod utils;
 
 pub use futures;
-pub use libp2p;
 pub use lazy_static;
+pub use libp2p;

--- a/p2p/testing/src/lib.rs
+++ b/p2p/testing/src/lib.rs
@@ -13,3 +13,4 @@ pub mod utils;
 
 pub use futures;
 pub use libp2p;
+pub use lazy_static;

--- a/p2p/testing/src/libp2p_node.rs
+++ b/p2p/testing/src/libp2p_node.rs
@@ -20,6 +20,7 @@ pub struct Libp2pNodeId(pub(super) usize);
 #[derive(Debug, Default, Clone)]
 pub struct Libp2pNodeConfig {
     pub peer_id: PeerIdConfig,
+    pub port_reuse: bool,
 }
 
 pub type Swarm = libp2p::Swarm<Libp2pBehaviour>;
@@ -91,6 +92,7 @@ pub struct Libp2pBehaviour {
 pub(crate) fn create_swarm(
     secret_key: p2p::identity::SecretKey,
     port: u16,
+    port_reuse: bool,
     chain_id: &str,
 ) -> Result<Swarm, Box<dyn Error>> {
     let identity_keys = libp2p::identity::Keypair::ed25519_from_bytes(secret_key.to_bytes())
@@ -178,7 +180,7 @@ pub(crate) fn create_swarm(
             let mut base_transport = libp2p::tcp::tokio::Transport::new(
                 libp2p::tcp::Config::default()
                     .nodelay(true)
-                    .port_reuse(true),
+                    .port_reuse(port_reuse),
             );
 
             base_transport

--- a/p2p/testing/src/libp2p_node.rs
+++ b/p2p/testing/src/libp2p_node.rs
@@ -1,21 +1,208 @@
+use std::{collections::BTreeMap, error::Error, time::Duration};
+
+use libp2p::{
+    gossipsub, identify,
+    swarm::{NetworkBehaviour, SwarmEvent, THandlerErr},
+    Transport,
+};
+use mina_p2p_messages::rpc_kernel::RpcTag;
 use p2p::PeerId;
 
-use crate::test_node::TestNode;
+use libp2p_rpc_behaviour::StreamId;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+use libp2p::kad::{self, record::store::MemoryStore};
+
+use crate::{cluster::PeerIdConfig, test_node::TestNode};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Libp2pNodeId(pub(super) usize);
 
-pub struct Libp2pNode {}
+#[derive(Debug, Default, Clone)]
+pub struct Libp2pNodeConfig {
+    pub peer_id: PeerIdConfig,
+}
 
-impl TestNode for Libp2pNode {
-    fn peer_id(&self) -> PeerId {
-        todo!()
+pub type Swarm = libp2p::Swarm<Libp2pBehaviour>;
+
+pub struct Libp2pNode {
+    swarm: Swarm,
+}
+
+impl Libp2pNode {
+    pub(super) fn new(swarm: Swarm) -> Self {
+        Libp2pNode { swarm }
     }
 
-    fn libp2p_port(&self) -> u16 {
-        todo!()
+    pub fn swarm(&self) -> &Swarm {
+        &self.swarm
+    }
+
+    pub fn swarm_mut(&mut self) -> &mut Swarm {
+        &mut self.swarm
     }
 }
 
-#[derive(Debug)]
-pub struct Libp2pEvent;
+impl TestNode for Libp2pNode {
+    fn peer_id(&self) -> PeerId {
+        self.swarm.local_peer_id().clone().into()
+    }
+
+    fn libp2p_port(&self) -> u16 {
+        self.swarm.behaviour().port
+    }
+}
+
+pub type Libp2pEvent = SwarmEvent<Libp2pBehaviourEvent, THandlerErr<Libp2pBehaviour>>;
+
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, derive_more::From)]
+pub enum Libp2pBehaviourEvent {
+    // Identify(IdentifyEvent),
+    Gossipsub(gossipsub::Event),
+    Rpc((libp2p::identity::PeerId, libp2p_rpc_behaviour::Event)),
+    Identify(identify::Event),
+    Kademlia(kad::Event),
+}
+
+#[derive(NetworkBehaviour)]
+#[behaviour(to_swarm = "Libp2pBehaviourEvent")]
+pub struct Libp2pBehaviour {
+    pub gossipsub: gossipsub::Behaviour,
+    pub rpc: libp2p_rpc_behaviour::Behaviour,
+    pub identify: identify::Behaviour,
+    pub kademlia: kad::Behaviour<MemoryStore>,
+
+    #[behaviour(ignore)]
+    pub chain_id: String,
+
+    #[behaviour(ignore)]
+    port: u16,
+
+    // TODO(vlad9486): move maps inside `RpcBehaviour`
+    // map msg_id into (tag, version)
+    #[behaviour(ignore)]
+    pub ongoing: BTreeMap<(PeerId, u64), (RpcTag, u32)>,
+    // map from (peer, msg_id) into (stream_id, tag, version)
+    //
+    #[behaviour(ignore)]
+    pub ongoing_incoming: BTreeMap<(PeerId, u64), (StreamId, String, u32)>,
+}
+
+pub(crate) fn create_swarm(
+    secret_key: p2p::identity::SecretKey,
+    port: u16,
+    chain_id: &str,
+) -> Result<Swarm, Box<dyn Error>> {
+    let identity_keys = libp2p::identity::Keypair::ed25519_from_bytes(secret_key.to_bytes())
+        .expect("secret key bytes must be valid");
+
+    let psk = libp2p::pnet::PreSharedKey::new(openmina_core::preshared_key(chain_id));
+    let identify = libp2p::identify::Behaviour::new(libp2p::identify::Config::new(
+        "ipfs/0.1.0".to_string(),
+        identity_keys.public(),
+    ));
+
+    let kademlia = {
+        let peer_id = identity_keys.public().to_peer_id();
+        let kad_config = {
+            let mut c = libp2p::kad::Config::default();
+            c.set_protocol_names(vec![libp2p::StreamProtocol::new("/coda/kad/1.0.0")]);
+            c
+        };
+
+        let mut kademlia = libp2p::kad::Behaviour::with_config(
+            peer_id,
+            libp2p::kad::store::MemoryStore::new(peer_id),
+            kad_config,
+        );
+
+        kademlia.set_mode(Some(libp2p::kad::Mode::Server));
+        kademlia
+    };
+
+    // gossipsub
+    let gossipsub = {
+        let message_authenticity = gossipsub::MessageAuthenticity::Signed(identity_keys.clone());
+        let gossipsub_config = gossipsub::ConfigBuilder::default()
+            .max_transmit_size(1024 * 1024 * 32)
+            .validate_messages()
+            .build()
+            .unwrap();
+        let mut gossipsub: gossipsub::Behaviour =
+            gossipsub::Behaviour::new(message_authenticity, gossipsub_config).unwrap();
+
+        gossipsub
+            .subscribe(&gossipsub::IdentTopic::new("coda/consensus-messages/0.0.1"))
+            .expect("subscribe");
+
+        gossipsub
+    };
+
+    // rpc
+    let rpc = {
+        use mina_p2p_messages::rpc::{
+            AnswerSyncLedgerQueryV2, GetAncestryV2, GetBestTipV2,
+            GetStagedLedgerAuxAndPendingCoinbasesAtHashV2, GetTransitionChainProofV1ForV2,
+            GetTransitionChainV2,
+        };
+
+        libp2p_rpc_behaviour::BehaviourBuilder::default()
+            .register_method::<GetBestTipV2>()
+            .register_method::<GetAncestryV2>()
+            .register_method::<GetStagedLedgerAuxAndPendingCoinbasesAtHashV2>()
+            .register_method::<AnswerSyncLedgerQueryV2>()
+            .register_method::<GetTransitionChainV2>()
+            .register_method::<GetTransitionChainProofV1ForV2>()
+            .build()
+    };
+
+    let behaviour = Libp2pBehaviour {
+        gossipsub,
+        identify,
+        kademlia,
+        rpc,
+        chain_id: chain_id.to_string(),
+        port,
+        ongoing: Default::default(),
+        ongoing_incoming: Default::default(),
+    };
+
+    let swarm = libp2p::SwarmBuilder::with_existing_identity(identity_keys)
+        .with_tokio()
+        .with_other_transport(|key| {
+            let noise_config = libp2p::noise::Config::new(key).unwrap();
+            let mut yamux_config = libp2p::yamux::Config::default();
+
+            yamux_config.set_protocol_name("/coda/yamux/1.0.0");
+
+            let mut base_transport = libp2p::tcp::tokio::Transport::new(
+                libp2p::tcp::Config::default()
+                    .nodelay(true)
+                    .port_reuse(true),
+            );
+
+            base_transport
+                .listen_on(
+                    libp2p::core::transport::ListenerId::next(),
+                    libp2p::multiaddr::multiaddr!(Ip4([127, 0, 0, 1]), Tcp(port)),
+                )
+                .expect("listen");
+
+            base_transport
+                .and_then(move |socket, _| libp2p::pnet::PnetConfig::new(psk).handshake(socket))
+                .upgrade(libp2p::core::upgrade::Version::V1)
+                .authenticate(noise_config)
+                .multiplex(yamux_config)
+                .timeout(Duration::from_secs(60))
+        })?
+        .with_dns()?
+        .with_behaviour(|_| behaviour)?
+        .with_swarm_config(|config| {
+            config.with_idle_connection_timeout(Duration::from_millis(1000))
+        })
+        .build();
+
+    //swarm.behaviour_mut().kademlia.set_mode(Some(Mode::Server));
+
+    Ok(swarm)
+}

--- a/p2p/testing/src/log.rs
+++ b/p2p/testing/src/log.rs
@@ -1,7 +1,31 @@
+use std::{env, sync::atomic::AtomicBool};
+
 use openmina_core::log::inner::Level;
+use tracing::Subscriber;
+use tracing_subscriber::{layer::SubscriberExt, Layer};
 
 lazy_static::lazy_static! {
     pub(crate) static ref LOG: () = initialize_logging();
+
+    pub(crate) static ref ERROR: AtomicBool = Default::default();
+}
+
+/// Tracing subscriber that panics on `Error` level events.
+struct ErrorPanicLayer;
+
+impl<S> Layer<S> for ErrorPanicLayer
+where
+    S: Subscriber,
+{
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        if event.metadata().level() == &Level::ERROR {
+            ERROR.store(true, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
 }
 
 fn initialize_logging() {
@@ -21,12 +45,22 @@ fn initialize_logging() {
         .with_test_writer()
         //.with_timer(ReduxTimer)
         ;
-    let subscriber = builder.finish();
+    let error_panic_layer = env::var("PANIC_ON_TRACING_ERROR")
+        .ok()
+        .and_then(|var| var.parse::<bool>().ok())
+        .unwrap_or(true)
+        .then(|| ErrorPanicLayer);
+    let subscriber = builder.finish().with(error_panic_layer);
     tracing::subscriber::set_global_default(subscriber)
         .expect("global subscriber should be configurable");
 
-    if let Err(err) = tracing_log::LogTracer::init() {
-        eprintln!("cannot initialize log tracing bridge: {err}");
+    if env::var("OPENMINA_LOG_TRACER")
+        .ok()
+        .and_then(|var| var.parse::<bool>().ok())
+        .unwrap_or_default()
+    {
+        if let Err(err) = tracing_log::LogTracer::init() {
+            eprintln!("cannot initialize log tracing bridge: {err}");
+        }
     }
-
 }

--- a/p2p/testing/src/log.rs
+++ b/p2p/testing/src/log.rs
@@ -24,4 +24,9 @@ fn initialize_logging() {
     let subscriber = builder.finish();
     tracing::subscriber::set_global_default(subscriber)
         .expect("global subscriber should be configurable");
+
+    if let Err(err) = tracing_log::LogTracer::init() {
+        eprintln!("cannot initialize log tracing bridge: {err}");
+    }
+
 }

--- a/p2p/testing/src/predicates.rs
+++ b/p2p/testing/src/predicates.rs
@@ -9,13 +9,14 @@ use p2p::PeerId;
 use crate::{
     cluster::{ClusterEvent, NodeId},
     event::RustNodeEvent,
+    libp2p_node::Libp2pEvent,
     rust_node::RustNodeId,
 };
 
 /// Wraps plain function over a cluster event into an async one.
-pub fn async_fn<T, F>(mut f: F) -> impl FnMut(&ClusterEvent) -> Ready<T>
+pub fn async_fn<T, F>(mut f: F) -> impl FnMut(ClusterEvent) -> Ready<T>
 where
-    F: FnMut(&ClusterEvent) -> T,
+    F: FnMut(ClusterEvent) -> T,
 {
     move |event| ready(f(event))
 }
@@ -76,7 +77,7 @@ where
                 } => {
                     println!("{id:?}: new listen addr: {address}");
                     ids.remove(&NodeId::Libp2p(id))
-                },
+                }
                 _ => false,
             } && ids.is_empty(),
         )
@@ -100,6 +101,29 @@ where
                 false
             },
         )
+    }
+}
+
+/// Returns a predicate over cluster events that returns `true` once it is
+/// called at least once for events that represent established connection
+/// between a node and a peer from the `nodes_peers`.
+pub fn all_nodes_peers_are_ready<I>(nodes_peers: I) -> impl FnMut(ClusterEvent) -> Ready<bool>
+where
+    I: IntoIterator<Item = (NodeId, PeerId)>,
+{
+    let mut nodes_peers = BTreeSet::from_iter(nodes_peers.into_iter());
+    move |event| {
+        ready(match event {
+            ClusterEvent::Rust {
+                id,
+                event: RustNodeEvent::PeerConnected { peer_id, .. },
+            } => nodes_peers.remove(&(id.into(), peer_id)) && nodes_peers.is_empty(),
+            ClusterEvent::Libp2p {
+                id,
+                event: Libp2pEvent::ConnectionEstablished { peer_id, .. },
+            } => nodes_peers.remove(&(id.into(), peer_id.into())) && nodes_peers.is_empty(),
+            _ => false,
+        })
     }
 }
 

--- a/p2p/testing/src/service.rs
+++ b/p2p/testing/src/service.rs
@@ -38,9 +38,8 @@ impl ClusterService {
         let mio = {
             let event_sender = event_sender.clone();
             MioService::run(move |mio_event| {
-                event_sender
-                    .send(mio_event.into())
-                    .expect("cannot send mio event")
+                let _ = event_sender.send(mio_event.into());
+                //.expect("cannot send mio event")
             })
         };
         let keypair = libp2p::identity::Keypair::ed25519_from_bytes(secret_key.to_bytes())

--- a/p2p/testing/src/test_node.rs
+++ b/p2p/testing/src/test_node.rs
@@ -1,5 +1,7 @@
 use std::net::IpAddr;
 
+use libp2p::multiaddr::multiaddr;
+use libp2p::Multiaddr;
 use p2p::{
     connection::outgoing::{P2pConnectionOutgoingInitLibp2pOpts, P2pConnectionOutgoingInitOpts},
     PeerId,
@@ -10,11 +12,22 @@ pub trait TestNode {
 
     fn libp2p_port(&self) -> u16;
 
-    fn dial_opts(&self, host: IpAddr) -> P2pConnectionOutgoingInitOpts {
+    fn rust_dial_opts(&self, host: IpAddr) -> P2pConnectionOutgoingInitOpts {
         P2pConnectionOutgoingInitOpts::LibP2P(P2pConnectionOutgoingInitLibp2pOpts {
             peer_id: self.peer_id(),
             host: host.into(),
             port: self.libp2p_port(),
         })
+    }
+
+    fn libp2p_dial_opts(&self, host: IpAddr) -> Multiaddr {
+        match host {
+            IpAddr::V4(ip) => {
+                multiaddr!(Ip4(ip), Tcp(self.libp2p_port()), P2p(self.peer_id()))
+            }
+            IpAddr::V6(ip) => {
+                multiaddr!(Ip6(ip), Tcp(self.libp2p_port()), P2p(self.peer_id()))
+            }
+        }
     }
 }

--- a/p2p/testing/src/utils.rs
+++ b/p2p/testing/src/utils.rs
@@ -193,7 +193,7 @@ where
 /// See [`super::predicates::all_nodes_with_items`].
 pub async fn try_wait_for_all_nodes_with_value<T, I, F>(
     cluster: &mut Cluster,
-    nodes_peers: I,
+    nodes_values: I,
     time: Duration,
     f: F,
 ) -> Result<bool, ClusterEvent>
@@ -205,7 +205,7 @@ where
     cluster
         .try_stream()
         .take_during(time)
-        .try_any(all_nodes_with_value(nodes_peers, f))
+        .try_any(all_nodes_with_value(nodes_values, f))
         .await
 }
 

--- a/p2p/testing/src/utils.rs
+++ b/p2p/testing/src/utils.rs
@@ -113,13 +113,32 @@ where
 
 /// Tries to run the cluster for the specified period of `time`, returning early
 /// true if the specified `nodes` are ready to accept connections.
-pub async fn try_wait_for_all_nodes_to_listen<I>(
+pub async fn wait_for_all_nodes_to_listen<T, I>(
+    cluster: &mut Cluster,
+    nodes: I,
+    time: Duration,
+) -> bool
+where
+    I: IntoIterator<Item = T>,
+    T: Into<NodeId>,
+{
+    cluster
+        .stream()
+        .take_during(time)
+        .any(all_listeners_are_ready(nodes))
+        .await
+}
+
+/// Tries to run the cluster for the specified period of `time`, returning early
+/// true if the specified `nodes` are ready to accept connections.
+pub async fn try_wait_for_all_nodes_to_listen<T, I>(
     cluster: &mut Cluster,
     nodes: I,
     time: Duration,
 ) -> Result<bool, ClusterEvent>
 where
-    I: IntoIterator<Item = NodeId>,
+    I: IntoIterator<Item = T>,
+    T: Into<NodeId>,
 {
     cluster
         .try_stream()
@@ -208,6 +227,8 @@ where
         .try_any(all_nodes_with_value(nodes_values, f))
         .await
 }
+
+
 
 #[cfg(test)]
 mod tests {

--- a/p2p/tests/basic.rs
+++ b/p2p/tests/basic.rs
@@ -10,8 +10,9 @@ use p2p_testing::{
 
 #[tokio::test]
 async fn accept_connection() {
+    const NUM: u16 = 50;
     let mut cluster = ClusterBuilder::new()
-        .ports(11000..11200)
+        .ports_with_len(NUM * 2 + 2)
         .idle_duration(Duration::from_millis(100))
         .start()
         .await

--- a/p2p/tests/connection.rs
+++ b/p2p/tests/connection.rs
@@ -1,0 +1,158 @@
+use std::time::Duration;
+
+use p2p::PeerId;
+use p2p_testing::{
+    cluster::{Cluster, ClusterBuilder},
+    libp2p_node::Libp2pNodeConfig,
+    rust_node::{RustNodeConfig, RustNodeId},
+    utils::{
+        peer_ids, rust_nodes_from_default_config, try_wait_for_nodes_to_connect,
+        wait_for_all_nodes_to_listen,
+    },
+};
+
+/// Asserts that Rust node `id` has a peer `peer_id`, and it is in ready state.
+fn assert_peer_is_ready(cluster: &Cluster, id: RustNodeId, peer_id: PeerId) {
+    let state = cluster.rust_node(id).state();
+    let peer = state.peers.get(&peer_id).expect("peer should exist");
+    assert!(
+        peer.status.as_ready().is_some(),
+        "peer's status should be ready, but it {:#?}",
+        peer.status
+    )
+}
+
+/// Asserts that the Rust node `id` has only one connection, with specified `peer_id`.
+fn assert_single_connection(cluster: &Cluster, id: RustNodeId, peer_id: PeerId) {
+    let state = cluster.rust_node(id).state();
+    let mut found = None;
+    for (addr, conn_state) in &state.network.scheduler.connections {
+        assert!(conn_state.peer_id() == Some(&peer_id), "{addr}: connection peer_id mismatch: {:?}", conn_state.peer_id());
+        assert!(found.is_none(), "should be only one connection");
+        found = Some(conn_state);
+    }
+}
+
+/// Tests that a Rust node can connect to another Rust node.
+#[tokio::test]
+async fn rust_to_rust() -> anyhow::Result<()> {
+    let mut cluster = ClusterBuilder::default()
+        .ports_with_len(10)
+        .total_duration(Duration::from_secs(10))
+        .start()
+        .await?;
+
+    let rust_node = cluster.add_rust_node(RustNodeConfig::default())?;
+    let rust_node1 = cluster.add_rust_node(RustNodeConfig::default())?;
+    let peer_id = cluster.peer_id(rust_node1);
+
+    let listening =
+        wait_for_all_nodes_to_listen(&mut cluster, [rust_node1], Duration::from_secs(2)).await;
+    assert!(listening);
+
+    cluster.connect(rust_node, rust_node1)?;
+
+    let connected =
+        try_wait_for_nodes_to_connect(&mut cluster, [(rust_node, peer_id)], Duration::from_secs(5))
+            .await?;
+    assert!(connected);
+
+    assert_peer_is_ready(&cluster, rust_node, peer_id);
+
+    Ok(())
+}
+
+/// Tests that a Rust node can connect to a libp2p client.
+#[tokio::test]
+async fn rust_to_libp2p() -> anyhow::Result<()> {
+    let mut cluster = ClusterBuilder::default()
+        .ports_with_len(10)
+        .total_duration(Duration::from_secs(10))
+        .start()
+        .await?;
+
+    let rust_node = cluster.add_rust_node(RustNodeConfig::default())?;
+    let libp2p_node = cluster.add_libp2p_node(Libp2pNodeConfig::default())?;
+    let peer_id = cluster.peer_id(libp2p_node);
+
+    let listening =
+        wait_for_all_nodes_to_listen(&mut cluster, [libp2p_node], Duration::from_secs(2)).await;
+    assert!(listening);
+
+    cluster.connect(rust_node, libp2p_node)?;
+
+    let connected =
+        try_wait_for_nodes_to_connect(&mut cluster, [(rust_node, peer_id)], Duration::from_secs(5))
+            .await?;
+    assert!(connected);
+
+    assert_peer_is_ready(&cluster, rust_node, peer_id);
+
+    Ok(())
+}
+
+/// Tests that a libp2p node can connect to a Rust node.
+#[tokio::test]
+#[ignore = "rust-libp2p cannot connect to Rust node"]
+async fn libp2p_to_rust() -> anyhow::Result<()> {
+    let mut cluster = ClusterBuilder::default()
+        .ports_with_len(10)
+        .total_duration(Duration::from_secs(10))
+        .start()
+        .await?;
+
+    let rust_node = cluster.add_rust_node(RustNodeConfig::default())?;
+    let libp2p_node = cluster.add_libp2p_node(Libp2pNodeConfig::default())?;
+    let peer_id = cluster.peer_id(libp2p_node);
+
+    let listening =
+        wait_for_all_nodes_to_listen(&mut cluster, [rust_node], Duration::from_secs(2)).await;
+    assert!(listening);
+
+    cluster.connect(libp2p_node, rust_node)?;
+
+    let connected =
+        try_wait_for_nodes_to_connect(&mut cluster, [(rust_node, peer_id)], Duration::from_secs(5))
+            .await?;
+    assert!(connected);
+
+    assert_peer_is_ready(&cluster, rust_node, peer_id);
+
+    Ok(())
+}
+
+/// Tests that a Rust node can connect to another Rust node.
+#[tokio::test]
+#[ignored = "no duplicate connections detection"]
+async fn mutual_rust_to_rust() -> anyhow::Result<()> {
+    let mut cluster = ClusterBuilder::default()
+        .ports_with_len(10)
+        .total_duration(Duration::from_secs(10))
+        .start()
+        .await?;
+
+    let [node1, node2] = rust_nodes_from_default_config(&mut cluster)?;
+    let [peer_id1, peer_id2] = peer_ids(&cluster, [node1, node2]);
+
+    let listening =
+        wait_for_all_nodes_to_listen(&mut cluster, [node1, node2], Duration::from_secs(2)).await;
+    assert!(listening);
+
+    cluster.connect(node1, node2)?;
+    cluster.connect(node2, node1)?;
+
+    let connected = try_wait_for_nodes_to_connect(
+        &mut cluster,
+        [(node1, peer_id2), (node2, peer_id1)],
+        Duration::from_secs(5),
+    )
+    .await?;
+    assert!(connected);
+
+    assert_peer_is_ready(&cluster, node1, peer_id2);
+    assert_peer_is_ready(&cluster, node2, peer_id1);
+
+    assert_single_connection(&cluster, node1, peer_id2);
+    assert_single_connection(&cluster, node2, peer_id1);
+    Ok(())
+}

--- a/p2p/tests/connection.rs
+++ b/p2p/tests/connection.rs
@@ -2,12 +2,12 @@ use std::time::Duration;
 
 use p2p::PeerId;
 use p2p_testing::{
-    cluster::{Cluster, ClusterBuilder},
+    cluster::{Cluster, ClusterBuilder, NodeId},
     libp2p_node::Libp2pNodeConfig,
     rust_node::{RustNodeConfig, RustNodeId},
     utils::{
-        peer_ids, rust_nodes_from_default_config, try_wait_for_nodes_to_connect,
-        wait_for_all_nodes_to_listen,
+        peer_ids, rust_nodes_from_default_config, try_wait_for_all_nodes_to_connect,
+        try_wait_for_nodes_to_connect, wait_for_all_nodes_to_listen,
     },
 };
 
@@ -25,11 +25,18 @@ fn assert_peer_is_ready(cluster: &Cluster, id: RustNodeId, peer_id: PeerId) {
 /// Asserts that the Rust node `id` has only one connection, with specified `peer_id`.
 fn assert_single_connection(cluster: &Cluster, id: RustNodeId, peer_id: PeerId) {
     let state = cluster.rust_node(id).state();
+    let my_id = cluster.peer_id(id);
     let mut found = None;
     for (addr, conn_state) in &state.network.scheduler.connections {
-        assert!(conn_state.peer_id() == Some(&peer_id), "{addr}: connection peer_id mismatch: {:?}", conn_state.peer_id());
-        assert!(found.is_none(), "should be only one connection");
-        found = Some(conn_state);
+        let conn_peer_id = conn_state.peer_id();
+        assert!(
+            conn_peer_id.is_some(),
+            "{my_id}: non-initialized connection to {addr}"
+        );
+        if conn_peer_id == Some(&peer_id) {
+            assert!(found.is_none(), "should be only one connection");
+            found = Some(conn_state);
+        }
     }
 }
 
@@ -93,7 +100,6 @@ async fn rust_to_libp2p() -> anyhow::Result<()> {
 
 /// Tests that a libp2p node can connect to a Rust node.
 #[tokio::test]
-#[ignore = "rust-libp2p cannot connect to Rust node"]
 async fn libp2p_to_rust() -> anyhow::Result<()> {
     let mut cluster = ClusterBuilder::default()
         .ports_with_len(10)
@@ -123,7 +129,6 @@ async fn libp2p_to_rust() -> anyhow::Result<()> {
 
 /// Tests that a Rust node can connect to another Rust node.
 #[tokio::test]
-#[ignored = "no duplicate connections detection"]
 async fn mutual_rust_to_rust() -> anyhow::Result<()> {
     let mut cluster = ClusterBuilder::default()
         .ports_with_len(10)
@@ -149,10 +154,144 @@ async fn mutual_rust_to_rust() -> anyhow::Result<()> {
     .await?;
     assert!(connected);
 
+    // try_run_cluster(&mut cluster, Duration::from_secs(2)).await?;
+
     assert_peer_is_ready(&cluster, node1, peer_id2);
     assert_peer_is_ready(&cluster, node2, peer_id1);
 
     assert_single_connection(&cluster, node1, peer_id2);
     assert_single_connection(&cluster, node2, peer_id1);
+    Ok(())
+}
+
+/// Tests that a many Rust nodes can connect to each other at the same time.
+#[tokio::test]
+async fn mutual_rust_to_rust_many() -> anyhow::Result<()> {
+    const NUM: u16 = 16;
+    let mut cluster = ClusterBuilder::default()
+        .ports_with_len(NUM * 2)
+        .total_duration(Duration::from_secs(60))
+        .start()
+        .await?;
+
+    let nodes = rust_nodes_from_default_config::<{ NUM as usize }>(&mut cluster)?;
+
+    let node_to_node = nodes.into_iter().flat_map(|node| {
+        nodes
+            .into_iter()
+            .filter_map(move |other_node| (node != other_node).then(|| (node, other_node)))
+    });
+
+    let listening = wait_for_all_nodes_to_listen(&mut cluster, nodes, Duration::from_secs(2)).await;
+    assert!(listening);
+
+    node_to_node
+        .clone()
+        .map(|(n1, n2)| cluster.connect(n1, n2))
+        .collect::<Result<_, _>>()?;
+    let node_to_peer = node_to_node
+        .map(|(n1, n2)| (n1, cluster.peer_id(n2)))
+        .collect::<Vec<_>>();
+
+    let connected =
+        try_wait_for_nodes_to_connect(&mut cluster, node_to_peer.clone(), Duration::from_secs(10))
+            .await?;
+    assert!(connected);
+
+    for (node, peer_id) in node_to_peer {
+        assert_peer_is_ready(&cluster, node, peer_id);
+        assert_single_connection(&cluster, node, peer_id);
+    }
+
+    Ok(())
+}
+
+/// Tests that a Rust node can resolve mutual connection between itself and a libp2p-based node.
+#[tokio::test]
+async fn mutual_rust_to_libp2p() -> anyhow::Result<()> {
+    let mut cluster = ClusterBuilder::default()
+        .ports_with_len(10)
+        .total_duration(Duration::from_secs(10))
+        .start()
+        .await?;
+
+    let rust_node = cluster.add_rust_node(RustNodeConfig::default())?;
+    let libp2p_node = cluster.add_libp2p_node(Libp2pNodeConfig::default())?;
+    let [peer_id1, peer_id2] = peer_ids(
+        &cluster,
+        [NodeId::from(rust_node), NodeId::from(libp2p_node)],
+    );
+
+    let listening = wait_for_all_nodes_to_listen(
+        &mut cluster,
+        [NodeId::from(rust_node), NodeId::from(libp2p_node)],
+        Duration::from_secs(2),
+    )
+    .await;
+    assert!(listening);
+
+    cluster.connect(rust_node, libp2p_node)?;
+    cluster.connect(libp2p_node, rust_node)?;
+
+    let connected = try_wait_for_all_nodes_to_connect(
+        &mut cluster,
+        [(rust_node.into(), peer_id2), (libp2p_node.into(), peer_id1)],
+        Duration::from_secs(5),
+    )
+    .await?;
+    assert!(connected);
+
+    // try_run_cluster(&mut cluster, Duration::from_secs(2)).await?;
+
+    assert_peer_is_ready(&cluster, rust_node, peer_id2);
+
+    assert_single_connection(&cluster, rust_node, peer_id2);
+    Ok(())
+}
+
+/// Tests that a Rust node can resolve mutual connection between itself and a libp2p-based node.
+#[tokio::test]
+#[ignore = "TODO: see https://github.com/openmina/openmina/issues/399"]
+async fn mutual_rust_to_libp2p_port_reuse() -> anyhow::Result<()> {
+    let mut cluster = ClusterBuilder::default()
+        .ports_with_len(10)
+        .total_duration(Duration::from_secs(10))
+        .start()
+        .await?;
+
+    let rust_node = cluster.add_rust_node(RustNodeConfig::default())?;
+    let libp2p_node = cluster.add_libp2p_node(Libp2pNodeConfig {
+        port_reuse: true,
+        ..Default::default()
+    })?;
+    let [peer_id1, peer_id2] = peer_ids(
+        &cluster,
+        [NodeId::from(rust_node), NodeId::from(libp2p_node)],
+    );
+
+    let listening = wait_for_all_nodes_to_listen(
+        &mut cluster,
+        [NodeId::from(rust_node), NodeId::from(libp2p_node)],
+        Duration::from_secs(2),
+    )
+    .await;
+    assert!(listening);
+
+    cluster.connect(rust_node, libp2p_node)?;
+    cluster.connect(libp2p_node, rust_node)?;
+
+    let connected = try_wait_for_all_nodes_to_connect(
+        &mut cluster,
+        [(rust_node.into(), peer_id2), (libp2p_node.into(), peer_id1)],
+        Duration::from_secs(5),
+    )
+    .await?;
+    assert!(connected);
+
+    // try_run_cluster(&mut cluster, Duration::from_secs(2)).await?;
+
+    assert_peer_is_ready(&cluster, rust_node, peer_id2);
+
+    assert_single_connection(&cluster, rust_node, peer_id2);
     Ok(())
 }

--- a/p2p/tests/identify.rs
+++ b/p2p/tests/identify.rs
@@ -1,31 +1,27 @@
 use std::{collections::BTreeSet, time::Duration};
 
-use p2p::{MioEvent, P2pEvent};
+use multiaddr::Multiaddr;
+use p2p::PeerId;
 use p2p_testing::{
-    cluster::ClusterBuilder,
+    cluster::{Cluster, ClusterBuilder, ClusterEvent},
     event::RustNodeEvent,
     futures::TryStreamExt,
-    predicates::{listener_is_ready, peer_is_connected},
-    rust_node::RustNodeConfig,
+    predicates::{async_fn, listener_is_ready, peer_is_connected},
+    rust_node::{RustNodeConfig, RustNodeId},
     stream::ClusterStreamExt,
 };
 
 #[tokio::test]
-async fn rust_node_to_rust_node() {
+async fn rust_node_to_rust_node() -> anyhow::Result<()> {
     let mut cluster = ClusterBuilder::new()
-        .ports(11000..11200)
+        .ports_with_len(10)
         .idle_duration(Duration::from_millis(100))
         .start()
-        .await
-        .expect("should build cluster");
+        .await?;
 
-    let node1 = cluster
-        .add_rust_node(RustNodeConfig::default())
-        .expect("node1");
+    let node1 = cluster.add_rust_node(RustNodeConfig::default())?;
 
-    let node2 = cluster
-        .add_rust_node(RustNodeConfig::default())
-        .expect("node2");
+    let node2 = cluster.add_rust_node(RustNodeConfig::default())?;
 
     let peer_id1 = cluster.rust_node(node1).state().my_id();
     let peer_id2 = cluster.rust_node(node2).state().my_id();
@@ -35,20 +31,18 @@ async fn rust_node_to_rust_node() {
         .try_stream()
         .take_during(Duration::from_secs(2))
         .try_any(listener_is_ready(node1))
-        .await
-        .expect("unexpected error");
+        .await?;
     assert!(listener_is_ready, "node1 should be ready");
 
     // connect node2 to node1
-    cluster.connect(node2, node1).expect("no error");
+    cluster.connect(node2, node1)?;
 
     // wait for node2 to have peer_id1 (node1) as its peer in `ready` state`
     let connected = cluster
         .try_stream()
         .take_during(Duration::from_secs(2))
         .try_any(peer_is_connected(node2, peer_id1))
-        .await
-        .expect("unexpected error");
+        .await?;
     assert!(
         connected,
         "node should be able to connect to {peer_id1}: {connected:?}\nnode state: {:#?}",
@@ -57,60 +51,64 @@ async fn rust_node_to_rust_node() {
 
     {
         let mut not_identified = BTreeSet::from_iter([(node1, peer_id2), (node2, peer_id1)]);
-        let mut addrs = Vec::new();
-        let take_during = cluster.try_stream().take_during(Duration::from_secs(10));
 
         // run the cluster until both nodes have identify data about each other
-        let found = take_during
-            .try_any_with_rust(|id, event, state| {
-                if let RustNodeEvent::P2p {
-                    event: P2pEvent::MioEvent(MioEvent::IncomingDataIsReady(_)),
-                } = event
-                {
-                    for (peer_id, state) in &state.peers {
-                        if state.identify.is_some() && not_identified.remove(&(id, *peer_id)) {
-                            if let Some(identify) = state.identify.as_ref() {
-                                // collect address and peer id to test later
-                                addrs.extend(
-                                    identify
-                                        .listen_addrs
-                                        .iter()
-                                        .map(|addr| (addr.clone(), *peer_id)),
-                                );
-                            }
-                        }
-                    }
-                }
-                // done when both nodes identify themselves
-                not_identified.is_empty()
-            })
-            .await
-            .expect("no errors");
-        assert!(
-            found,
-            "nodes should be identified, but these are not: {not_identified:?}"
-        );
+        let addrs =
+            wait_for_identify(&mut cluster, &mut not_identified, Duration::from_secs(10)).await?;
 
         // for each address provided by identify, create a node and ensure it
         // can connect to that address
-        for (addr, peer_id) in addrs {
+        for (peer_id, addr) in addrs {
             let node = cluster
                 .add_rust_node(RustNodeConfig::default())
                 .expect("no error");
             cluster
-                .connect(node, addr.with_p2p(peer_id.into()).expect("no error"))
+                .connect(
+                    node,
+                    addr.clone().with_p2p(peer_id.into()).expect("no error"),
+                )
                 .expect("no error");
             let connected = cluster
                 .try_stream()
-                .take_during(Duration::from_secs(2))
+                .take_during(Duration::from_secs(5))
                 .try_any(peer_is_connected(node, peer_id))
                 .await
                 .expect("unexpected error");
             assert!(
                 connected,
-                "node should be able to connect to {peer_id}: {connected:?}\nnode state: {:#?}",
+                "node {} should be able to connect to {peer_id} via {addr}: {connected:?}\nnode state: {:#?}", cluster.peer_id(node),
                 cluster.rust_node(node).state().peers.get(&peer_id)
             );
         }
     }
+
+    Ok(())
+}
+
+async fn wait_for_identify(
+    cluster: &mut Cluster,
+    nodes_peers: &mut BTreeSet<(RustNodeId, PeerId)>,
+    time: Duration,
+) -> anyhow::Result<Vec<(PeerId, Multiaddr)>> {
+    let mut addrs = Vec::new();
+    let pred = |event: ClusterEvent| {
+        if let ClusterEvent::Rust {
+            id,
+            event: RustNodeEvent::Identify { peer_id, info },
+        } = event
+        {
+            if nodes_peers.remove(&(id, peer_id)) {
+                addrs.extend(info.listen_addrs.iter().map(|addr| (peer_id, addr.clone())));
+                return nodes_peers.is_empty();
+            }
+        }
+        false
+    };
+    let identified = cluster
+        .try_stream()
+        .take_during(time)
+        .try_any(async_fn(pred))
+        .await?;
+    assert!(identified, "all peers should be identified");
+    Ok(addrs)
 }


### PR DESCRIPTION
To allow Rust node acting as a seed node, we need to capture information about nodes that connect to us and provide information about them using `identify` protocol.