### PR TITLE
fix(ledger): propagate verifier index serde errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,13 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+      - uses: actions-rs/cargo@v1
+        name: check
+        with:
+          command: check
+          args: --all-targets
+        env:
+          RUSTFLAGS: -D warnings
       - uses: actions-rs/clippy-check@v1
         name: clippy
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3655,6 +3655,7 @@ dependencies = [
  "serde_with 3.7.0",
  "sha2 0.10.8",
  "static_assertions",
+ "thiserror",
  "tuple-map",
  "uuid 1.5.0",
  "wasm-bindgen",
@@ -6270,18 +6271,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.58"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+checksum = "579e9083ca58dd9dcf91a9923bb9054071b9ebbd800b342194c9feb0ee89fc18"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.58"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cli/src/commands/snark/precalculate_block_verifier_index_and_srs.rs
+++ b/cli/src/commands/snark/precalculate_block_verifier_index_and_srs.rs
@@ -15,7 +15,8 @@ pub struct PrecalculateBlockVerifierIndexAndSrs {
 
 impl PrecalculateBlockVerifierIndexAndSrs {
     pub fn run(self) -> Result<(), crate::CommandError> {
-        let verifier_index = verifier_index_to_bytes(&get_verifier_index(VerifierKind::Blockchain));
+        let verifier_index =
+            verifier_index_to_bytes(&get_verifier_index(VerifierKind::Blockchain))?;
         let mut hasher = Sha256::new();
         hasher.update(&verifier_index);
         let index_hash = hex::encode(hasher.finalize());

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -70,6 +70,7 @@ crc32fast = "1"
 chrono = "0.4"
 serde_with = "3.6.1"
 anyhow = "1.0.75"
+thiserror = "1.0.60"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }

--- a/ledger/src/proofs/caching.rs
+++ b/ledger/src/proofs/caching.rs
@@ -412,14 +412,26 @@ impl From<&VerifierIndexCached> for VerifierIndex<Pallas> {
     }
 }
 
-pub fn verifier_index_to_bytes(verifier: &VerifierIndex<Pallas>) -> Vec<u8> {
+#[derive(Debug, thiserror::Error)]
+#[error("Error writing verifier index to bytes: {0}")]
+pub struct VerifierIndexToBytesError(#[from] serde_cbor::Error);
+
+pub fn verifier_index_to_bytes(
+    verifier: &VerifierIndex<Pallas>,
+) -> Result<Vec<u8>, VerifierIndexToBytesError> {
     let verifier: VerifierIndexCached = verifier.into();
-    serde_cbor::to_vec(&verifier).unwrap()
+    Ok(serde_cbor::to_vec(&verifier)?)
 }
 
-pub fn verifier_index_from_bytes(bytes: &[u8]) -> VerifierIndex<Pallas> {
-    let verifier: VerifierIndexCached = serde_cbor::from_slice(bytes).unwrap();
-    (&verifier).into()
+#[derive(Debug, thiserror::Error)]
+#[error("Error reading verifier index from bytes: {0}")]
+pub struct VerifierIndexFromBytesError(#[from] serde_cbor::Error);
+
+pub fn verifier_index_from_bytes(
+    bytes: &[u8],
+) -> Result<VerifierIndex<Pallas>, VerifierIndexFromBytesError> {
+    let verifier: VerifierIndexCached = serde_cbor::from_slice(bytes)?;
+    Ok((&verifier).into())
 }
 
 pub fn srs_to_bytes<'a, G>(srs: &'a SRS<G>) -> Vec<u8>

--- a/ledger/src/proofs/verifier_index.rs
+++ b/ledger/src/proofs/verifier_index.rs
@@ -76,11 +76,11 @@ fn read_index(path: &Path, digest: &[u8]) -> anyhow::Result<VerifierIndex<Pallas
     if &d != digest.as_slice() {
         anyhow::bail!("verifier index digest verification failed");
     }
-    Ok(verifier_index_from_bytes(&buf))
+    Ok(verifier_index_from_bytes(&buf)?)
 }
 
 fn write_index(path: &Path, index: &VerifierIndex<Pallas>, digest: &[u8]) -> anyhow::Result<()> {
-    let bytes = verifier_index_to_bytes(index);
+    let bytes = verifier_index_to_bytes(index)?;
     let mut hasher = Sha256::new();
     hasher.update(&bytes);
     let Some(parent) = path.parent() else {

--- a/node/testing/src/scenarios/p2p/basic_connection_handling.rs
+++ b/node/testing/src/scenarios/p2p/basic_connection_handling.rs
@@ -230,7 +230,7 @@ impl MaxNumberOfPeersIncoming {
 
         println!("connecting nodes....");
 
-        for (peer, peer_id) in &peers {
+        for (peer, _peer_id) in &peers {
             connect_rust_nodes(driver.inner_mut(), *peer, node_ut).await;
             let connected = wait_for_connection_event(
                 &mut driver,


### PR DESCRIPTION
Also added a `cargo check`  lint step that will fail if there are warnings.