### PR TITLE
Compute chain id from network configuration at startup.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4300,6 +4300,7 @@ dependencies = [
  "binprot",
  "binprot_derive",
  "lazy_static",
+ "md5",
  "mina-hasher",
  "mina-p2p-messages",
  "multihash 0.18.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,6 +1051,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.8",
  "shellexpand",
+ "time",
  "tokio",
  "tracing",
  "vrf",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -24,6 +24,7 @@ vrf = { workspace = true }
 
 console = "0.15.5"
 clap = { version = "4.3", features = [ "derive", "env" ] }
+time = { version = "0.3", features = ["formatting", "macros", "parsing"] }
 
 openmina-core = { path = "../core" }
 node = { path = "../node", features = ["replay"] }

--- a/cli/src/commands/node/mod.rs
+++ b/cli/src/commands/node/mod.rs
@@ -8,10 +8,10 @@ use std::time::Duration;
 use libp2p_identity::Keypair;
 use mina_p2p_messages::v2::{
     CurrencyFeeStableV1, NonZeroCurvePoint, NonZeroCurvePointUncompressedStableV1,
-    UnsignedExtendedUInt64Int64ForVersionTagsStableV1,
+    UnsignedExtendedUInt32StableV1, UnsignedExtendedUInt64Int64ForVersionTagsStableV1,
 };
 use node::transition_frontier::genesis::GenesisConfig;
-use openmina_core::ChainId;
+use openmina_core::{constants, ChainId};
 use rand::prelude::*;
 
 use redux::SystemTime;
@@ -38,10 +38,6 @@ use node::{
 
 use openmina_node_native::rpc::RpcService;
 use openmina_node_native::{http_server, tracing, NodeService, P2pTaskSpawner, RpcSender};
-
-// old:
-// 3c41383994b87449625df91769dff7b507825c064287d30fada9286f3f1cb15e
-const CHAIN_ID: ChainId = openmina_core::CHAIN_ID;
 
 /// Openmina node
 #[derive(Debug, clap::Args)]
@@ -190,10 +186,20 @@ impl Node {
         let rng_seed = rng.next_u64();
         let srs: Arc<_> = get_srs();
 
-        let transition_frontier = match conf {
-            Some(c) => TransitionFrontierConfig::new(Arc::new(GenesisConfig::DaemonJson(c))),
-            None => TransitionFrontierConfig::new(node::config::BERKELEY_CONFIG.clone()),
+        let genesis_config = match conf {
+            Some(c) => Arc::new(GenesisConfig::DaemonJson(c)),
+            None => node::config::BERKELEY_CONFIG.clone(),
         };
+        let transition_frontier = TransitionFrontierConfig::new(genesis_config.clone());
+        let protocol_constants = genesis_config.protocol_constants()?;
+        let chain_id = ChainId::compute(
+            constants::CONSTRAINT_SYSTEM_DIGESTS.as_slice(),
+            &constants::GENESIS_STATE_HASH,
+            &protocol_constants,
+            constants::PROTOCOL_TRANSACTION_VERSION,
+            constants::PROTOCOL_NETWORK_VERSION,
+            &UnsignedExtendedUInt32StableV1::from(constants::TX_POOL_MAX_SIZE),
+        );
         let config = Config {
             ledger: LedgerConfig {},
             snark: SnarkConfig {
@@ -224,7 +230,7 @@ impl Node {
                 ask_initial_peers_interval: Duration::from_secs(3600),
                 enabled_channels: ChannelId::for_libp2p().collect(),
                 timeouts: P2pTimeouts::default(),
-                chain_id: CHAIN_ID.to_owned(),
+                chain_id: chain_id.to_owned(),
                 peer_discovery: !self.no_peers_discovery,
                 initial_time: SystemTime::now()
                     .duration_since(SystemTime::UNIX_EPOCH)
@@ -246,7 +252,7 @@ impl Node {
         let p2p_service_ctx = <NodeService as P2pServiceWebrtcWithLibp2p>::init(
             Some(self.libp2p_port),
             secret_key.clone(),
-            CHAIN_ID.clone(),
+            chain_id.clone(),
             event_sender.clone(),
             P2pTaskSpawner {},
         );

--- a/cli/src/commands/node/mod.rs
+++ b/cli/src/commands/node/mod.rs
@@ -11,6 +11,7 @@ use mina_p2p_messages::v2::{
     UnsignedExtendedUInt64Int64ForVersionTagsStableV1,
 };
 use node::transition_frontier::genesis::GenesisConfig;
+use openmina_core::ChainId;
 use rand::prelude::*;
 
 use redux::SystemTime;
@@ -40,7 +41,7 @@ use openmina_node_native::{http_server, tracing, NodeService, P2pTaskSpawner, Rp
 
 // old:
 // 3c41383994b87449625df91769dff7b507825c064287d30fada9286f3f1cb15e
-const CHAIN_ID: &'static str = openmina_core::CHAIN_ID;
+const CHAIN_ID: ChainId = openmina_core::CHAIN_ID;
 
 /// Openmina node
 #[derive(Debug, clap::Args)]
@@ -245,7 +246,7 @@ impl Node {
         let p2p_service_ctx = <NodeService as P2pServiceWebrtcWithLibp2p>::init(
             Some(self.libp2p_port),
             secret_key.clone(),
-            CHAIN_ID.to_owned().into_bytes(),
+            CHAIN_ID.clone(),
             event_sender.clone(),
             P2pTaskSpawner {},
         );

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,7 +14,8 @@ binprot = { git = "https://github.com/openmina/binprot-rs", rev = "3f29b25" }
 binprot_derive = { git = "https://github.com/openmina/binprot-rs", rev = "3f29b25" }
 redux = { workspace = true }
 tokio = { version = "1.26", features = ["sync"] }
-time = { version = "0.3", features = ["formatting"] }
+time = { version = "0.3", features = ["formatting", "macros", "parsing"] }
+md5 = "0.7.0"
 multihash = { version = "0.18.1", features = ["blake2b"] }
 openmina-macros = { path = "../macros" }
 

--- a/core/src/chain_id.rs
+++ b/core/src/chain_id.rs
@@ -1,0 +1,66 @@
+use std::fmt::{self, Debug, Display, Formatter};
+use std::num::ParseIntError;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+#[derive(Clone)]
+pub struct ChainId([u8; 32]);
+
+impl ChainId {
+    pub fn as_hex(&self) -> String {
+        format!("{}", self)
+    }
+
+    pub fn from_hex(s: &str) -> Result<ChainId, ParseIntError> {
+        let mut bytes = [0u8; 32];
+        for i in 0..32 {
+            bytes[i] = u8::from_str_radix(&s[i * 2..i * 2 + 2], 16)?;
+        }
+        Ok(ChainId(bytes))
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> ChainId {
+        let mut arr = [0u8; 32];
+        arr.copy_from_slice(&bytes[..32]);
+        ChainId(arr)
+    }
+}
+
+impl Serialize for ChainId {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.as_hex())
+    }
+}
+
+impl<'de> Deserialize<'de> for ChainId {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        ChainId::from_hex(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+impl AsRef<[u8]> for ChainId {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl Display for ChainId {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        for b in self.0 {
+            write!(f, "{:02x}", b)?;
+        }
+        Ok(())
+    }
+}
+
+impl Debug for ChainId {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "ChainId({})", self)
+    }
+}
+
+pub const CHAIN_ID: ChainId = ChainId([
+    0xfd, 0x7d, 0x11, 0x19, 0x73, 0xbf, 0x5a, 0x9e, 0x3e, 0x87, 0x38, 0x4f, 0x56, 0x0f, 0xde, 0xad,
+    0x2f, 0x27, 0x25, 0x89, 0xca, 0x00, 0xb6, 0xd9, 0xe3, 0x57, 0xfc, 0xa9, 0x83, 0x96, 0x31, 0xda,
+]);

--- a/core/src/chain_id.rs
+++ b/core/src/chain_id.rs
@@ -32,7 +32,7 @@ fn hash_genesis_constants(
 ) -> [u8; 32] {
     let mut hasher = Blake2b256::default();
     let genesis_timestamp = OffsetDateTime::from_unix_timestamp_nanos(
-        constants.genesis_state_timestamp.0 .0 .0 as i128,
+        (constants.genesis_state_timestamp.0 .0 .0 * 1000000) as i128,
     )
     .unwrap();
     let time_format =

--- a/core/src/chain_id.rs
+++ b/core/src/chain_id.rs
@@ -1,12 +1,82 @@
+use mina_p2p_messages::v2::{
+    MinaBaseProtocolConstantsCheckedValueStableV1, StateHash, UnsignedExtendedUInt32StableV1,
+};
+use multihash::{Blake2b256, Hasher};
+use time::macros::format_description;
+use time::OffsetDateTime;
+
 use std::fmt::{self, Debug, Display, Formatter};
 use std::num::ParseIntError;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct ChainId([u8; 32]);
 
+fn u8_slice_as_hex(slice: &[u8]) -> String {
+    slice.iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+fn md5_hash(data: u8) -> String {
+    let mut hasher = md5::Context::new();
+    hasher.consume(data.to_string().as_bytes());
+    let hash: Md5 = *hasher.compute();
+    u8_slice_as_hex(&hash)
+}
+
+type Md5 = [u8; 16];
+
+fn hash_genesis_constants(
+    constants: &MinaBaseProtocolConstantsCheckedValueStableV1,
+    tx_pool_max_size: &UnsignedExtendedUInt32StableV1,
+) -> [u8; 32] {
+    let mut hasher = Blake2b256::default();
+    let genesis_timestamp =
+        OffsetDateTime::from_unix_timestamp(constants.genesis_state_timestamp.0 .0 .0 as i64)
+            .unwrap();
+    let time_format =
+        format_description!("[year]-[month]-[day] [hour]:[minute]:[second].[subsecond digits:6]Z");
+    let input = format!(
+        "{}{}{}{}{}{}",
+        constants.k.to_string(),
+        constants.slots_per_epoch.to_string(),
+        constants.slots_per_sub_window.to_string(),
+        constants.delta.to_string(),
+        tx_pool_max_size.to_string(),
+        genesis_timestamp.format(&time_format).unwrap(),
+    );
+    hasher.update(input.as_bytes());
+    hasher.finalize().try_into().unwrap()
+}
+
 impl ChainId {
+    pub fn compute(
+        constraint_system_digests: &[Md5],
+        genesis_state_hash: &StateHash,
+        genesis_constants: &MinaBaseProtocolConstantsCheckedValueStableV1,
+        protocol_transaction_version: u8,
+        protocol_network_version: u8,
+        tx_max_pool_size: &UnsignedExtendedUInt32StableV1,
+    ) -> ChainId {
+        let mut hasher = Blake2b256::default();
+        let constraint_system_hash = constraint_system_digests
+            .iter()
+            .map(|md5| u8_slice_as_hex(md5))
+            .collect::<Vec<String>>()
+            .join("");
+        let genesis_constants_hash = hash_genesis_constants(genesis_constants, tx_max_pool_size);
+        let input = format!(
+            "{}{}{}{}{}",
+            genesis_state_hash,
+            constraint_system_hash,
+            u8_slice_as_hex(&genesis_constants_hash),
+            md5_hash(protocol_transaction_version),
+            md5_hash(protocol_network_version)
+        );
+        hasher.update(input.as_bytes());
+        ChainId(hasher.finalize().try_into().unwrap())
+    }
+
     pub fn as_hex(&self) -> String {
         format!("{}", self)
     }
@@ -64,3 +134,50 @@ pub const CHAIN_ID: ChainId = ChainId([
     0xfd, 0x7d, 0x11, 0x19, 0x73, 0xbf, 0x5a, 0x9e, 0x3e, 0x87, 0x38, 0x4f, 0x56, 0x0f, 0xde, 0xad,
     0x2f, 0x27, 0x25, 0x89, 0xca, 0x00, 0xb6, 0xd9, 0xe3, 0x57, 0xfc, 0xa9, 0x83, 0x96, 0x31, 0xda,
 ]);
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::constants::*;
+    use mina_p2p_messages::v2::{
+        BlockTimeTimeStableV1, UnsignedExtendedUInt64Int64ForVersionTagsStableV1,
+    };
+    use time::format_description::well_known::Rfc3339;
+
+    #[test]
+    fn test_berkeley_chain_id() {
+        // Compute the chain id for the Berkeley network and compare it the real one.
+        let genesis_state_timestamp = OffsetDateTime::parse("2024-02-02T14:01:01Z", &Rfc3339)
+            .unwrap()
+            .unix_timestamp();
+        let genesis_constants = MinaBaseProtocolConstantsCheckedValueStableV1 {
+            k: 290.into(),
+            slots_per_epoch: 7140.into(),
+            slots_per_sub_window: 7.into(),
+            grace_period_slots: 2160.into(),
+            delta: 0.into(),
+            genesis_state_timestamp: BlockTimeTimeStableV1(
+                UnsignedExtendedUInt64Int64ForVersionTagsStableV1(
+                    (genesis_state_timestamp as u64).into(),
+                ),
+            ),
+        };
+        let chain_id = ChainId::compute(
+            CONSTRAINT_SYSTEM_DIGESTS.as_slice(),
+            &genesis_state_hash(),
+            &genesis_constants,
+            PROTOCOL_TRANSACTION_VERSION,
+            PROTOCOL_NETWORK_VERSION,
+            &UnsignedExtendedUInt32StableV1::from(TX_POOL_MAX_SIZE),
+        );
+        assert_eq!(chain_id, CHAIN_ID);
+    }
+
+    #[test]
+    fn test_chain_id_as_hex() {
+        assert_eq!(
+            CHAIN_ID.as_hex(),
+            "fd7d111973bf5a9e3e87384f560fdead2f272589ca00b6d9e357fca9839631da"
+        );
+    }
+}

--- a/core/src/chain_id.rs
+++ b/core/src/chain_id.rs
@@ -31,9 +31,10 @@ fn hash_genesis_constants(
     tx_pool_max_size: &UnsignedExtendedUInt32StableV1,
 ) -> [u8; 32] {
     let mut hasher = Blake2b256::default();
-    let genesis_timestamp =
-        OffsetDateTime::from_unix_timestamp(constants.genesis_state_timestamp.0 .0 .0 as i64)
-            .unwrap();
+    let genesis_timestamp = OffsetDateTime::from_unix_timestamp_nanos(
+        constants.genesis_state_timestamp.0 .0 .0 as i128,
+    )
+    .unwrap();
     let time_format =
         format_description!("[year]-[month]-[day] [hour]:[minute]:[second].[subsecond digits:6]Z");
     let input = format!(
@@ -130,7 +131,7 @@ impl Debug for ChainId {
     }
 }
 
-pub const CHAIN_ID: ChainId = ChainId([
+pub const BERKELEY_CHAIN_ID: ChainId = ChainId([
     0xfd, 0x7d, 0x11, 0x19, 0x73, 0xbf, 0x5a, 0x9e, 0x3e, 0x87, 0x38, 0x4f, 0x56, 0x0f, 0xde, 0xad,
     0x2f, 0x27, 0x25, 0x89, 0xca, 0x00, 0xb6, 0xd9, 0xe3, 0x57, 0xfc, 0xa9, 0x83, 0x96, 0x31, 0xda,
 ]);
@@ -149,7 +150,7 @@ mod test {
         // Compute the chain id for the Berkeley network and compare it the real one.
         let genesis_state_timestamp = OffsetDateTime::parse("2024-02-02T14:01:01Z", &Rfc3339)
             .unwrap()
-            .unix_timestamp();
+            .unix_timestamp_nanos();
         let genesis_constants = MinaBaseProtocolConstantsCheckedValueStableV1 {
             k: 290.into(),
             slots_per_epoch: 7140.into(),
@@ -164,19 +165,19 @@ mod test {
         };
         let chain_id = ChainId::compute(
             CONSTRAINT_SYSTEM_DIGESTS.as_slice(),
-            &genesis_state_hash(),
+            &GENESIS_STATE_HASH,
             &genesis_constants,
             PROTOCOL_TRANSACTION_VERSION,
             PROTOCOL_NETWORK_VERSION,
             &UnsignedExtendedUInt32StableV1::from(TX_POOL_MAX_SIZE),
         );
-        assert_eq!(chain_id, CHAIN_ID);
+        assert_eq!(chain_id, BERKELEY_CHAIN_ID);
     }
 
     #[test]
     fn test_chain_id_as_hex() {
         assert_eq!(
-            CHAIN_ID.as_hex(),
+            BERKELEY_CHAIN_ID.as_hex(),
             "fd7d111973bf5a9e3e87384f560fdead2f272589ca00b6d9e357fca9839631da"
         );
     }

--- a/core/src/chain_id.rs
+++ b/core/src/chain_id.rs
@@ -140,33 +140,14 @@ pub const BERKELEY_CHAIN_ID: ChainId = ChainId([
 mod test {
     use super::*;
     use crate::constants::*;
-    use mina_p2p_messages::v2::{
-        BlockTimeTimeStableV1, UnsignedExtendedUInt64Int64ForVersionTagsStableV1,
-    };
-    use time::format_description::well_known::Rfc3339;
 
     #[test]
     fn test_berkeley_chain_id() {
         // Compute the chain id for the Berkeley network and compare it the real one.
-        let genesis_state_timestamp = OffsetDateTime::parse("2024-02-02T14:01:01Z", &Rfc3339)
-            .unwrap()
-            .unix_timestamp_nanos();
-        let genesis_constants = MinaBaseProtocolConstantsCheckedValueStableV1 {
-            k: 290.into(),
-            slots_per_epoch: 7140.into(),
-            slots_per_sub_window: 7.into(),
-            grace_period_slots: 2160.into(),
-            delta: 0.into(),
-            genesis_state_timestamp: BlockTimeTimeStableV1(
-                UnsignedExtendedUInt64Int64ForVersionTagsStableV1(
-                    (genesis_state_timestamp as u64).into(),
-                ),
-            ),
-        };
         let chain_id = ChainId::compute(
             CONSTRAINT_SYSTEM_DIGESTS.as_slice(),
             &GENESIS_STATE_HASH,
-            &genesis_constants,
+            &PROTOCOL_CONSTANTS,
             PROTOCOL_TRANSACTION_VERSION,
             PROTOCOL_NETWORK_VERSION,
             &UnsignedExtendedUInt32StableV1::from(TX_POOL_MAX_SIZE),

--- a/core/src/constants.rs
+++ b/core/src/constants.rs
@@ -138,7 +138,7 @@ pub fn grace_period_end(constants: &v2::MinaBaseProtocolConstantsCheckedValueSta
     }
 }
 
-pub const DEFAULT_GENESIS_TIMESTAMP: u64 = 1706882461000000000;
+pub const DEFAULT_GENESIS_TIMESTAMP_MILLISECONDS: u64 = 1706882461000;
 
 pub const PROTOCOL_TRANSACTION_VERSION: u8 = 2;
 pub const PROTOCOL_NETWORK_VERSION: u8 = 2;
@@ -172,7 +172,7 @@ lazy_static! {
             delta: 0.into(),
             genesis_state_timestamp: BlockTimeTimeStableV1(
                 UnsignedExtendedUInt64Int64ForVersionTagsStableV1(
-                    (DEFAULT_GENESIS_TIMESTAMP as u64).into(),
+                    (DEFAULT_GENESIS_TIMESTAMP_MILLISECONDS as u64).into(),
                 ),
             ),
         };

--- a/core/src/constants.rs
+++ b/core/src/constants.rs
@@ -5,7 +5,10 @@ use binprot_derive::BinProtWrite;
 use mina_hasher::Fp;
 use mina_p2p_messages::{
     bigint, number,
-    v2::{self, StateHash},
+    v2::{
+        self, BlockTimeTimeStableV1, MinaBaseProtocolConstantsCheckedValueStableV1, StateHash,
+        UnsignedExtendedUInt64Int64ForVersionTagsStableV1,
+    },
 };
 
 pub const GENESIS_PRODUCER_SK: &'static str =
@@ -135,7 +138,7 @@ pub fn grace_period_end(constants: &v2::MinaBaseProtocolConstantsCheckedValueSta
     }
 }
 
-pub const DEFAULT_GENESIS_TIMESTAMP: u64 = 1697558461000;
+pub const DEFAULT_GENESIS_TIMESTAMP: u64 = 1706882461000000000;
 
 pub const PROTOCOL_TRANSACTION_VERSION: u8 = 2;
 pub const PROTOCOL_NETWORK_VERSION: u8 = 2;
@@ -160,4 +163,17 @@ pub const CONSTRAINT_SYSTEM_DIGESTS: [[u8; 16]; 3] = [
 lazy_static! {
     pub static ref GENESIS_STATE_HASH: StateHash =
         StateHash::from_str("3NK512ryRJvj1TUKGgPoGZeHSNbn37e9BbnpyeqHL9tvKLeD8yrY").unwrap();
+    pub static ref PROTOCOL_CONSTANTS: v2::MinaBaseProtocolConstantsCheckedValueStableV1 =
+        MinaBaseProtocolConstantsCheckedValueStableV1 {
+            k: 290.into(),
+            slots_per_epoch: 7140.into(),
+            slots_per_sub_window: 7.into(),
+            grace_period_slots: 2160.into(),
+            delta: 0.into(),
+            genesis_state_timestamp: BlockTimeTimeStableV1(
+                UnsignedExtendedUInt64Int64ForVersionTagsStableV1(
+                    (DEFAULT_GENESIS_TIMESTAMP as u64).into(),
+                ),
+            ),
+        };
 }

--- a/core/src/constants.rs
+++ b/core/src/constants.rs
@@ -1,3 +1,4 @@
+use lazy_static::lazy_static;
 use std::str::FromStr;
 
 use binprot_derive::BinProtWrite;
@@ -134,6 +135,8 @@ pub fn grace_period_end(constants: &v2::MinaBaseProtocolConstantsCheckedValueSta
     }
 }
 
+pub const DEFAULT_GENESIS_TIMESTAMP: u64 = 1697558461000;
+
 pub const PROTOCOL_TRANSACTION_VERSION: u8 = 2;
 pub const PROTOCOL_NETWORK_VERSION: u8 = 2;
 pub const TX_POOL_MAX_SIZE: u32 = 3000;
@@ -154,6 +157,7 @@ pub const CONSTRAINT_SYSTEM_DIGESTS: [[u8; 16]; 3] = [
 ];
 
 // TODO: This should be computed from the genesis state, rather than hard-coded like this.
-pub fn genesis_state_hash() -> StateHash {
-    StateHash::from_str("3NK512ryRJvj1TUKGgPoGZeHSNbn37e9BbnpyeqHL9tvKLeD8yrY").unwrap()
+lazy_static! {
+    pub static ref GENESIS_STATE_HASH: StateHash =
+        StateHash::from_str("3NK512ryRJvj1TUKGgPoGZeHSNbn37e9BbnpyeqHL9tvKLeD8yrY").unwrap();
 }

--- a/core/src/constants.rs
+++ b/core/src/constants.rs
@@ -1,6 +1,11 @@
+use std::str::FromStr;
+
 use binprot_derive::BinProtWrite;
 use mina_hasher::Fp;
-use mina_p2p_messages::{bigint, number, v2};
+use mina_p2p_messages::{
+    bigint, number,
+    v2::{self, StateHash},
+};
 
 pub const GENESIS_PRODUCER_SK: &'static str =
     "EKFKgDtU3rcuFTVSEpmpXSkukjmX4cKefYREi6Sdsk7E7wsT7KRw";
@@ -127,4 +132,28 @@ pub fn grace_period_end(constants: &v2::MinaBaseProtocolConstantsCheckedValueSta
         None => slots,
         Some(fork) => slots + fork.previous_global_slot,
     }
+}
+
+pub const PROTOCOL_TRANSACTION_VERSION: u8 = 2;
+pub const PROTOCOL_NETWORK_VERSION: u8 = 2;
+pub const TX_POOL_MAX_SIZE: u32 = 3000;
+
+pub const CONSTRAINT_SYSTEM_DIGESTS: [[u8; 16]; 3] = [
+    [
+        0xb8, 0x87, 0x9f, 0x67, 0x7f, 0x62, 0x2a, 0x1d, 0x86, 0x64, 0x80, 0x30, 0x70, 0x1f, 0x43,
+        0xe1,
+    ],
+    [
+        0xc2, 0xb8, 0x0e, 0x3b, 0x10, 0x21, 0xe7, 0x78, 0x1d, 0x76, 0x8c, 0xe0, 0x31, 0x7b, 0x3f,
+        0x9c,
+    ],
+    [
+        0x7c, 0xf1, 0x07, 0x1e, 0x7e, 0x55, 0xbe, 0x3f, 0x41, 0x93, 0xbb, 0xd8, 0xa6, 0x67, 0x91,
+        0x4e,
+    ],
+];
+
+// TODO: This should be computed from the genesis state, rather than hard-coded like this.
+pub fn genesis_state_hash() -> StateHash {
+    StateHash::from_str("3NK512ryRJvj1TUKGgPoGZeHSNbn37e9BbnpyeqHL9tvKLeD8yrY").unwrap()
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -12,15 +12,14 @@ pub mod snark;
 
 pub mod consensus;
 
-/// Default chain id, as used by [berkeleynet](https://berkeley.minaexplorer.com/status).
-pub const CHAIN_ID: &'static str =
-    "fd7d111973bf5a9e3e87384f560fdead2f272589ca00b6d9e357fca9839631da";
+mod chain_id;
+pub use chain_id::*;
 
-pub fn preshared_key(chain_id: &str) -> [u8; 32] {
-    use multihash::{Blake2b256, Hasher};
+pub fn preshared_key(chain_id: ChainId) -> [u8; 32] {
+    use multihash::Hasher;
     let mut hasher = Blake2b256::default();
     hasher.update(b"/coda/0.0.1/");
-    hasher.update(chain_id.as_bytes());
+    hasher.update(chain_id.as_hex().as_bytes());
     let hash = hasher.finalize();
     let mut psk_fixed: [u8; 32] = Default::default();
     psk_fixed.copy_from_slice(hash.as_ref());
@@ -28,4 +27,5 @@ pub fn preshared_key(chain_id: &str) -> [u8; 32] {
 }
 
 pub use log::ActionEvent;
+use multihash::Blake2b256;
 pub use openmina_macros::*;

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -144,5 +144,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/node/src/daemon_json/json_genesis.rs
+++ b/node/src/daemon_json/json_genesis.rs
@@ -59,7 +59,7 @@ impl Genesis {
     pub fn genesis_state_timestamp(&self) -> Result<BlockTimeTimeStableV1, time::error::Parse> {
         OffsetDateTime::parse(&self.genesis_state_timestamp, &Rfc3339).map(|dt| {
             BlockTimeTimeStableV1(UnsignedExtendedUInt64Int64ForVersionTagsStableV1(Number(
-                dt.unix_timestamp_nanos() as u64,
+                (dt.unix_timestamp() * 1000) as u64,
             )))
         })
     }

--- a/node/src/daemon_json/json_genesis.rs
+++ b/node/src/daemon_json/json_genesis.rs
@@ -4,20 +4,76 @@ use time::OffsetDateTime;
 
 use mina_p2p_messages::{
     number::Number,
-    v2::{BlockTimeTimeStableV1, UnsignedExtendedUInt64Int64ForVersionTagsStableV1},
+    v2::{
+        BlockTimeTimeStableV1, MinaBaseProtocolConstantsCheckedValueStableV1,
+        UnsignedExtendedUInt32StableV1, UnsignedExtendedUInt64Int64ForVersionTagsStableV1,
+    },
 };
+use openmina_core::constants::PROTOCOL_CONSTANTS;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Genesis {
+    k: Option<u32>,
+    slots_per_epoch: Option<u32>,
+    slots_per_sub_window: Option<u32>,
+    grace_period_slots: Option<u32>,
+    delta: Option<u32>,
     genesis_state_timestamp: String,
 }
 
 impl Genesis {
+    pub fn k(&self) -> UnsignedExtendedUInt32StableV1 {
+        self.k
+            .map(|k| UnsignedExtendedUInt32StableV1(Number(k as u32)))
+            .unwrap_or(PROTOCOL_CONSTANTS.k.clone())
+    }
+
+    pub fn slots_per_epoch(&self) -> UnsignedExtendedUInt32StableV1 {
+        self.slots_per_epoch
+            .map(|slots_per_epoch| UnsignedExtendedUInt32StableV1(Number(slots_per_epoch as u32)))
+            .unwrap_or(PROTOCOL_CONSTANTS.slots_per_epoch.clone())
+    }
+
+    pub fn slots_per_sub_window(&self) -> UnsignedExtendedUInt32StableV1 {
+        self.slots_per_sub_window
+            .map(|slots_per_sub_window| {
+                UnsignedExtendedUInt32StableV1(Number(slots_per_sub_window as u32))
+            })
+            .unwrap_or(PROTOCOL_CONSTANTS.slots_per_sub_window.clone())
+    }
+
+    pub fn grace_period_slots(&self) -> UnsignedExtendedUInt32StableV1 {
+        self.grace_period_slots
+            .map(|grace_period_slots| {
+                UnsignedExtendedUInt32StableV1(Number(grace_period_slots as u32))
+            })
+            .unwrap_or(PROTOCOL_CONSTANTS.grace_period_slots.clone())
+    }
+
+    pub fn delta(&self) -> UnsignedExtendedUInt32StableV1 {
+        self.delta
+            .map(|delta| UnsignedExtendedUInt32StableV1(Number(delta as u32)))
+            .unwrap_or(PROTOCOL_CONSTANTS.delta.clone())
+    }
+
     pub fn genesis_state_timestamp(&self) -> Result<BlockTimeTimeStableV1, time::error::Parse> {
         OffsetDateTime::parse(&self.genesis_state_timestamp, &Rfc3339).map(|dt| {
             BlockTimeTimeStableV1(UnsignedExtendedUInt64Int64ForVersionTagsStableV1(Number(
                 dt.unix_timestamp_nanos() as u64,
             )))
+        })
+    }
+
+    pub fn protocol_constants(
+        &self,
+    ) -> Result<MinaBaseProtocolConstantsCheckedValueStableV1, time::error::Parse> {
+        Ok(MinaBaseProtocolConstantsCheckedValueStableV1 {
+            k: self.k(),
+            slots_per_epoch: self.slots_per_epoch(),
+            slots_per_sub_window: self.slots_per_sub_window(),
+            grace_period_slots: self.grace_period_slots(),
+            delta: self.delta(),
+            genesis_state_timestamp: self.genesis_state_timestamp()?,
         })
     }
 }

--- a/node/src/daemon_json/json_genesis.rs
+++ b/node/src/daemon_json/json_genesis.rs
@@ -16,7 +16,7 @@ impl Genesis {
     pub fn genesis_state_timestamp(&self) -> Result<BlockTimeTimeStableV1, time::error::Parse> {
         OffsetDateTime::parse(&self.genesis_state_timestamp, &Rfc3339).map(|dt| {
             BlockTimeTimeStableV1(UnsignedExtendedUInt64Int64ForVersionTagsStableV1(Number(
-                dt.unix_timestamp() as u64 * 1_000,
+                dt.unix_timestamp_nanos() as u64,
             )))
         })
     }

--- a/node/src/transition_frontier/genesis/transition_frontier_genesis_config.rs
+++ b/node/src/transition_frontier/genesis/transition_frontier_genesis_config.rs
@@ -4,7 +4,7 @@ use crate::account::AccountSecretKey;
 use ledger::{scan_state::currency::Balance, Account, BaseLedger};
 use mina_hasher::Fp;
 use mina_p2p_messages::{binprot::BinProtRead, v2};
-use openmina_core::constants::{CONSTRAINT_CONSTANTS, DEFAULT_GENESIS_TIMESTAMP};
+use openmina_core::constants::{CONSTRAINT_CONSTANTS, DEFAULT_GENESIS_TIMESTAMP_MILLISECONDS};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -69,7 +69,7 @@ impl GenesisConfig {
                     .as_ref()
                     .map(|g: &daemon_json::Genesis| g.genesis_state_timestamp().map(|t| t.0 .0 .0))
                     .transpose()?
-                    .unwrap_or(DEFAULT_GENESIS_TIMESTAMP);
+                    .unwrap_or(DEFAULT_GENESIS_TIMESTAMP_MILLISECONDS);
                 Ok(Self::default_constants(genesis_timestamp))
             }
         }

--- a/node/src/transition_frontier/genesis/transition_frontier_genesis_config.rs
+++ b/node/src/transition_frontier/genesis/transition_frontier_genesis_config.rs
@@ -1,11 +1,10 @@
 use std::borrow::Cow;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::account::AccountSecretKey;
 use ledger::{scan_state::currency::Balance, Account, BaseLedger};
 use mina_hasher::Fp;
 use mina_p2p_messages::{binprot::BinProtRead, v2};
-use openmina_core::constants::CONSTRAINT_CONSTANTS;
+use openmina_core::constants::{CONSTRAINT_CONSTANTS, DEFAULT_GENESIS_TIMESTAMP};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -56,6 +55,23 @@ impl GenesisConfig {
             genesis_state_timestamp: v2::BlockTimeTimeStableV1(
                 v2::UnsignedExtendedUInt64Int64ForVersionTagsStableV1(timestamp_ms.into()),
             ),
+        }
+    }
+
+    pub fn protocol_constants(&self) -> Result<ProtocolConstants, time::error::Parse> {
+        match self {
+            Self::Counts { constants, .. }
+            | Self::BalancesDelegateTable { constants, .. }
+            | Self::AccountsBinProt { constants, .. } => Ok(constants.clone()),
+            Self::DaemonJson(config) => {
+                let genesis_timestamp = config
+                    .genesis
+                    .as_ref()
+                    .map(|g: &daemon_json::Genesis| g.genesis_state_timestamp().map(|t| t.0 .0 .0))
+                    .transpose()?
+                    .unwrap_or(DEFAULT_GENESIS_TIMESTAMP);
+                Ok(Self::default_constants(genesis_timestamp))
+            }
         }
     }
 
@@ -135,18 +151,7 @@ impl GenesisConfig {
                 (mask, load_result)
             }
             Self::DaemonJson(config) => {
-                let genesis_timestamp = config
-                    .genesis
-                    .as_ref()
-                    .map(|g: &daemon_json::Genesis| g.genesis_state_timestamp().map(|t| t.0 .0 .0))
-                    .transpose()?
-                    .unwrap_or_else(|| {
-                        SystemTime::now()
-                            .duration_since(UNIX_EPOCH)
-                            .unwrap()
-                            .as_millis() as u64
-                    });
-                let constants = Self::default_constants(genesis_timestamp);
+                let constants = self.protocol_constants()?;
                 let ledger = config
                     .ledger
                     .as_ref()

--- a/node/testing/src/cluster/mod.rs
+++ b/node/testing/src/cluster/mod.rs
@@ -3,6 +3,7 @@ pub use config::{ClusterConfig, ProofKind};
 
 mod p2p_task_spawner;
 use node::account::{AccountPublicKey, AccountSecretKey};
+use openmina_core::ChainId;
 pub use p2p_task_spawner::P2pTaskSpawner;
 
 mod node_id;
@@ -130,7 +131,7 @@ pub struct Cluster {
     nodes: Vec<Node>,
     ocaml_nodes: Vec<Option<OcamlNode>>,
     // TODO: remove option if this is viable in the future
-    chain_id: Option<String>,
+    chain_id: Option<ChainId>,
     initial_time: Option<redux::Timestamp>,
 
     rpc_counter: usize,
@@ -199,7 +200,7 @@ impl Cluster {
             .or_else(|| DETERMINISTIC_ACCOUNT_SEC_KEYS.get(pub_key))
     }
 
-    pub fn set_chain_id(&mut self, chain_id: String) {
+    pub fn set_chain_id(&mut self, chain_id: ChainId) {
         self.chain_id = Some(chain_id)
     }
 
@@ -207,7 +208,7 @@ impl Cluster {
         self.initial_time = Some(initial_time)
     }
 
-    pub fn get_chain_id(&self) -> Option<String> {
+    pub fn get_chain_id(&self) -> Option<ChainId> {
         self.chain_id.clone()
     }
 
@@ -291,7 +292,7 @@ impl Cluster {
                 ask_initial_peers_interval: testing_config.ask_initial_peers_interval,
                 enabled_channels: ChannelId::iter_all().collect(),
                 timeouts: testing_config.timeouts,
-                chain_id: String::from_utf8(testing_config.chain_id.clone()).expect("hex string"),
+                chain_id: testing_config.chain_id.clone(),
                 peer_discovery: true,
                 initial_time: Duration::ZERO,
             },

--- a/node/testing/src/node/ocaml/mod.rs
+++ b/node/testing/src/node/ocaml/mod.rs
@@ -5,6 +5,7 @@ use node::p2p::{
     connection::outgoing::{P2pConnectionOutgoingInitLibp2pOpts, P2pConnectionOutgoingInitOpts},
     PeerId,
 };
+use openmina_core::ChainId;
 
 use std::{
     path::{Path, PathBuf},
@@ -288,23 +289,23 @@ impl OcamlNode {
     }
 
     /// Queries graphql to get chain_id.
-    pub fn chain_id(&self) -> anyhow::Result<String> {
+    pub fn chain_id(&self) -> anyhow::Result<ChainId> {
         let res = self.grapql_query("query { daemonStatus { chainId } }")?;
-        res["data"]["daemonStatus"]["chainId"]
+        let chain_id = res["data"]["daemonStatus"]["chainId"]
             .as_str()
-            .map(|s| s.to_owned())
-            .ok_or_else(|| anyhow::anyhow!("empty chain_id response"))
+            .ok_or_else(|| anyhow::anyhow!("empty chain_id response"))?;
+        ChainId::from_hex(chain_id).map_err(|e| anyhow::anyhow!("invalid chain_id: {}", e))
     }
 
     /// Queries graphql to get chain_id.
-    pub async fn chain_id_async(&self) -> anyhow::Result<String> {
+    pub async fn chain_id_async(&self) -> anyhow::Result<ChainId> {
         let res = self
             .grapql_query_async("query { daemonStatus { chainId } }")
             .await?;
-        res["data"]["daemonStatus"]["chainId"]
+        let chain_id = res["data"]["daemonStatus"]["chainId"]
             .as_str()
-            .map(|s| s.to_owned())
-            .ok_or_else(|| anyhow::anyhow!("empty chain_id response"))
+            .ok_or_else(|| anyhow::anyhow!("empty chain_id response"))?;
+        ChainId::from_hex(chain_id).map_err(|e| anyhow::anyhow!("invalid chain_id: {}", e))
     }
 
     /// Queries graphql to check if ocaml node is synced,

--- a/node/testing/src/node/rust/config.rs
+++ b/node/testing/src/node/rust/config.rs
@@ -4,7 +4,7 @@ use node::account::AccountSecretKey;
 use node::config::BERKELEY_CONFIG;
 use node::transition_frontier::genesis::GenesisConfig;
 use node::{p2p::P2pTimeouts, BlockProducerConfig, SnarkerConfig};
-use openmina_core::{ChainId, CHAIN_ID};
+use openmina_core::{ChainId, BERKELEY_CHAIN_ID};
 use serde::{Deserialize, Serialize};
 
 use crate::scenario::ListenerNode;
@@ -44,7 +44,7 @@ pub struct RustNodeBlockProducerTestingConfig {
 impl RustNodeTestingConfig {
     pub fn berkeley_default() -> Self {
         Self {
-            chain_id: CHAIN_ID.to_owned(),
+            chain_id: BERKELEY_CHAIN_ID.to_owned(),
             initial_time: redux::Timestamp::ZERO,
             genesis: BERKELEY_CONFIG.clone(),
             max_peers: 100,
@@ -60,7 +60,7 @@ impl RustNodeTestingConfig {
 
     pub fn berkeley_default_no_rpc_timeouts() -> Self {
         Self {
-            chain_id: CHAIN_ID.to_owned(),
+            chain_id: BERKELEY_CHAIN_ID.to_owned(),
             initial_time: redux::Timestamp::ZERO,
             genesis: BERKELEY_CONFIG.clone(),
             max_peers: 100,

--- a/node/testing/src/node/rust/config.rs
+++ b/node/testing/src/node/rust/config.rs
@@ -4,7 +4,7 @@ use node::account::AccountSecretKey;
 use node::config::BERKELEY_CONFIG;
 use node::transition_frontier::genesis::GenesisConfig;
 use node::{p2p::P2pTimeouts, BlockProducerConfig, SnarkerConfig};
-use openmina_core::CHAIN_ID;
+use openmina_core::{ChainId, CHAIN_ID};
 use serde::{Deserialize, Serialize};
 
 use crate::scenario::ListenerNode;
@@ -22,7 +22,7 @@ pub enum TestPeerId {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RustNodeTestingConfig {
-    pub chain_id: Vec<u8>,
+    pub chain_id: ChainId,
     pub initial_time: redux::Timestamp,
     pub genesis: Arc<GenesisConfig>,
     pub max_peers: usize,
@@ -44,7 +44,7 @@ pub struct RustNodeBlockProducerTestingConfig {
 impl RustNodeTestingConfig {
     pub fn berkeley_default() -> Self {
         Self {
-            chain_id: CHAIN_ID.to_owned().into_bytes(),
+            chain_id: CHAIN_ID.to_owned(),
             initial_time: redux::Timestamp::ZERO,
             genesis: BERKELEY_CONFIG.clone(),
             max_peers: 100,
@@ -60,7 +60,7 @@ impl RustNodeTestingConfig {
 
     pub fn berkeley_default_no_rpc_timeouts() -> Self {
         Self {
-            chain_id: CHAIN_ID.as_bytes().to_owned(),
+            chain_id: CHAIN_ID.to_owned(),
             initial_time: redux::Timestamp::ZERO,
             genesis: BERKELEY_CONFIG.clone(),
             max_peers: 100,
@@ -79,8 +79,8 @@ impl RustNodeTestingConfig {
         self
     }
 
-    pub fn chain_id(mut self, s: impl AsRef<[u8]>) -> Self {
-        self.chain_id = s.as_ref().to_owned();
+    pub fn chain_id(mut self, s: &ChainId) -> Self {
+        self.chain_id = s.clone();
         self
     }
 

--- a/node/testing/src/scenarios/cluster_runner.rs
+++ b/node/testing/src/scenarios/cluster_runner.rs
@@ -7,6 +7,7 @@ use std::{
 use ledger::BaseLedger;
 use node::account::{AccountPublicKey, AccountSecretKey};
 use node::{event_source::Event, ledger::LedgerService, ActionKind, ActionWithMeta, State};
+use openmina_core::ChainId;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use time::OffsetDateTime;
 
@@ -117,7 +118,7 @@ impl<'a> ClusterRunner<'a> {
         )
     }
 
-    pub fn get_chain_id(&self) -> Option<String> {
+    pub fn get_chain_id(&self) -> Option<ChainId> {
         self.cluster.get_chain_id()
     }
 
@@ -125,7 +126,7 @@ impl<'a> ClusterRunner<'a> {
         self.cluster.get_initial_time()
     }
 
-    pub fn set_chain_id(&mut self, chain_id: String) {
+    pub fn set_chain_id(&mut self, chain_id: ChainId) {
         self.cluster.set_chain_id(chain_id)
     }
 

--- a/node/testing/src/scenarios/multi_node/vrf_correct_ledgers.rs
+++ b/node/testing/src/scenarios/multi_node/vrf_correct_ledgers.rs
@@ -35,7 +35,7 @@ impl MultiNodeVrfGetCorrectLedgers {
                 .unwrap();
 
         let producer_node = runner.add_rust_node(RustNodeTestingConfig {
-            chain_id: chain_id.into_bytes(),
+            chain_id,
             initial_time,
             genesis: node::config::BERKELEY_CONFIG.clone(),
             max_peers: 100,

--- a/node/testing/src/scenarios/multi_node/vrf_correct_slots.rs
+++ b/node/testing/src/scenarios/multi_node/vrf_correct_slots.rs
@@ -31,7 +31,7 @@ impl MultiNodeVrfGetCorrectSlots {
     pub async fn run(self, mut runner: ClusterRunner<'_>) {
         eprintln!("Running vrf get correct ledgers scenario");
 
-        let chain_id = runner.get_chain_id().unwrap().into_bytes();
+        let chain_id = runner.get_chain_id().unwrap();
         let initial_time = runner.get_initial_time().unwrap();
 
         let (initial_node, _) = runner.nodes_iter().last().unwrap();

--- a/node/testing/src/scenarios/multi_node/vrf_epoch_bounds_correct_ledgers.rs
+++ b/node/testing/src/scenarios/multi_node/vrf_epoch_bounds_correct_ledgers.rs
@@ -33,7 +33,7 @@ pub struct MultiNodeVrfEpochBoundsCorrectLedger;
 impl MultiNodeVrfEpochBoundsCorrectLedger {
     pub async fn run(self, mut runner: ClusterRunner<'_>) {
         let start = tokio::time::Instant::now();
-        let chain_id = runner.get_chain_id().unwrap().into_bytes();
+        let chain_id = runner.get_chain_id().unwrap();
         let initial_time = runner.get_initial_time().unwrap();
 
         let (initial_node, _) = runner.nodes_iter().last().unwrap();

--- a/node/testing/src/scenarios/multi_node/vrf_epoch_bounds_evaluation.rs
+++ b/node/testing/src/scenarios/multi_node/vrf_epoch_bounds_evaluation.rs
@@ -24,7 +24,7 @@ pub struct MultiNodeVrfEpochBoundsEvaluation;
 
 impl MultiNodeVrfEpochBoundsEvaluation {
     pub async fn run(self, mut runner: ClusterRunner<'_>) {
-        let chain_id = runner.get_chain_id().unwrap().into_bytes();
+        let chain_id = runner.get_chain_id().unwrap();
         let initial_time = runner.get_initial_time().unwrap();
 
         let (initial_node, _) = runner.nodes_iter().last().unwrap();

--- a/node/testing/src/scenarios/p2p/kademlia.rs
+++ b/node/testing/src/scenarios/p2p/kademlia.rs
@@ -200,7 +200,9 @@ fn fake_kad_peer(
     identity_key: Keypair,
     port: Option<u16>,
 ) -> anyhow::Result<libp2p::Swarm<Behaviour>> {
-    let psk = PreSharedKey::new(openmina_core::preshared_key(openmina_core::CHAIN_ID));
+    let psk = PreSharedKey::new(openmina_core::preshared_key(
+        openmina_core::BERKELEY_CHAIN_ID,
+    ));
     let _identify = libp2p::identify::Behaviour::new(libp2p::identify::Config::new(
         "ipfs/0.1.0".to_string(),
         identity_key.public(),

--- a/node/testing/src/scenarios/solo_node/sync_to_genesis.rs
+++ b/node/testing/src/scenarios/solo_node/sync_to_genesis.rs
@@ -48,8 +48,7 @@ impl SoloNodeSyncToGenesis {
             .unwrap()
             .chain_id_async()
             .await
-            .unwrap()
-            .into_bytes();
+            .unwrap();
         let rust_node = runner.add_rust_node(RustNodeTestingConfig {
             chain_id,
             initial_time,

--- a/node/testing/src/scenarios/solo_node/sync_to_genesis_custom.rs
+++ b/node/testing/src/scenarios/solo_node/sync_to_genesis_custom.rs
@@ -63,7 +63,7 @@ impl SoloNodeSyncToGenesisCustom {
         runner.set_initial_time(initial_time);
 
         let rust_node = runner.add_rust_node(RustNodeTestingConfig {
-            chain_id: chain_id.into_bytes(),
+            chain_id,
             initial_time,
             genesis: node::config::BERKELEY_CONFIG.clone(),
             max_peers: 100,

--- a/node/testing/src/simulator/mod.rs
+++ b/node/testing/src/simulator/mod.rs
@@ -3,6 +3,7 @@ pub use config::*;
 use mina_p2p_messages::v2::{
     CurrencyFeeStableV1, UnsignedExtendedUInt64Int64ForVersionTagsStableV1,
 };
+use openmina_core::ChainId;
 
 use std::{collections::BTreeSet, time::Duration};
 
@@ -41,9 +42,9 @@ impl Simulator {
         {
             chain_id
         } else if let Some(node) = runner.ocaml_node(ClusterOcamlNodeId::new_unchecked(0)) {
-            node.chain_id_async().await.unwrap().into_bytes()
+            node.chain_id_async().await.unwrap()
         } else {
-            "<unknown_chain_id>".into()
+            ChainId::from_bytes("<unknown chain_id>".as_bytes())
         };
 
         RustNodeTestingConfig {

--- a/p2p/src/network/p2p_network_reducer.rs
+++ b/p2p/src/network/p2p_network_reducer.rs
@@ -1,5 +1,5 @@
 use multiaddr::Multiaddr;
-use openmina_core::error;
+use openmina_core::{error, ChainId};
 
 use crate::{identity::PublicKey, PeerId};
 
@@ -10,7 +10,7 @@ impl P2pNetworkState {
         identity: PublicKey,
         addrs: Vec<Multiaddr>,
         known_peers: Vec<(PeerId, Multiaddr)>,
-        chain_id: &str,
+        chain_id: &ChainId,
         discovery: bool,
     ) -> Self {
         let peer_id = identity.peer_id();
@@ -24,7 +24,7 @@ impl P2pNetworkState {
             Blake2bVar::new(32)
                 .expect("valid constant")
                 .chain(b"/coda/0.0.1/")
-                .chain(chain_id)
+                .chain(chain_id.as_hex())
                 .finalize_variable(&mut key)
                 .expect("good buffer size");
             key.into()

--- a/p2p/src/p2p_config.rs
+++ b/p2p/src/p2p_config.rs
@@ -1,5 +1,6 @@
 use std::{collections::BTreeSet, time::Duration};
 
+use openmina_core::ChainId;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -29,7 +30,7 @@ pub struct P2pConfig {
     pub timeouts: P2pTimeouts,
 
     /// Chain id
-    pub chain_id: String,
+    pub chain_id: ChainId,
 
     /// Use peers discovery.
     pub peer_discovery: bool,

--- a/p2p/src/service_impl/webrtc_with_libp2p.rs
+++ b/p2p/src/service_impl/webrtc_with_libp2p.rs
@@ -1,4 +1,5 @@
 use openmina_core::channels::mpsc;
+use openmina_core::ChainId;
 
 use crate::{
     channels::{ChannelId, ChannelMsg, MsgId, P2pChannelsService},
@@ -28,7 +29,7 @@ pub trait P2pServiceWebrtcWithLibp2p: P2pServiceWebrtc {
     fn init<E: From<P2pEvent> + Send + 'static, S: TaskSpawner>(
         _libp2p_port: Option<u16>,
         secret_key: SecretKey,
-        _chain_id: Vec<u8>,
+        _chain_id: ChainId,
         event_source_sender: mpsc::UnboundedSender<E>,
         spawner: S,
     ) -> P2pServiceCtx {

--- a/p2p/testing/src/cluster.rs
+++ b/p2p/testing/src/cluster.rs
@@ -9,6 +9,7 @@ use std::{
 use derive_builder::UninitializedFieldError;
 use futures::StreamExt;
 use libp2p::{multiaddr::multiaddr, swarm::DialError, Multiaddr};
+use openmina_core::{ChainId, CHAIN_ID};
 use p2p::{
     connection::outgoing::{
         P2pConnectionOutgoingAction, P2pConnectionOutgoingInitLibp2pOpts,
@@ -53,7 +54,7 @@ pub enum NodeId {
 }
 
 pub struct Cluster {
-    chain_id: String,
+    chain_id: ChainId,
     ports: Range<u16>,
     ip: IpAddr,
 
@@ -85,7 +86,7 @@ impl PortsConfig {
 }
 
 pub struct ClusterBuilder {
-    chain_id: String,
+    chain_id: ChainId,
     ports: Option<PortsConfig>,
     ip: IpAddr,
     idle_duration: Duration,
@@ -96,7 +97,7 @@ pub struct ClusterBuilder {
 impl Default for ClusterBuilder {
     fn default() -> Self {
         ClusterBuilder {
-            chain_id: openmina_core::CHAIN_ID.to_string(),
+            chain_id: CHAIN_ID,
             ports: None,
             ip: Ipv4Addr::LOCALHOST.into(),
             idle_duration: Duration::from_millis(100),
@@ -111,7 +112,7 @@ impl ClusterBuilder {
         ClusterBuilder::default()
     }
 
-    pub fn chain_id(mut self, chain_id: String) -> Self {
+    pub fn chain_id(mut self, chain_id: ChainId) -> Self {
         self.chain_id = chain_id;
         self
     }
@@ -414,8 +415,13 @@ impl Cluster {
         let secret_key = Self::secret_key(config.peer_id, node_id.0, LIBP2P_NODE_SIG_BYTE);
         let libp2p_port = self.next_port()?;
 
-        let swarm = create_swarm(secret_key, libp2p_port, config.port_reuse, &self.chain_id)
-            .map_err(|err| Error::Libp2pSwarm(err.to_string()))?;
+        let swarm = create_swarm(
+            secret_key,
+            libp2p_port,
+            config.port_reuse,
+            self.chain_id.clone(),
+        )
+        .map_err(|err| Error::Libp2pSwarm(err.to_string()))?;
         self.libp2p_nodes.push(Libp2pNode::new(swarm));
 
         Ok(node_id)

--- a/p2p/testing/src/cluster.rs
+++ b/p2p/testing/src/cluster.rs
@@ -9,7 +9,7 @@ use std::{
 use derive_builder::UninitializedFieldError;
 use futures::StreamExt;
 use libp2p::{multiaddr::multiaddr, swarm::DialError, Multiaddr};
-use openmina_core::{ChainId, CHAIN_ID};
+use openmina_core::{ChainId, BERKELEY_CHAIN_ID};
 use p2p::{
     connection::outgoing::{
         P2pConnectionOutgoingAction, P2pConnectionOutgoingInitLibp2pOpts,
@@ -97,7 +97,7 @@ pub struct ClusterBuilder {
 impl Default for ClusterBuilder {
     fn default() -> Self {
         ClusterBuilder {
-            chain_id: CHAIN_ID,
+            chain_id: BERKELEY_CHAIN_ID,
             ports: None,
             ip: Ipv4Addr::LOCALHOST.into(),
             idle_duration: Duration::from_millis(100),

--- a/p2p/testing/src/libp2p_node.rs
+++ b/p2p/testing/src/libp2p_node.rs
@@ -6,6 +6,7 @@ use libp2p::{
     Transport,
 };
 use mina_p2p_messages::rpc_kernel::RpcTag;
+use openmina_core::ChainId;
 use p2p::PeerId;
 
 use libp2p_rpc_behaviour::StreamId;
@@ -74,7 +75,7 @@ pub struct Libp2pBehaviour {
     pub kademlia: kad::Behaviour<MemoryStore>,
 
     #[behaviour(ignore)]
-    pub chain_id: String,
+    pub chain_id: ChainId,
 
     #[behaviour(ignore)]
     port: u16,
@@ -93,12 +94,12 @@ pub(crate) fn create_swarm(
     secret_key: p2p::identity::SecretKey,
     port: u16,
     port_reuse: bool,
-    chain_id: &str,
+    chain_id: ChainId,
 ) -> Result<Swarm, Box<dyn Error>> {
     let identity_keys = libp2p::identity::Keypair::ed25519_from_bytes(secret_key.to_bytes())
         .expect("secret key bytes must be valid");
 
-    let psk = libp2p::pnet::PreSharedKey::new(openmina_core::preshared_key(chain_id));
+    let psk = libp2p::pnet::PreSharedKey::new(openmina_core::preshared_key(chain_id.clone()));
     let identify = libp2p::identify::Behaviour::new(libp2p::identify::Config::new(
         "ipfs/0.1.0".to_string(),
         identity_keys.public(),
@@ -163,7 +164,7 @@ pub(crate) fn create_swarm(
         identify,
         kademlia,
         rpc,
-        chain_id: chain_id.to_string(),
+        chain_id,
         port,
         ongoing: Default::default(),
         ongoing_incoming: Default::default(),


### PR DESCRIPTION
Up until now chain id was hard coded in source and so the network could not access different networks without modification and recompilation. With this change the chain id will now be computed at startup. Node still won't be reconfigurable to other networks without recopmpilation, because we can't compute some of the input and still had to hard-code them, but modifying them makes it easier to adapt the code for other networks (it boils down to changing some constants).

Solve: https://github.com/openmina/openmina/issues/397