### PR TITLE
task(p2p): make p2p start on demand

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  RUST_MIN_STACK: 10000000
+
 jobs:
   ledger-tests:
     runs-on: ubuntu-20.04
@@ -62,7 +65,7 @@ jobs:
 
       - name: Test p2p crate
         run: |
-          RUST_MIN_STACK=8388608 cargo test -p p2p --tests
+          cargo test -p p2p --tests
 
 
   build:
@@ -191,7 +194,7 @@ jobs:
 
       - name: Run the test
         run: |
-          RUST_MIN_STACK=8388608 ./${{ matrix.test }} --test-threads=1
+          ./${{ matrix.test }} --test-threads=1
 
   k8s-peers:
     runs-on: ubuntu-20.04
@@ -254,12 +257,14 @@ jobs:
 
       - name: Run the test
         run: |
-          RUST_MIN_STACK=8388608 ./${{ matrix.test }} --test-threads=1
+          ./${{ matrix.test }} --test-threads=1
 
 
   bootstrap-test:
     needs: [ k8s-peers, build ]
     runs-on: ubuntu-20.04
+    container:
+      image: minaprotocol/mina-daemon:2.0.0berkeley-rc1-1551e2f-focal-berkeley
     env:
       PEERS: ${{ needs.k8s-peers.outputs.peers }}
     steps:
@@ -272,7 +277,7 @@ jobs:
         run: |
           set -eu
           chmod +x ./openmina
-          ./openmina node --no-peers-discovery --peers $PEERS |& tee run.log &
+          ./openmina node --config /var/lib/coda/berkeley.json --no-peers-discovery --peers $PEERS 2>&1 | tee run.log &
           PID=$!
           TIME=10
           SLEEP=10

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,6 +1078,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.8",
  "shellexpand",
+ "time",
  "tokio",
  "tracing",
  "vrf",
@@ -4330,7 +4331,9 @@ version = "0.4.0"
 dependencies = [
  "binprot",
  "binprot_derive",
+ "hex",
  "lazy_static",
+ "md5",
  "mina-hasher",
  "mina-p2p-messages",
  "multihash 0.18.1",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -24,6 +24,7 @@ vrf = { workspace = true }
 
 console = "0.15.5"
 clap = { version = "4.3", features = [ "derive", "env" ] }
+time = { version = "0.3", features = ["formatting", "macros", "parsing"] }
 
 openmina-core = { path = "../core" }
 node = { path = "../node", features = ["replay"] }

--- a/cli/src/commands/node/mod.rs
+++ b/cli/src/commands/node/mod.rs
@@ -8,9 +8,10 @@ use std::time::Duration;
 use libp2p_identity::Keypair;
 use mina_p2p_messages::v2::{
     CurrencyFeeStableV1, NonZeroCurvePoint, NonZeroCurvePointUncompressedStableV1,
-    UnsignedExtendedUInt64Int64ForVersionTagsStableV1,
+    UnsignedExtendedUInt32StableV1, UnsignedExtendedUInt64Int64ForVersionTagsStableV1,
 };
 use node::transition_frontier::genesis::GenesisConfig;
+use openmina_core::{constants, ChainId};
 use rand::prelude::*;
 
 use redux::SystemTime;
@@ -37,10 +38,6 @@ use node::{
 
 use openmina_node_native::rpc::RpcService;
 use openmina_node_native::{http_server, tracing, NodeService, P2pTaskSpawner, RpcSender};
-
-// old:
-// 3c41383994b87449625df91769dff7b507825c064287d30fada9286f3f1cb15e
-const CHAIN_ID: &'static str = openmina_core::CHAIN_ID;
 
 /// Openmina node
 #[derive(Debug, clap::Args)]
@@ -189,10 +186,20 @@ impl Node {
         let rng_seed = rng.next_u64();
         let srs: Arc<_> = get_srs();
 
-        let transition_frontier = match conf {
-            Some(c) => TransitionFrontierConfig::new(Arc::new(GenesisConfig::DaemonJson(c))),
-            None => TransitionFrontierConfig::new(node::config::BERKELEY_CONFIG.clone()),
+        let genesis_config = match conf {
+            Some(c) => Arc::new(GenesisConfig::DaemonJson(c)),
+            None => node::config::BERKELEY_CONFIG.clone(),
         };
+        let transition_frontier = TransitionFrontierConfig::new(genesis_config.clone());
+        let protocol_constants = genesis_config.protocol_constants()?;
+        let chain_id = ChainId::compute(
+            constants::CONSTRAINT_SYSTEM_DIGESTS.as_slice(),
+            &constants::GENESIS_STATE_HASH,
+            &protocol_constants,
+            constants::PROTOCOL_TRANSACTION_VERSION,
+            constants::PROTOCOL_NETWORK_VERSION,
+            &UnsignedExtendedUInt32StableV1::from(constants::TX_POOL_MAX_SIZE),
+        );
         let config = Config {
             ledger: LedgerConfig {},
             snark: SnarkConfig {
@@ -223,7 +230,7 @@ impl Node {
                 ask_initial_peers_interval: Duration::from_secs(3600),
                 enabled_channels: ChannelId::for_libp2p().collect(),
                 timeouts: P2pTimeouts::default(),
-                chain_id: CHAIN_ID.to_owned(),
+                chain_id: chain_id.to_owned(),
                 peer_discovery: !self.no_peers_discovery,
                 initial_time: SystemTime::now()
                     .duration_since(SystemTime::UNIX_EPOCH)
@@ -245,7 +252,7 @@ impl Node {
         let p2p_service_ctx = <NodeService as P2pServiceWebrtcWithLibp2p>::init(
             Some(self.libp2p_port),
             secret_key.clone(),
-            CHAIN_ID.to_owned().into_bytes(),
+            chain_id.clone(),
             event_sender.clone(),
             P2pTaskSpawner {},
         );

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,12 +14,14 @@ binprot = { git = "https://github.com/openmina/binprot-rs", rev = "2b5a909" }
 binprot_derive = { git = "https://github.com/openmina/binprot-rs", rev = "2b5a909" }
 redux = { workspace = true }
 tokio = { version = "1.26", features = ["sync"] }
-time = { version = "0.3", features = ["formatting"] }
+time = { version = "0.3", features = ["formatting", "macros", "parsing"] }
+md5 = "0.7.0"
 multihash = { version = "0.18.1", features = ["blake2b"] }
 openmina-macros = { path = "../macros" }
 
 mina-hasher = { workspace = true }
 mina-p2p-messages = { workspace = true }
+hex = "0.4.3"
 
 [dev-dependencies]
 serde_json = { version = "1" }

--- a/core/src/chain_id.rs
+++ b/core/src/chain_id.rs
@@ -27,7 +27,7 @@ fn hash_genesis_constants(
 ) -> [u8; 32] {
     let mut hasher = Blake2b256::default();
     let genesis_timestamp = OffsetDateTime::from_unix_timestamp_nanos(
-        constants.genesis_state_timestamp.0 .0 .0 as i128,
+        (constants.genesis_state_timestamp.0 .0 .0 * 1000000) as i128,
     )
     .unwrap();
     let time_format =

--- a/core/src/chain_id.rs
+++ b/core/src/chain_id.rs
@@ -1,0 +1,150 @@
+use mina_p2p_messages::v2::{
+    MinaBaseProtocolConstantsCheckedValueStableV1, StateHash, UnsignedExtendedUInt32StableV1,
+};
+use multihash::{Blake2b256, Hasher};
+use time::macros::format_description;
+use time::OffsetDateTime;
+
+use std::fmt::{self, Debug, Display, Formatter};
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct ChainId([u8; 32]);
+
+fn md5_hash(data: u8) -> String {
+    let mut hasher = md5::Context::new();
+    hasher.consume(data.to_string().as_bytes());
+    let hash: Md5 = *hasher.compute();
+    hex::encode(&hash)
+}
+
+type Md5 = [u8; 16];
+
+fn hash_genesis_constants(
+    constants: &MinaBaseProtocolConstantsCheckedValueStableV1,
+    tx_pool_max_size: &UnsignedExtendedUInt32StableV1,
+) -> [u8; 32] {
+    let mut hasher = Blake2b256::default();
+    let genesis_timestamp = OffsetDateTime::from_unix_timestamp_nanos(
+        constants.genesis_state_timestamp.0 .0 .0 as i128,
+    )
+    .unwrap();
+    let time_format =
+        format_description!("[year]-[month]-[day] [hour]:[minute]:[second].[subsecond digits:6]Z");
+    hasher.update(constants.k.to_string().as_bytes());
+    hasher.update(constants.slots_per_epoch.to_string().as_bytes());
+    hasher.update(constants.slots_per_sub_window.to_string().as_bytes());
+    hasher.update(constants.delta.to_string().as_bytes());
+    hasher.update(tx_pool_max_size.to_string().as_bytes());
+    hasher.update(genesis_timestamp.format(&time_format).unwrap().as_bytes());
+    hasher.finalize().try_into().unwrap()
+}
+
+impl ChainId {
+    pub fn compute(
+        constraint_system_digests: &[Md5],
+        genesis_state_hash: &StateHash,
+        genesis_constants: &MinaBaseProtocolConstantsCheckedValueStableV1,
+        protocol_transaction_version: u8,
+        protocol_network_version: u8,
+        tx_max_pool_size: &UnsignedExtendedUInt32StableV1,
+    ) -> ChainId {
+        let mut hasher = Blake2b256::default();
+        let constraint_system_hash = constraint_system_digests
+            .iter()
+            .map(|md5| hex::encode(md5))
+            .reduce(|acc, el| acc + &el)
+            .unwrap_or_else(|| String::new());
+        let genesis_constants_hash = hash_genesis_constants(genesis_constants, tx_max_pool_size);
+            hasher.update(genesis_state_hash.to_string().as_bytes());
+            hasher.update(constraint_system_hash.to_string().as_bytes());
+            hasher.update(hex::encode(&genesis_constants_hash).as_bytes());
+            hasher.update(md5_hash(protocol_transaction_version).as_bytes());
+            hasher.update(md5_hash(protocol_network_version).as_bytes());
+        ChainId(hasher.finalize().try_into().unwrap())
+    }
+
+    pub fn to_hex(&self) -> String {
+        hex::encode(&self.0)
+    }
+
+    pub fn from_hex(s: &str) -> Result<ChainId, hex::FromHexError> {
+        let h = hex::decode(s)?;
+        let bs = h[..32]
+            .try_into()
+            .or(Err(hex::FromHexError::InvalidStringLength))?;
+        Ok(ChainId(bs))
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> ChainId {
+        let mut arr = [0u8; 32];
+        arr.copy_from_slice(&bytes[..32]);
+        ChainId(arr)
+    }
+}
+
+impl Serialize for ChainId {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.to_hex())
+    }
+}
+
+impl<'de> Deserialize<'de> for ChainId {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        ChainId::from_hex(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+impl AsRef<[u8]> for ChainId {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl Display for ChainId {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{}", self.to_hex())?;
+        Ok(())
+    }
+}
+
+impl Debug for ChainId {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "ChainId({})", self)
+    }
+}
+
+pub const BERKELEY_CHAIN_ID: ChainId = ChainId([
+    0xfd, 0x7d, 0x11, 0x19, 0x73, 0xbf, 0x5a, 0x9e, 0x3e, 0x87, 0x38, 0x4f, 0x56, 0x0f, 0xde, 0xad,
+    0x2f, 0x27, 0x25, 0x89, 0xca, 0x00, 0xb6, 0xd9, 0xe3, 0x57, 0xfc, 0xa9, 0x83, 0x96, 0x31, 0xda,
+]);
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::constants::*;
+
+    #[test]
+    fn test_berkeley_chain_id() {
+        // Compute the chain id for the Berkeley network and compare it the real one.
+        let chain_id = ChainId::compute(
+            CONSTRAINT_SYSTEM_DIGESTS.as_slice(),
+            &GENESIS_STATE_HASH,
+            &PROTOCOL_CONSTANTS,
+            PROTOCOL_TRANSACTION_VERSION,
+            PROTOCOL_NETWORK_VERSION,
+            &UnsignedExtendedUInt32StableV1::from(TX_POOL_MAX_SIZE),
+        );
+        assert_eq!(chain_id, BERKELEY_CHAIN_ID);
+    }
+
+    #[test]
+    fn test_chain_id_as_hex() {
+        assert_eq!(
+            BERKELEY_CHAIN_ID.to_hex(),
+            "fd7d111973bf5a9e3e87384f560fdead2f272589ca00b6d9e357fca9839631da"
+        );
+    }
+}

--- a/core/src/chain_id.rs
+++ b/core/src/chain_id.rs
@@ -57,12 +57,23 @@ impl ChainId {
             .reduce(|acc, el| acc + &el)
             .unwrap_or_else(|| String::new());
         let genesis_constants_hash = hash_genesis_constants(genesis_constants, tx_max_pool_size);
-            hasher.update(genesis_state_hash.to_string().as_bytes());
-            hasher.update(constraint_system_hash.to_string().as_bytes());
-            hasher.update(hex::encode(&genesis_constants_hash).as_bytes());
-            hasher.update(md5_hash(protocol_transaction_version).as_bytes());
-            hasher.update(md5_hash(protocol_network_version).as_bytes());
+        hasher.update(genesis_state_hash.to_string().as_bytes());
+        hasher.update(constraint_system_hash.to_string().as_bytes());
+        hasher.update(hex::encode(&genesis_constants_hash).as_bytes());
+        hasher.update(md5_hash(protocol_transaction_version).as_bytes());
+        hasher.update(md5_hash(protocol_network_version).as_bytes());
         ChainId(hasher.finalize().try_into().unwrap())
+    }
+
+    /// Computes shared key for libp2p Pnet protocol.
+    pub fn preshared_key(&self) -> [u8; 32] {
+        let mut hasher = Blake2b256::default();
+        hasher.update(b"/coda/0.0.1/");
+        hasher.update(self.to_hex().as_bytes());
+        let hash = hasher.finalize();
+        let mut psk_fixed: [u8; 32] = Default::default();
+        psk_fixed.copy_from_slice(hash.as_ref());
+        psk_fixed
     }
 
     pub fn to_hex(&self) -> String {

--- a/core/src/constants.rs
+++ b/core/src/constants.rs
@@ -138,7 +138,7 @@ pub fn grace_period_end(constants: &v2::MinaBaseProtocolConstantsCheckedValueSta
     }
 }
 
-pub const DEFAULT_GENESIS_TIMESTAMP: u64 = 1706882461000000000;
+pub const DEFAULT_GENESIS_TIMESTAMP_MILLISECONDS: u64 = 1706882461000;
 
 pub const PROTOCOL_TRANSACTION_VERSION: u8 = 2;
 pub const PROTOCOL_NETWORK_VERSION: u8 = 2;
@@ -172,7 +172,7 @@ lazy_static! {
             delta: 0.into(),
             genesis_state_timestamp: BlockTimeTimeStableV1(
                 UnsignedExtendedUInt64Int64ForVersionTagsStableV1(
-                    (DEFAULT_GENESIS_TIMESTAMP as u64).into(),
+                    (DEFAULT_GENESIS_TIMESTAMP_MILLISECONDS as u64).into(),
                 ),
             ),
         };

--- a/core/src/constants.rs
+++ b/core/src/constants.rs
@@ -1,6 +1,15 @@
+use lazy_static::lazy_static;
+use std::str::FromStr;
+
 use binprot_derive::BinProtWrite;
 use mina_hasher::Fp;
-use mina_p2p_messages::{bigint, number, v2};
+use mina_p2p_messages::{
+    bigint, number,
+    v2::{
+        self, BlockTimeTimeStableV1, MinaBaseProtocolConstantsCheckedValueStableV1, StateHash,
+        UnsignedExtendedUInt64Int64ForVersionTagsStableV1,
+    },
+};
 
 pub const GENESIS_PRODUCER_SK: &'static str =
     "EKFKgDtU3rcuFTVSEpmpXSkukjmX4cKefYREi6Sdsk7E7wsT7KRw";
@@ -127,4 +136,44 @@ pub fn grace_period_end(constants: &v2::MinaBaseProtocolConstantsCheckedValueSta
         None => slots,
         Some(fork) => slots + fork.previous_global_slot,
     }
+}
+
+pub const DEFAULT_GENESIS_TIMESTAMP: u64 = 1706882461000000000;
+
+pub const PROTOCOL_TRANSACTION_VERSION: u8 = 2;
+pub const PROTOCOL_NETWORK_VERSION: u8 = 2;
+pub const TX_POOL_MAX_SIZE: u32 = 3000;
+
+pub const CONSTRAINT_SYSTEM_DIGESTS: [[u8; 16]; 3] = [
+    [
+        0xb8, 0x87, 0x9f, 0x67, 0x7f, 0x62, 0x2a, 0x1d, 0x86, 0x64, 0x80, 0x30, 0x70, 0x1f, 0x43,
+        0xe1,
+    ],
+    [
+        0xc2, 0xb8, 0x0e, 0x3b, 0x10, 0x21, 0xe7, 0x78, 0x1d, 0x76, 0x8c, 0xe0, 0x31, 0x7b, 0x3f,
+        0x9c,
+    ],
+    [
+        0x7c, 0xf1, 0x07, 0x1e, 0x7e, 0x55, 0xbe, 0x3f, 0x41, 0x93, 0xbb, 0xd8, 0xa6, 0x67, 0x91,
+        0x4e,
+    ],
+];
+
+// TODO: This should be computed from the genesis state, rather than hard-coded like this.
+lazy_static! {
+    pub static ref GENESIS_STATE_HASH: StateHash =
+        StateHash::from_str("3NK512ryRJvj1TUKGgPoGZeHSNbn37e9BbnpyeqHL9tvKLeD8yrY").unwrap();
+    pub static ref PROTOCOL_CONSTANTS: v2::MinaBaseProtocolConstantsCheckedValueStableV1 =
+        MinaBaseProtocolConstantsCheckedValueStableV1 {
+            k: 290.into(),
+            slots_per_epoch: 7140.into(),
+            slots_per_sub_window: 7.into(),
+            grace_period_slots: 2160.into(),
+            delta: 0.into(),
+            genesis_state_timestamp: BlockTimeTimeStableV1(
+                UnsignedExtendedUInt64Int64ForVersionTagsStableV1(
+                    (DEFAULT_GENESIS_TIMESTAMP as u64).into(),
+                ),
+            ),
+        };
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -12,15 +12,14 @@ pub mod snark;
 
 pub mod consensus;
 
-/// Default chain id, as used by [berkeleynet](https://berkeley.minaexplorer.com/status).
-pub const CHAIN_ID: &'static str =
-    "fd7d111973bf5a9e3e87384f560fdead2f272589ca00b6d9e357fca9839631da";
+mod chain_id;
+pub use chain_id::*;
 
-pub fn preshared_key(chain_id: &str) -> [u8; 32] {
-    use multihash::{Blake2b256, Hasher};
+pub fn preshared_key(chain_id: ChainId) -> [u8; 32] {
+    use multihash::Hasher;
     let mut hasher = Blake2b256::default();
     hasher.update(b"/coda/0.0.1/");
-    hasher.update(chain_id.as_bytes());
+    hasher.update(chain_id.to_hex().as_bytes());
     let hash = hasher.finalize();
     let mut psk_fixed: [u8; 32] = Default::default();
     psk_fixed.copy_from_slice(hash.as_ref());
@@ -28,4 +27,5 @@ pub fn preshared_key(chain_id: &str) -> [u8; 32] {
 }
 
 pub use log::ActionEvent;
+use multihash::Blake2b256;
 pub use openmina_macros::*;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -15,7 +15,7 @@ pub mod consensus;
 mod chain_id;
 pub use chain_id::*;
 
-pub fn preshared_key(chain_id: ChainId) -> [u8; 32] {
+pub fn preshared_key(chain_id: &ChainId) -> [u8; 32] {
     use multihash::Hasher;
     let mut hasher = Blake2b256::default();
     hasher.update(b"/coda/0.0.1/");

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -144,5 +144,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/node/src/action.rs
+++ b/node/src/action.rs
@@ -53,7 +53,7 @@ impl redux::EnablingCondition<crate::State> for CheckTimeoutsAction {}
 
 #[cfg(feature = "replay")]
 impl redux::EnablingCondition<crate::State> for Action {
-    fn is_enabled(&self, _: &crate::State, _time: redux::Timestamp) -> bool {
+    fn is_enabled(&self, _state: &crate::State, _time: redux::Timestamp) -> bool {
         true
     }
 }

--- a/node/src/action_kind.rs
+++ b/node/src/action_kind.rs
@@ -48,7 +48,7 @@ use crate::p2p::network::select::P2pNetworkSelectAction;
 use crate::p2p::network::yamux::P2pNetworkYamuxAction;
 use crate::p2p::network::P2pNetworkAction;
 use crate::p2p::peer::P2pPeerAction;
-use crate::p2p::P2pAction;
+use crate::p2p::{P2pAction, P2pInitializeAction};
 use crate::rpc::RpcAction;
 use crate::snark::block_verify::SnarkBlockVerifyAction;
 use crate::snark::work_verify::SnarkWorkVerifyAction;
@@ -211,6 +211,7 @@ pub enum ActionKind {
     P2pDiscoverySuccess,
     P2pIdentifyNewRequest,
     P2pIdentifyUpdatePeerInformation,
+    P2pInitializeInitialize,
     P2pNetworkIdentifyStreamClose,
     P2pNetworkIdentifyStreamIncomingData,
     P2pNetworkIdentifyStreamNew,
@@ -444,7 +445,7 @@ pub enum ActionKind {
 }
 
 impl ActionKind {
-    pub const COUNT: u16 = 371;
+    pub const COUNT: u16 = 372;
 }
 
 impl std::fmt::Display for ActionKind {
@@ -492,6 +493,7 @@ impl ActionKindGet for EventSourceAction {
 impl ActionKindGet for P2pAction {
     fn kind(&self) -> ActionKind {
         match self {
+            Self::Initialization(a) => a.kind(),
             Self::Connection(a) => a.kind(),
             Self::Disconnection(a) => a.kind(),
             Self::Discovery(a) => a.kind(),
@@ -690,6 +692,14 @@ impl ActionKindGet for WatchedAccountsAction {
             Self::BlockLedgerQuerySuccess { .. } => {
                 ActionKind::WatchedAccountsBlockLedgerQuerySuccess
             }
+        }
+    }
+}
+
+impl ActionKindGet for P2pInitializeAction {
+    fn kind(&self) -> ActionKind {
+        match self {
+            Self::Initialize { .. } => ActionKind::P2pInitializeInitialize,
         }
     }
 }

--- a/node/src/daemon_json/json_genesis.rs
+++ b/node/src/daemon_json/json_genesis.rs
@@ -59,7 +59,7 @@ impl Genesis {
     pub fn genesis_state_timestamp(&self) -> Result<BlockTimeTimeStableV1, time::error::Parse> {
         OffsetDateTime::parse(&self.genesis_state_timestamp, &Rfc3339).map(|dt| {
             BlockTimeTimeStableV1(UnsignedExtendedUInt64Int64ForVersionTagsStableV1(Number(
-                dt.unix_timestamp_nanos() as u64,
+                (dt.unix_timestamp() * 1000) as u64,
             )))
         })
     }

--- a/node/src/daemon_json/json_genesis.rs
+++ b/node/src/daemon_json/json_genesis.rs
@@ -4,20 +4,76 @@ use time::OffsetDateTime;
 
 use mina_p2p_messages::{
     number::Number,
-    v2::{BlockTimeTimeStableV1, UnsignedExtendedUInt64Int64ForVersionTagsStableV1},
+    v2::{
+        BlockTimeTimeStableV1, MinaBaseProtocolConstantsCheckedValueStableV1,
+        UnsignedExtendedUInt32StableV1, UnsignedExtendedUInt64Int64ForVersionTagsStableV1,
+    },
 };
+use openmina_core::constants::PROTOCOL_CONSTANTS;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Genesis {
+    k: Option<u32>,
+    slots_per_epoch: Option<u32>,
+    slots_per_sub_window: Option<u32>,
+    grace_period_slots: Option<u32>,
+    delta: Option<u32>,
     genesis_state_timestamp: String,
 }
 
 impl Genesis {
+    pub fn k(&self) -> UnsignedExtendedUInt32StableV1 {
+        self.k
+            .map(|k| UnsignedExtendedUInt32StableV1(Number(k as u32)))
+            .unwrap_or(PROTOCOL_CONSTANTS.k.clone())
+    }
+
+    pub fn slots_per_epoch(&self) -> UnsignedExtendedUInt32StableV1 {
+        self.slots_per_epoch
+            .map(|slots_per_epoch| UnsignedExtendedUInt32StableV1(Number(slots_per_epoch as u32)))
+            .unwrap_or(PROTOCOL_CONSTANTS.slots_per_epoch.clone())
+    }
+
+    pub fn slots_per_sub_window(&self) -> UnsignedExtendedUInt32StableV1 {
+        self.slots_per_sub_window
+            .map(|slots_per_sub_window| {
+                UnsignedExtendedUInt32StableV1(Number(slots_per_sub_window as u32))
+            })
+            .unwrap_or(PROTOCOL_CONSTANTS.slots_per_sub_window.clone())
+    }
+
+    pub fn grace_period_slots(&self) -> UnsignedExtendedUInt32StableV1 {
+        self.grace_period_slots
+            .map(|grace_period_slots| {
+                UnsignedExtendedUInt32StableV1(Number(grace_period_slots as u32))
+            })
+            .unwrap_or(PROTOCOL_CONSTANTS.grace_period_slots.clone())
+    }
+
+    pub fn delta(&self) -> UnsignedExtendedUInt32StableV1 {
+        self.delta
+            .map(|delta| UnsignedExtendedUInt32StableV1(Number(delta as u32)))
+            .unwrap_or(PROTOCOL_CONSTANTS.delta.clone())
+    }
+
     pub fn genesis_state_timestamp(&self) -> Result<BlockTimeTimeStableV1, time::error::Parse> {
         OffsetDateTime::parse(&self.genesis_state_timestamp, &Rfc3339).map(|dt| {
             BlockTimeTimeStableV1(UnsignedExtendedUInt64Int64ForVersionTagsStableV1(Number(
-                dt.unix_timestamp() as u64 * 1_000,
+                dt.unix_timestamp_nanos() as u64,
             )))
+        })
+    }
+
+    pub fn protocol_constants(
+        &self,
+    ) -> Result<MinaBaseProtocolConstantsCheckedValueStableV1, time::error::Parse> {
+        Ok(MinaBaseProtocolConstantsCheckedValueStableV1 {
+            k: self.k(),
+            slots_per_epoch: self.slots_per_epoch(),
+            slots_per_sub_window: self.slots_per_sub_window(),
+            grace_period_slots: self.grace_period_slots(),
+            delta: self.delta(),
+            genesis_state_timestamp: self.genesis_state_timestamp()?,
         })
     }
 }

--- a/node/src/external_snark_worker/external_snark_worker_effects.rs
+++ b/node/src/external_snark_worker/external_snark_worker_effects.rs
@@ -1,6 +1,6 @@
 use openmina_core::snark::Snark;
 
-use crate::snark_pool::SnarkPoolAction;
+use crate::{p2p_ready, snark_pool::SnarkPoolAction};
 
 use super::{
     available_job_to_snark_worker_spec, ExternalSnarkWorkerAction,
@@ -11,7 +11,7 @@ pub fn external_snark_worker_effects<S: crate::Service>(
     store: &mut crate::Store<S>,
     action: ExternalSnarkWorkerActionWithMeta,
 ) {
-    let (action, _) = action.split();
+    let (action, meta) = action.split();
     match action {
         ExternalSnarkWorkerAction::Start => {
             let Some(config) = &store.state.get().config.snarker else {
@@ -70,6 +70,7 @@ pub fn external_snark_worker_effects<S: crate::Service>(
             let Some(config) = &store.state().config.snarker else {
                 return;
             };
+            let p2p = p2p_ready!(store.state().p2p, meta.time());
             let snarker = config.public_key.clone().into();
             let fee = config.fee.clone();
             let snark = Snark {
@@ -77,7 +78,7 @@ pub fn external_snark_worker_effects<S: crate::Service>(
                 fee,
                 proofs: result.clone(),
             };
-            let sender = store.state().p2p.my_id();
+            let sender = p2p.my_id();
             // Directly add snark to the snark pool as it's produced by us.
             store.dispatch(SnarkPoolAction::WorkAdd { snark, sender });
             store.dispatch(ExternalSnarkWorkerAction::PruneWork);

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -11,7 +11,7 @@ pub mod config;
 pub use config::*;
 
 mod state;
-pub use state::State;
+pub use state::{P2p, State};
 
 mod reducer;
 pub use reducer::reducer;

--- a/node/src/logger/logger_effects.rs
+++ b/node/src/logger/logger_effects.rs
@@ -46,6 +46,7 @@ pub fn logger_effects<S: Service>(store: &Store<S>, action: ActionWithMetaRef<'_
 
     match action {
         Action::P2p(action) => match action {
+            P2pAction::Initialization(action) => action.action_event(&context),
             P2pAction::Connection(action) => match action {
                 P2pConnectionAction::Outgoing(action) => action.action_event(&context),
                 P2pConnectionAction::Incoming(action) => action.action_event(&context),

--- a/node/src/p2p/channels/best_tip/p2p_channels_best_tip_actions.rs
+++ b/node/src/p2p/channels/best_tip/p2p_channels_best_tip_actions.rs
@@ -2,6 +2,6 @@ use super::*;
 
 impl redux::EnablingCondition<crate::State> for P2pChannelsBestTipAction {
     fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
-        self.is_enabled(&state.p2p, time)
+        state.p2p.is_enabled(self, time)
     }
 }

--- a/node/src/p2p/channels/p2p_channels_actions.rs
+++ b/node/src/p2p/channels/p2p_channels_actions.rs
@@ -2,6 +2,6 @@ use super::*;
 
 impl redux::EnablingCondition<crate::State> for P2pChannelsMessageReceivedAction {
     fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
-        self.is_enabled(&state.p2p, time)
+        state.p2p.is_enabled(self, time)
     }
 }

--- a/node/src/p2p/channels/rpc/p2p_channels_rpc_actions.rs
+++ b/node/src/p2p/channels/rpc/p2p_channels_rpc_actions.rs
@@ -2,6 +2,6 @@ use super::*;
 
 impl redux::EnablingCondition<crate::State> for P2pChannelsRpcAction {
     fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
-        self.is_enabled(&state.p2p, time)
+        state.p2p.is_enabled(self, time)
     }
 }

--- a/node/src/p2p/channels/snark/p2p_channels_snark_actions.rs
+++ b/node/src/p2p/channels/snark/p2p_channels_snark_actions.rs
@@ -2,6 +2,6 @@ use super::*;
 
 impl redux::EnablingCondition<crate::State> for P2pChannelsSnarkAction {
     fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
-        self.is_enabled(&state.p2p, time)
+        state.p2p.is_enabled(self, time)
     }
 }

--- a/node/src/p2p/channels/snark_job_commitment/p2p_channels_snark_job_commitment_actions.rs
+++ b/node/src/p2p/channels/snark_job_commitment/p2p_channels_snark_job_commitment_actions.rs
@@ -2,6 +2,6 @@ use super::*;
 
 impl redux::EnablingCondition<crate::State> for P2pChannelsSnarkJobCommitmentAction {
     fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
-        self.is_enabled(&state.p2p, time)
+        state.p2p.is_enabled(self, time)
     }
 }

--- a/node/src/p2p/connection/incoming/p2p_connection_incoming_actions.rs
+++ b/node/src/p2p/connection/incoming/p2p_connection_incoming_actions.rs
@@ -2,6 +2,6 @@ use super::*;
 
 impl redux::EnablingCondition<crate::State> for P2pConnectionIncomingAction {
     fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
-        self.is_enabled(&state.p2p, time)
+        state.p2p.is_enabled(self, time)
     }
 }

--- a/node/src/p2p/connection/outgoing/p2p_connection_outgoing_actions.rs
+++ b/node/src/p2p/connection/outgoing/p2p_connection_outgoing_actions.rs
@@ -2,6 +2,6 @@ use super::*;
 
 impl redux::EnablingCondition<crate::State> for P2pConnectionOutgoingAction {
     fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
-        self.is_enabled(&state.p2p, time)
+        state.p2p.is_enabled(self, time)
     }
 }

--- a/node/src/p2p/disconnection/p2p_disconnection_actions.rs
+++ b/node/src/p2p/disconnection/p2p_disconnection_actions.rs
@@ -2,6 +2,6 @@ use super::*;
 
 impl redux::EnablingCondition<crate::State> for P2pDisconnectionAction {
     fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
-        self.is_enabled(&state.p2p, time)
+        state.p2p.is_enabled(self, time)
     }
 }

--- a/node/src/p2p/discovery/mod.rs
+++ b/node/src/p2p/discovery/mod.rs
@@ -2,6 +2,6 @@ pub use ::p2p::discovery::*;
 
 impl redux::EnablingCondition<crate::State> for P2pDiscoveryAction {
     fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
-        self.is_enabled(&state.p2p, time)
+        state.p2p.is_enabled(self, time)
     }
 }

--- a/node/src/p2p/network/mod.rs
+++ b/node/src/p2p/network/mod.rs
@@ -3,77 +3,77 @@ use p2p::network::identify::{P2pNetworkIdentifyAction, P2pNetworkIdentifyStreamA
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkSchedulerAction {
     fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
-        self.is_enabled(&state.p2p, time)
+        state.p2p.is_enabled(self, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkPnetAction {
     fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
-        self.is_enabled(&state.p2p, time)
+        state.p2p.is_enabled(self, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkSelectAction {
     fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
-        self.is_enabled(&state.p2p, time)
+        state.p2p.is_enabled(self, time)
     }
 }
 impl redux::EnablingCondition<crate::State> for P2pNetworkNoiseAction {
     fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
-        self.is_enabled(&state.p2p, time)
+        state.p2p.is_enabled(self, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkYamuxAction {
     fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
-        self.is_enabled(&state.p2p, time)
+        state.p2p.is_enabled(self, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkRpcAction {
     fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
-        self.is_enabled(&state.p2p, time)
+        state.p2p.is_enabled(self, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkIdentifyStreamAction {
     fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
-        self.is_enabled(&state.p2p, time)
+        state.p2p.is_enabled(self, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkIdentifyAction {
     fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
-        self.is_enabled(&state.p2p, time)
+        state.p2p.is_enabled(self, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkKademliaAction {
     fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
-        self.is_enabled(&state.p2p, time)
+        state.p2p.is_enabled(self, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkKademliaStreamAction {
     fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
-        self.is_enabled(&state.p2p, time)
+        state.p2p.is_enabled(self, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkKadRequestAction {
     fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
-        self.is_enabled(&state.p2p, time)
+        state.p2p.is_enabled(self, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkKadBootstrapAction {
     fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
-        self.is_enabled(&state.p2p, time)
+        state.p2p.is_enabled(self, time)
     }
 }
 
 impl redux::EnablingCondition<crate::State> for P2pNetworkPubsubAction {
     fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
-        self.is_enabled(&state.p2p, time)
+        state.p2p.is_enabled(self, time)
     }
 }

--- a/node/src/p2p/peer/p2p_peer_actions.rs
+++ b/node/src/p2p/peer/p2p_peer_actions.rs
@@ -2,6 +2,6 @@ use super::*;
 
 impl redux::EnablingCondition<crate::State> for P2pPeerAction {
     fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
-        self.is_enabled(&state.p2p, time)
+        state.p2p.is_enabled(self, time)
     }
 }

--- a/node/src/reducer.rs
+++ b/node/src/reducer.rs
@@ -1,4 +1,7 @@
-use crate::{Action, ActionWithMeta, EventSourceAction, State};
+use openmina_core::error;
+use p2p::{P2pAction, P2pInitializeAction};
+
+use crate::{Action, ActionWithMeta, EventSourceAction, P2p, State};
 
 pub fn reducer(state: &mut State, action: &ActionWithMeta) {
     let meta = action.meta().clone();
@@ -9,9 +12,7 @@ pub fn reducer(state: &mut State, action: &ActionWithMeta) {
         },
         Action::EventSource(_) => {}
 
-        Action::P2p(a) => {
-            state.p2p.reducer(meta.with_action(a));
-        }
+        Action::P2p(a) => state.p2p.reduce(meta.with_action(a)),
         Action::Ledger(a) => {
             state.ledger.reducer(meta.with_action(a));
         }
@@ -45,4 +46,23 @@ pub fn reducer(state: &mut State, action: &ActionWithMeta) {
 
     // must be the last.
     state.action_applied(action);
+}
+
+impl P2p {
+    fn reduce(&mut self, action: redux::ActionWithMeta<&P2pAction>) {
+        let (action, meta) = action.split();
+        match action {
+            P2pAction::Initialization(P2pInitializeAction::Initialize { chain_id }) => {
+                if let Err(err) = self.initialize(chain_id) {
+                    error!(meta.time(); summary = "error initializing p2p", error = display(err));
+                }
+            }
+            action => match self {
+                P2p::Pending(_) => {
+                    error!(meta.time(); summary = "p2p is not initialized", action = debug(action))
+                }
+                P2p::Ready(p2p_state) => p2p_state.reducer(meta.with_action(action)),
+            },
+        }
+    }
 }

--- a/node/src/snark_pool/candidate/snark_pool_candidate_actions.rs
+++ b/node/src/snark_pool/candidate/snark_pool_candidate_actions.rs
@@ -63,7 +63,7 @@ impl redux::EnablingCondition<crate::State> for SnarkPoolCandidateAction {
                         .get(*peer_id, &info.job_id)
                         .map_or(true, |v| info > v)
             }
-            SnarkPoolCandidateAction::WorkFetchAll => true,
+            SnarkPoolCandidateAction::WorkFetchAll => state.p2p.ready().is_some(),
             SnarkPoolCandidateAction::WorkFetchInit { peer_id, job_id } => {
                 let is_peer_available = state
                     .p2p

--- a/node/src/state.rs
+++ b/node/src/state.rs
@@ -1,5 +1,6 @@
-use openmina_core::constants::CONSTRAINT_CONSTANTS;
-use redux::{ActionMeta, Timestamp};
+use openmina_core::{constants::CONSTRAINT_CONSTANTS, error, ChainId};
+use p2p::{P2pConfig, P2pPeerState, P2pPeerStatusReady, PeerId};
+use redux::{ActionMeta, EnablingCondition, Timestamp};
 use serde::{Deserialize, Serialize};
 
 pub use crate::block_producer::BlockProducerState;
@@ -20,7 +21,7 @@ pub use crate::Config;
 pub struct State {
     pub config: GlobalConfig,
 
-    pub p2p: P2pState,
+    pub p2p: P2p,
     pub ledger: LedgerState,
     pub snark: SnarkState,
     pub consensus: ConsensusState,
@@ -41,7 +42,7 @@ impl State {
     pub fn new(config: Config) -> Self {
         let now = Timestamp::global_now();
         Self {
-            p2p: P2pState::new(config.p2p),
+            p2p: P2p::Pending(config.p2p),
             ledger: LedgerState::new(config.ledger),
             snark_pool: SnarkPoolState::new(),
             snark: SnarkState::new(config.snark),
@@ -92,5 +93,126 @@ impl State {
         const SLOTS_PER_EPOCH: u32 = 7140;
         let current_global_slot = self.cur_global_slot()?;
         Some(current_global_slot / SLOTS_PER_EPOCH)
+    }
+}
+
+#[serde_with::serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum P2p {
+    Pending(P2pConfig),
+    Ready(P2pState),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum P2pInitializationError {
+    #[error("p2p is already initialized")]
+    AlreadyInitialized,
+}
+
+#[macro_export]
+macro_rules! p2p_ready {
+    ($p2p:expr, $time:expr) => {
+        p2p_ready!($p2p, "", $time)
+    };
+    ($p2p:expr, $reason:expr, $time:expr) => {
+        match $p2p.ready() {
+            Some(v) => v,
+            None => {
+                //panic!("p2p is not ready: {:?}\nline: {}", $reason, line!());
+                openmina_core::error!($time; "p2p is not initialized: {}", $reason);
+                return;
+            }
+        }
+    };
+}
+
+impl P2p {
+    pub fn config(&self) -> &P2pConfig {
+        match self {
+            P2p::Pending(config) => config,
+            P2p::Ready(p2p_state) => &p2p_state.config,
+        }
+    }
+
+    // TODO: add chain id
+    pub fn initialize(&mut self, chain_id: &ChainId) -> Result<(), P2pInitializationError> {
+        let P2p::Pending(config) = self else {
+            return Err(P2pInitializationError::AlreadyInitialized);
+        };
+        *self = P2p::Ready(P2pState::new(config.clone(), chain_id));
+        Ok(())
+    }
+
+    pub fn ready(&self) -> Option<&P2pState> {
+        if let P2p::Ready(state) = self {
+            Some(state)
+        } else {
+            None
+        }
+    }
+
+    pub fn unwrap(&self) -> &P2pState {
+        self.ready().expect("p2p is not initialized")
+    }
+
+    pub fn is_enabled<T>(&self, action: &T, time: Timestamp) -> bool
+    where
+        T: EnablingCondition<P2pState>,
+    {
+        match self {
+            P2p::Pending(_) => false,
+            P2p::Ready(p2p_state) => action.is_enabled(p2p_state, time),
+        }
+    }
+
+    pub fn my_id(&self) -> PeerId {
+        match self {
+            P2p::Pending(config) => &config.identity_pub_key,
+            P2p::Ready(state) => &state.config.identity_pub_key,
+        }
+        .peer_id()
+    }
+
+    pub fn get_peer(&self, peer_id: &PeerId) -> Option<&P2pPeerState> {
+        self.ready().and_then(|p2p| p2p.peers.get(peer_id))
+    }
+
+    pub fn get_ready_peer(&self, peer_id: &PeerId) -> Option<&P2pPeerStatusReady> {
+        self.ready().and_then(|p2p| p2p.get_ready_peer(peer_id))
+    }
+
+    pub fn ready_peers(&self) -> Vec<PeerId> {
+        self.ready_peers_iter()
+            .map(|(peer_id, _)| *peer_id)
+            .collect()
+    }
+
+    pub fn ready_peers_iter(&self) -> ReadyPeersIter {
+        ReadyPeersIter::new(self)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ReadyPeersIter<'a>(Option<std::collections::btree_map::Iter<'a, PeerId, P2pPeerState>>);
+
+impl<'a> ReadyPeersIter<'a> {
+    fn new(p2p: &'a P2p) -> Self {
+        ReadyPeersIter(p2p.ready().map(|p2p| p2p.peers.iter()))
+    }
+}
+
+impl<'a> Iterator for ReadyPeersIter<'a> {
+    type Item = (&'a PeerId, &'a P2pPeerStatusReady);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let Some(iter) = self.0.as_mut() else {
+            return None;
+        };
+        Some(loop {
+            let (peer_id, state) = iter.next()?;
+            if let Some(ready) = state.status.as_ready() {
+                break (peer_id, ready);
+            }
+        })
     }
 }

--- a/node/src/transition_frontier/genesis/transition_frontier_genesis_config.rs
+++ b/node/src/transition_frontier/genesis/transition_frontier_genesis_config.rs
@@ -4,7 +4,7 @@ use crate::account::AccountSecretKey;
 use ledger::{scan_state::currency::Balance, Account, BaseLedger};
 use mina_hasher::Fp;
 use mina_p2p_messages::{binprot::BinProtRead, v2};
-use openmina_core::constants::{CONSTRAINT_CONSTANTS, DEFAULT_GENESIS_TIMESTAMP};
+use openmina_core::constants::{CONSTRAINT_CONSTANTS, DEFAULT_GENESIS_TIMESTAMP_MILLISECONDS};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -69,7 +69,7 @@ impl GenesisConfig {
                     .as_ref()
                     .map(|g: &daemon_json::Genesis| g.genesis_state_timestamp().map(|t| t.0 .0 .0))
                     .transpose()?
-                    .unwrap_or(DEFAULT_GENESIS_TIMESTAMP);
+                    .unwrap_or(DEFAULT_GENESIS_TIMESTAMP_MILLISECONDS);
                 Ok(Self::default_constants(genesis_timestamp))
             }
         }

--- a/node/src/transition_frontier/genesis/transition_frontier_genesis_config.rs
+++ b/node/src/transition_frontier/genesis/transition_frontier_genesis_config.rs
@@ -1,11 +1,10 @@
 use std::borrow::Cow;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::account::AccountSecretKey;
 use ledger::{scan_state::currency::Balance, Account, BaseLedger};
 use mina_hasher::Fp;
 use mina_p2p_messages::{binprot::BinProtRead, v2};
-use openmina_core::constants::CONSTRAINT_CONSTANTS;
+use openmina_core::constants::{CONSTRAINT_CONSTANTS, DEFAULT_GENESIS_TIMESTAMP};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -56,6 +55,23 @@ impl GenesisConfig {
             genesis_state_timestamp: v2::BlockTimeTimeStableV1(
                 v2::UnsignedExtendedUInt64Int64ForVersionTagsStableV1(timestamp_ms.into()),
             ),
+        }
+    }
+
+    pub fn protocol_constants(&self) -> Result<ProtocolConstants, time::error::Parse> {
+        match self {
+            Self::Counts { constants, .. }
+            | Self::BalancesDelegateTable { constants, .. }
+            | Self::AccountsBinProt { constants, .. } => Ok(constants.clone()),
+            Self::DaemonJson(config) => {
+                let genesis_timestamp = config
+                    .genesis
+                    .as_ref()
+                    .map(|g: &daemon_json::Genesis| g.genesis_state_timestamp().map(|t| t.0 .0 .0))
+                    .transpose()?
+                    .unwrap_or(DEFAULT_GENESIS_TIMESTAMP);
+                Ok(Self::default_constants(genesis_timestamp))
+            }
         }
     }
 
@@ -135,18 +151,7 @@ impl GenesisConfig {
                 (mask, load_result)
             }
             Self::DaemonJson(config) => {
-                let genesis_timestamp = config
-                    .genesis
-                    .as_ref()
-                    .map(|g: &daemon_json::Genesis| g.genesis_state_timestamp().map(|t| t.0 .0 .0))
-                    .transpose()?
-                    .unwrap_or_else(|| {
-                        SystemTime::now()
-                            .duration_since(UNIX_EPOCH)
-                            .unwrap()
-                            .as_millis() as u64
-                    });
-                let constants = Self::default_constants(genesis_timestamp);
+                let constants = self.protocol_constants()?;
                 let ledger = config
                     .ledger
                     .as_ref()

--- a/node/src/transition_frontier/sync/ledger/staged/transition_frontier_sync_ledger_staged_actions.rs
+++ b/node/src/transition_frontier/sync/ledger/staged/transition_frontier_sync_ledger_staged_actions.rs
@@ -79,7 +79,10 @@ impl redux::EnablingCondition<crate::State> for TransitionFrontierSyncLedgerStag
                 .ledger()
                 .and_then(|s| s.staged())
                 .map_or(false, |staged| {
-                    let iter = state.p2p.ready_rpc_peers_iter();
+                    let Some(p2p) = state.p2p.ready() else {
+                        return false;
+                    };
+                    let iter = p2p.ready_rpc_peers_iter();
                     staged.filter_available_peers(iter).next().is_some()
                 }),
             TransitionFrontierSyncLedgerStagedAction::PartsPeerFetchPending { .. } => state

--- a/node/src/transition_frontier/sync/ledger/staged/transition_frontier_sync_ledger_staged_effects.rs
+++ b/node/src/transition_frontier/sync/ledger/staged/transition_frontier_sync_ledger_staged_effects.rs
@@ -19,10 +19,13 @@ impl TransitionFrontierSyncLedgerStagedAction {
                 else {
                     return;
                 };
+                let Some(p2p) = state.p2p.ready() else {
+                    return;
+                };
                 let block_hash = staged_ledger.target().staged.block_hash.clone();
 
                 let ready_peers = staged_ledger
-                    .filter_available_peers(state.p2p.ready_rpc_peers_iter())
+                    .filter_available_peers(p2p.ready_rpc_peers_iter())
                     .collect::<Vec<_>>();
 
                 for (peer_id, rpc_id) in ready_peers {

--- a/node/src/transition_frontier/sync/transition_frontier_sync_effects.rs
+++ b/node/src/transition_frontier/sync/transition_frontier_sync_effects.rs
@@ -5,7 +5,7 @@ use redux::ActionMeta;
 use crate::ledger::write::{LedgerWriteAction, LedgerWriteRequest};
 use crate::p2p::channels::rpc::P2pRpcRequest;
 use crate::service::TransitionFrontierSyncLedgerSnarkedService;
-use crate::Store;
+use crate::{p2p_ready, Store};
 
 use super::ledger::snarked::TransitionFrontierSyncLedgerSnarkedAction;
 use super::ledger::staged::TransitionFrontierSyncLedgerStagedAction;
@@ -13,7 +13,7 @@ use super::ledger::{SyncLedgerTarget, TransitionFrontierSyncLedgerAction};
 use super::{TransitionFrontierSyncAction, TransitionFrontierSyncState};
 
 impl TransitionFrontierSyncAction {
-    pub fn effects<S: redux::Service>(&self, _: &ActionMeta, store: &mut Store<S>)
+    pub fn effects<S: redux::Service>(&self, meta: &ActionMeta, store: &mut Store<S>)
     where
         S: TransitionFrontierSyncLedgerSnarkedService,
     {
@@ -107,10 +107,9 @@ impl TransitionFrontierSyncAction {
                 }
             }
             TransitionFrontierSyncAction::BlocksPeersQuery => {
+                let p2p = p2p_ready!(store.state().p2p, meta.time());
                 // TODO(binier): make sure they have the ledger we want to query.
-                let mut peer_ids = store
-                    .state()
-                    .p2p
+                let mut peer_ids = p2p
                     .ready_peers_iter()
                     .filter(|(_, p)| p.channels.rpc.can_send_request())
                     .map(|(id, p)| (*id, p.connected_since))
@@ -149,9 +148,8 @@ impl TransitionFrontierSyncAction {
                 }
             }
             TransitionFrontierSyncAction::BlocksPeerQueryInit { hash, peer_id } => {
-                let Some(rpc_id) = store
-                    .state()
-                    .p2p
+                let p2p = p2p_ready!(store.state().p2p, meta.time());
+                let Some(rpc_id) = p2p
                     .get_ready_peer(peer_id)
                     .map(|v| v.channels.rpc.next_local_rpc_id())
                 else {
@@ -171,9 +169,8 @@ impl TransitionFrontierSyncAction {
                 }
             }
             TransitionFrontierSyncAction::BlocksPeerQueryRetry { hash, peer_id } => {
-                let Some(rpc_id) = store
-                    .state()
-                    .p2p
+                let p2p = p2p_ready!(store.state().p2p, meta.time());
+                let Some(rpc_id) = p2p
                     .get_ready_peer(peer_id)
                     .map(|v| v.channels.rpc.next_local_rpc_id())
                 else {

--- a/node/testing/src/cluster/mod.rs
+++ b/node/testing/src/cluster/mod.rs
@@ -132,7 +132,7 @@ pub struct Cluster {
     nodes: Vec<Node>,
     ocaml_nodes: Vec<Option<OcamlNode>>,
     // TODO: remove option if this is viable in the future
-    chain_id: Option<String>,
+    chain_id: Option<ChainId>,
     initial_time: Option<redux::Timestamp>,
 
     rpc_counter: usize,
@@ -201,7 +201,7 @@ impl Cluster {
             .or_else(|| DETERMINISTIC_ACCOUNT_SEC_KEYS.get(pub_key))
     }
 
-    pub fn set_chain_id(&mut self, chain_id: String) {
+    pub fn set_chain_id(&mut self, chain_id: ChainId) {
         self.chain_id = Some(chain_id)
     }
 
@@ -209,7 +209,7 @@ impl Cluster {
         self.initial_time = Some(initial_time)
     }
 
-    pub fn get_chain_id(&self) -> Option<String> {
+    pub fn get_chain_id(&self) -> Option<ChainId> {
         self.chain_id.clone()
     }
 
@@ -293,7 +293,7 @@ impl Cluster {
                 ask_initial_peers_interval: testing_config.ask_initial_peers_interval,
                 enabled_channels: ChannelId::iter_all().collect(),
                 timeouts: testing_config.timeouts,
-                chain_id: String::from_utf8(testing_config.chain_id.clone()).expect("hex string"),
+                chain_id: testing_config.chain_id.clone(),
                 peer_discovery: true,
                 initial_time: testing_config
                     .initial_time

--- a/node/testing/src/cluster/mod.rs
+++ b/node/testing/src/cluster/mod.rs
@@ -131,8 +131,6 @@ pub struct Cluster {
     account_sec_keys: BTreeMap<AccountPublicKey, AccountSecretKey>,
     nodes: Vec<Node>,
     ocaml_nodes: Vec<Option<OcamlNode>>,
-    // TODO: remove option if this is viable in the future
-    chain_id: Option<ChainId>,
     initial_time: Option<redux::Timestamp>,
 
     rpc_counter: usize,
@@ -173,7 +171,6 @@ impl Cluster {
             account_sec_keys: Default::default(),
             nodes: Vec::new(),
             ocaml_nodes: Vec::new(),
-            chain_id: None,
             initial_time: None,
 
             rpc_counter: 0,
@@ -201,16 +198,8 @@ impl Cluster {
             .or_else(|| DETERMINISTIC_ACCOUNT_SEC_KEYS.get(pub_key))
     }
 
-    pub fn set_chain_id(&mut self, chain_id: ChainId) {
-        self.chain_id = Some(chain_id)
-    }
-
     pub fn set_initial_time(&mut self, initial_time: redux::Timestamp) {
         self.initial_time = Some(initial_time)
-    }
-
-    pub fn get_chain_id(&self) -> Option<ChainId> {
-        self.chain_id.clone()
     }
 
     pub fn get_initial_time(&self) -> Option<redux::Timestamp> {
@@ -293,7 +282,6 @@ impl Cluster {
                 ask_initial_peers_interval: testing_config.ask_initial_peers_interval,
                 enabled_channels: ChannelId::iter_all().collect(),
                 timeouts: testing_config.timeouts,
-                chain_id: testing_config.chain_id.clone(),
                 peer_discovery: true,
                 initial_time: testing_config
                     .initial_time
@@ -310,10 +298,7 @@ impl Cluster {
             .expect("secret key bytes must be valid");
 
         let p2p_service_ctx = <NodeService as P2pServiceWebrtcWithLibp2p>::init(
-            Some(libp2p_port),
             secret_key.clone(),
-            testing_config.chain_id,
-            event_sender.clone(),
             p2p_task_spawner::P2pTaskSpawner::new(shutdown_tx.clone()),
         );
 

--- a/node/testing/src/cluster/runner/mod.rs
+++ b/node/testing/src/cluster/runner/mod.rs
@@ -94,16 +94,8 @@ impl<'a> ClusterRunner<'a> {
         )
     }
 
-    pub fn get_chain_id(&self) -> Option<ChainId> {
-        self.cluster.get_chain_id()
-    }
-
     pub fn get_initial_time(&self) -> Option<redux::Timestamp> {
         self.cluster.get_initial_time()
-    }
-
-    pub fn set_chain_id(&mut self, chain_id: ChainId) {
-        self.cluster.set_chain_id(chain_id)
     }
 
     pub fn set_initial_time(&mut self, initial_time: redux::Timestamp) {

--- a/node/testing/src/cluster/runner/mod.rs
+++ b/node/testing/src/cluster/runner/mod.rs
@@ -94,7 +94,7 @@ impl<'a> ClusterRunner<'a> {
         )
     }
 
-    pub fn get_chain_id(&self) -> Option<String> {
+    pub fn get_chain_id(&self) -> Option<ChainId> {
         self.cluster.get_chain_id()
     }
 
@@ -102,7 +102,7 @@ impl<'a> ClusterRunner<'a> {
         self.cluster.get_initial_time()
     }
 
-    pub fn set_chain_id(&mut self, chain_id: String) {
+    pub fn set_chain_id(&mut self, chain_id: ChainId) {
         self.cluster.set_chain_id(chain_id)
     }
 

--- a/node/testing/src/node/ocaml/mod.rs
+++ b/node/testing/src/node/ocaml/mod.rs
@@ -5,6 +5,7 @@ use node::p2p::{
     connection::outgoing::{P2pConnectionOutgoingInitLibp2pOpts, P2pConnectionOutgoingInitOpts},
     PeerId,
 };
+use openmina_core::ChainId;
 
 use std::{
     path::{Path, PathBuf},
@@ -288,23 +289,23 @@ impl OcamlNode {
     }
 
     /// Queries graphql to get chain_id.
-    pub fn chain_id(&self) -> anyhow::Result<String> {
+    pub fn chain_id(&self) -> anyhow::Result<ChainId> {
         let res = self.grapql_query("query { daemonStatus { chainId } }")?;
-        res["data"]["daemonStatus"]["chainId"]
+        let chain_id = res["data"]["daemonStatus"]["chainId"]
             .as_str()
-            .map(|s| s.to_owned())
-            .ok_or_else(|| anyhow::anyhow!("empty chain_id response"))
+            .ok_or_else(|| anyhow::anyhow!("empty chain_id response"))?;
+        ChainId::from_hex(chain_id).map_err(|e| anyhow::anyhow!("invalid chain_id: {}", e))
     }
 
     /// Queries graphql to get chain_id.
-    pub async fn chain_id_async(&self) -> anyhow::Result<String> {
+    pub async fn chain_id_async(&self) -> anyhow::Result<ChainId> {
         let res = self
             .grapql_query_async("query { daemonStatus { chainId } }")
             .await?;
-        res["data"]["daemonStatus"]["chainId"]
+        let chain_id = res["data"]["daemonStatus"]["chainId"]
             .as_str()
-            .map(|s| s.to_owned())
-            .ok_or_else(|| anyhow::anyhow!("empty chain_id response"))
+            .ok_or_else(|| anyhow::anyhow!("empty chain_id response"))?;
+        ChainId::from_hex(chain_id).map_err(|e| anyhow::anyhow!("invalid chain_id: {}", e))
     }
 
     /// Queries graphql to check if ocaml node is synced,

--- a/node/testing/src/node/rust/config.rs
+++ b/node/testing/src/node/rust/config.rs
@@ -4,7 +4,7 @@ use node::account::AccountSecretKey;
 use node::config::BERKELEY_CONFIG;
 use node::transition_frontier::genesis::GenesisConfig;
 use node::{p2p::P2pTimeouts, BlockProducerConfig, SnarkerConfig};
-use openmina_core::CHAIN_ID;
+use openmina_core::{ChainId, BERKELEY_CHAIN_ID};
 use serde::{Deserialize, Serialize};
 
 use crate::scenario::ListenerNode;
@@ -22,7 +22,7 @@ pub enum TestPeerId {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RustNodeTestingConfig {
-    pub chain_id: Vec<u8>,
+    pub chain_id: ChainId,
     pub initial_time: redux::Timestamp,
     pub genesis: Arc<GenesisConfig>,
     pub max_peers: usize,
@@ -44,7 +44,7 @@ pub struct RustNodeBlockProducerTestingConfig {
 impl RustNodeTestingConfig {
     pub fn berkeley_default() -> Self {
         Self {
-            chain_id: CHAIN_ID.to_owned().into_bytes(),
+            chain_id: BERKELEY_CHAIN_ID.to_owned(),
             initial_time: redux::Timestamp::ZERO,
             genesis: BERKELEY_CONFIG.clone(),
             max_peers: 100,
@@ -60,7 +60,7 @@ impl RustNodeTestingConfig {
 
     pub fn berkeley_default_no_rpc_timeouts() -> Self {
         Self {
-            chain_id: CHAIN_ID.as_bytes().to_owned(),
+            chain_id: BERKELEY_CHAIN_ID.to_owned(),
             initial_time: redux::Timestamp::ZERO,
             genesis: BERKELEY_CONFIG.clone(),
             max_peers: 100,
@@ -79,8 +79,8 @@ impl RustNodeTestingConfig {
         self
     }
 
-    pub fn chain_id(mut self, s: impl AsRef<[u8]>) -> Self {
-        self.chain_id = s.as_ref().to_owned();
+    pub fn chain_id(mut self, s: &ChainId) -> Self {
+        self.chain_id = s.clone();
         self
     }
 

--- a/node/testing/src/node/rust/config.rs
+++ b/node/testing/src/node/rust/config.rs
@@ -1,10 +1,11 @@
+use std::fs::File;
+use std::path::Path;
 use std::{sync::Arc, time::Duration};
 
 use node::account::AccountSecretKey;
 use node::config::BERKELEY_CONFIG;
 use node::transition_frontier::genesis::GenesisConfig;
 use node::{p2p::P2pTimeouts, BlockProducerConfig, SnarkerConfig};
-use openmina_core::{ChainId, BERKELEY_CHAIN_ID};
 use serde::{Deserialize, Serialize};
 
 use crate::scenario::ListenerNode;
@@ -22,7 +23,6 @@ pub enum TestPeerId {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RustNodeTestingConfig {
-    pub chain_id: ChainId,
     pub initial_time: redux::Timestamp,
     pub genesis: Arc<GenesisConfig>,
     pub max_peers: usize,
@@ -44,7 +44,6 @@ pub struct RustNodeBlockProducerTestingConfig {
 impl RustNodeTestingConfig {
     pub fn berkeley_default() -> Self {
         Self {
-            chain_id: BERKELEY_CHAIN_ID.to_owned(),
             initial_time: redux::Timestamp::ZERO,
             genesis: BERKELEY_CONFIG.clone(),
             max_peers: 100,
@@ -60,7 +59,6 @@ impl RustNodeTestingConfig {
 
     pub fn berkeley_default_no_rpc_timeouts() -> Self {
         Self {
-            chain_id: BERKELEY_CHAIN_ID.to_owned(),
             initial_time: redux::Timestamp::ZERO,
             genesis: BERKELEY_CONFIG.clone(),
             max_peers: 100,
@@ -76,11 +74,6 @@ impl RustNodeTestingConfig {
 
     pub fn max_peers(mut self, n: usize) -> Self {
         self.max_peers = n;
-        self
-    }
-
-    pub fn chain_id(mut self, s: &ChainId) -> Self {
-        self.chain_id = s.clone();
         self
     }
 
@@ -106,6 +99,14 @@ impl RustNodeTestingConfig {
 
     pub fn with_libp2p_port(mut self, libp2p_port: u16) -> Self {
         self.libp2p_port = Some(libp2p_port);
+        self
+    }
+
+    pub fn with_daemon_json<P: AsRef<Path>>(mut self, daemon_json: P) -> Self {
+        self.genesis = Arc::new(GenesisConfig::DaemonJson(
+            serde_json::from_reader(&mut File::open(daemon_json).expect("daemon json file"))
+                .expect("daemon json"),
+        ));
         self
     }
 }

--- a/node/testing/src/node/rust/mod.rs
+++ b/node/testing/src/node/rust/mod.rs
@@ -50,14 +50,14 @@ impl Node {
     pub fn dial_addr(&self) -> P2pConnectionOutgoingInitOpts {
         let peer_id = self.store.state().p2p.my_id();
         if self.service().rust_to_rust_use_webrtc() {
-            let port = self.store.state().p2p.config.listen_port;
+            let port = self.store.state().p2p.config().listen_port;
             let signaling = SignalingMethod::Http(([127, 0, 0, 1], port).into());
             P2pConnectionOutgoingInitOpts::WebRTC { peer_id, signaling }
         } else {
             let opts = P2pConnectionOutgoingInitLibp2pOpts {
                 peer_id,
                 host: node::p2p::webrtc::Host::Ipv4([127, 0, 0, 1].into()),
-                port: self.store.state().p2p.config.libp2p_port.unwrap(),
+                port: self.store.state().p2p.config().libp2p_port.unwrap(),
             };
             P2pConnectionOutgoingInitOpts::LibP2P(opts)
         }
@@ -72,7 +72,7 @@ impl Node {
     }
 
     pub fn peer_id(&self) -> PeerId {
-        self.state().p2p.config.identity_pub_key.peer_id()
+        self.state().p2p.my_id()
     }
 
     pub fn pending_events(&mut self, poll: bool) -> impl Iterator<Item = (PendingEventId, &Event)> {

--- a/node/testing/src/scenarios/multi_node/basic_connectivity_peer_discovery.rs
+++ b/node/testing/src/scenarios/multi_node/basic_connectivity_peer_discovery.rs
@@ -68,6 +68,7 @@ impl MultiNodeBasicConnectivityPeerDiscovery {
 
         let config = RustNodeTestingConfig::berkeley_default()
             .ask_initial_peers_interval(Duration::from_secs(3600))
+            .with_daemon_json("/var/lib/coda/berkeley.json")
             .max_peers(100)
             .initial_peers(
                 nodes
@@ -123,11 +124,9 @@ impl MultiNodeBasicConnectivityPeerDiscovery {
             if this
                 .state()
                 .p2p
-                .network
-                .scheduler
-                .discovery_state()
-                .unwrap()
-                .is_bootstrapped()
+                .ready()
+                .and_then(|p2p| p2p.network.scheduler.discovery_state())
+                .map_or(false, |discovery_state| discovery_state.is_bootstrapped())
             {
                 // the node must find all already running OCaml nodes
                 // assert_eq!(this.state().p2p.peers.len(), TOTAL_OCAML_NODES as usize);
@@ -135,7 +134,7 @@ impl MultiNodeBasicConnectivityPeerDiscovery {
                     eprintln!("the Openmina node finished peer discovery",);
                     eprintln!(
                         "connected peers: {:?}",
-                        this.state().p2p.peers.keys().collect::<Vec<_>>()
+                        this.state().p2p.unwrap().peers.keys().collect::<Vec<_>>()
                     );
                     let node_id = runner.add_ocaml_node(ocaml_node_config.clone());
                     let node = runner.ocaml_node(node_id).unwrap();
@@ -153,11 +152,14 @@ impl MultiNodeBasicConnectivityPeerDiscovery {
                     .unwrap()
                     .state()
                     .p2p
-                    .peers
-                    .iter()
-                    .filter(|(id, n)| n.is_libp2p && id == &peer_id)
-                    .filter_map(|(_, n)| n.status.as_ready())
-                    .find(|n| n.is_incoming)
+                    .ready()
+                    .and_then(|p2p| {
+                        p2p.peers
+                            .iter()
+                            .filter(|(id, n)| n.is_libp2p && id == &peer_id)
+                            .filter_map(|(_, n)| n.status.as_ready())
+                            .find(|n| n.is_incoming)
+                    })
                     .is_some()
                 {
                     eprintln!("the additional OCaml node connected to Openmina node");

--- a/node/testing/src/scenarios/multi_node/connection_discovery.rs
+++ b/node/testing/src/scenarios/multi_node/connection_discovery.rs
@@ -145,7 +145,7 @@ impl OCamlToRust {
         let state = driver.exec_even_step(connected).await.unwrap().unwrap();
         // check that now there is an outgoing connection to the ocaml peer
         assert!(matches!(
-            &state.p2p.peers.get(&ocaml_peer_id).unwrap().status,
+            &state.p2p.get_peer(&ocaml_peer_id).unwrap().status,
             P2pPeerStatus::Ready(ready) if ready.is_incoming
         ));
 
@@ -214,7 +214,7 @@ impl RustToOCaml {
         let state = driver.exec_even_step(connected).await.unwrap().unwrap();
         // check that now there is an outgoing connection to the ocaml peer
         assert!(matches!(
-            &state.p2p.peers.get(&seed_peer_id.clone().into()).unwrap().status,
+            &state.p2p.get_peer(&seed_peer_id.clone().into()).unwrap().status,
             P2pPeerStatus::Ready(ready) if !ready.is_incoming
         ));
 
@@ -292,7 +292,7 @@ impl OCamlToRustViaSeed {
 
         let state = driver.exec_even_step(connected).await.unwrap().unwrap();
         assert!(matches!(
-            &state.p2p.peers.get(&seed_peer_id.clone().into()).unwrap().status,
+            &state.p2p.get_peer(&seed_peer_id.clone().into()).unwrap().status,
             P2pPeerStatus::Ready(ready) if !ready.is_incoming
         ));
 
@@ -318,8 +318,7 @@ impl OCamlToRustViaSeed {
                 .unwrap()
                 .state()
                 .p2p
-                .peers
-                .get(&seed_peer_id.clone().into())
+                .get_peer(&seed_peer_id.clone().into())
                 .unwrap()
                 .status,
             P2pPeerStatus::Disconnected { .. }
@@ -341,7 +340,7 @@ impl OCamlToRustViaSeed {
 
         let state = driver.exec_even_step(connected).await.unwrap().unwrap();
         assert!(matches!(
-            &state.p2p.peers.get(&ocaml_peer_id).unwrap().status,
+            &state.p2p.get_peer(&ocaml_peer_id).unwrap().status,
             P2pPeerStatus::Ready(ready) if ready.is_incoming
         ));
     }
@@ -414,7 +413,7 @@ impl RustToOCamlViaSeed {
 
         let state = driver.exec_even_step(connected).await.unwrap().unwrap();
         assert!(matches!(
-            &state.p2p.peers.get(&seed_peer_id.clone().into()).unwrap().status,
+            &state.p2p.get_peer(&seed_peer_id.clone().into()).unwrap().status,
             P2pPeerStatus::Ready(ready) if !ready.is_incoming
         ));
 
@@ -429,7 +428,7 @@ impl RustToOCamlViaSeed {
                             peer,
                             Ok(()),
                         ))) if peer == &ocaml_peer_id => {
-                            if let Some(peer_state) = &state.p2p.peers.get(peer) {
+                            if let Some(peer_state) = &state.p2p.get_peer(peer) {
                                 let status = &peer_state.status;
                                 if let P2pPeerStatus::Connecting(P2pConnectionState::Incoming(..)) =
                                     status

--- a/node/testing/src/scenarios/multi_node/vrf_correct_ledgers.rs
+++ b/node/testing/src/scenarios/multi_node/vrf_correct_ledgers.rs
@@ -35,7 +35,7 @@ impl MultiNodeVrfGetCorrectLedgers {
                 .unwrap();
 
         let producer_node = runner.add_rust_node(RustNodeTestingConfig {
-            chain_id: chain_id.into_bytes(),
+            chain_id,
             initial_time,
             genesis: node::config::BERKELEY_CONFIG.clone(),
             max_peers: 100,

--- a/node/testing/src/scenarios/multi_node/vrf_correct_ledgers.rs
+++ b/node/testing/src/scenarios/multi_node/vrf_correct_ledgers.rs
@@ -24,7 +24,6 @@ impl MultiNodeVrfGetCorrectLedgers {
     pub async fn run(self, mut runner: ClusterRunner<'_>) {
         eprintln!("Running vrf get correct ledgers scenario");
 
-        let chain_id = runner.get_chain_id().unwrap();
         let initial_time = runner.get_initial_time().unwrap();
 
         let (initial_node, _) = runner.nodes_iter().last().unwrap();
@@ -35,7 +34,6 @@ impl MultiNodeVrfGetCorrectLedgers {
                 .unwrap();
 
         let producer_node = runner.add_rust_node(RustNodeTestingConfig {
-            chain_id,
             initial_time,
             genesis: node::config::BERKELEY_CONFIG.clone(),
             max_peers: 100,

--- a/node/testing/src/scenarios/multi_node/vrf_correct_slots.rs
+++ b/node/testing/src/scenarios/multi_node/vrf_correct_slots.rs
@@ -31,7 +31,6 @@ impl MultiNodeVrfGetCorrectSlots {
     pub async fn run(self, mut runner: ClusterRunner<'_>) {
         eprintln!("Running vrf get correct ledgers scenario");
 
-        let chain_id = runner.get_chain_id().unwrap();
         let initial_time = runner.get_initial_time().unwrap();
 
         let (initial_node, _) = runner.nodes_iter().last().unwrap();
@@ -41,7 +40,6 @@ impl MultiNodeVrfGetCorrectSlots {
         let sec_key: AccountSecretKey = AccountSecretKey::from_str(sec_key_bs58).unwrap();
 
         let producer_node = runner.add_rust_node(RustNodeTestingConfig {
-            chain_id,
             initial_time,
             genesis: node::config::BERKELEY_CONFIG.clone(),
             max_peers: 100,

--- a/node/testing/src/scenarios/multi_node/vrf_correct_slots.rs
+++ b/node/testing/src/scenarios/multi_node/vrf_correct_slots.rs
@@ -31,7 +31,7 @@ impl MultiNodeVrfGetCorrectSlots {
     pub async fn run(self, mut runner: ClusterRunner<'_>) {
         eprintln!("Running vrf get correct ledgers scenario");
 
-        let chain_id = runner.get_chain_id().unwrap().into_bytes();
+        let chain_id = runner.get_chain_id().unwrap();
         let initial_time = runner.get_initial_time().unwrap();
 
         let (initial_node, _) = runner.nodes_iter().last().unwrap();

--- a/node/testing/src/scenarios/multi_node/vrf_epoch_bounds_correct_ledgers.rs
+++ b/node/testing/src/scenarios/multi_node/vrf_epoch_bounds_correct_ledgers.rs
@@ -33,7 +33,7 @@ pub struct MultiNodeVrfEpochBoundsCorrectLedger;
 impl MultiNodeVrfEpochBoundsCorrectLedger {
     pub async fn run(self, mut runner: ClusterRunner<'_>) {
         let start = tokio::time::Instant::now();
-        let chain_id = runner.get_chain_id().unwrap().into_bytes();
+        let chain_id = runner.get_chain_id().unwrap();
         let initial_time = runner.get_initial_time().unwrap();
 
         let (initial_node, _) = runner.nodes_iter().last().unwrap();

--- a/node/testing/src/scenarios/multi_node/vrf_epoch_bounds_correct_ledgers.rs
+++ b/node/testing/src/scenarios/multi_node/vrf_epoch_bounds_correct_ledgers.rs
@@ -33,7 +33,6 @@ pub struct MultiNodeVrfEpochBoundsCorrectLedger;
 impl MultiNodeVrfEpochBoundsCorrectLedger {
     pub async fn run(self, mut runner: ClusterRunner<'_>) {
         let start = tokio::time::Instant::now();
-        let chain_id = runner.get_chain_id().unwrap();
         let initial_time = runner.get_initial_time().unwrap();
 
         let (initial_node, _) = runner.nodes_iter().last().unwrap();
@@ -49,7 +48,6 @@ impl MultiNodeVrfEpochBoundsCorrectLedger {
                 .unwrap();
 
         let rust_config = RustNodeTestingConfig {
-            chain_id,
             initial_time,
             genesis: node::config::BERKELEY_CONFIG.clone(),
             max_peers: 100,

--- a/node/testing/src/scenarios/multi_node/vrf_epoch_bounds_evaluation.rs
+++ b/node/testing/src/scenarios/multi_node/vrf_epoch_bounds_evaluation.rs
@@ -24,7 +24,6 @@ pub struct MultiNodeVrfEpochBoundsEvaluation;
 
 impl MultiNodeVrfEpochBoundsEvaluation {
     pub async fn run(self, mut runner: ClusterRunner<'_>) {
-        let chain_id = runner.get_chain_id().unwrap();
         let initial_time = runner.get_initial_time().unwrap();
 
         let (initial_node, _) = runner.nodes_iter().last().unwrap();
@@ -35,7 +34,6 @@ impl MultiNodeVrfEpochBoundsEvaluation {
                 .unwrap();
 
         let rust_config = RustNodeTestingConfig {
-            chain_id,
             initial_time,
             genesis: node::config::BERKELEY_CONFIG.clone(),
             max_peers: 100,

--- a/node/testing/src/scenarios/multi_node/vrf_epoch_bounds_evaluation.rs
+++ b/node/testing/src/scenarios/multi_node/vrf_epoch_bounds_evaluation.rs
@@ -24,7 +24,7 @@ pub struct MultiNodeVrfEpochBoundsEvaluation;
 
 impl MultiNodeVrfEpochBoundsEvaluation {
     pub async fn run(self, mut runner: ClusterRunner<'_>) {
-        let chain_id = runner.get_chain_id().unwrap().into_bytes();
+        let chain_id = runner.get_chain_id().unwrap();
         let initial_time = runner.get_initial_time().unwrap();
 
         let (initial_node, _) = runner.nodes_iter().last().unwrap();

--- a/node/testing/src/scenarios/p2p/basic_connection_handling.rs
+++ b/node/testing/src/scenarios/p2p/basic_connection_handling.rs
@@ -126,12 +126,12 @@ impl AllNodesConnectionsAreSymmetric {
 
         // Check that for each peer, if it is in the node's peer list, then the node is in the peer's peer list
         for (peer1, peer_id1) in &peers {
-            let peer1_p2p_state = &driver.inner().node(*peer1).unwrap().state().p2p;
+            let peer1_p2p_state = &driver.inner().node(*peer1).unwrap().state().p2p.unwrap();
             for (peer2, peer_id2) in &peers {
                 if peer2 == peer1 {
                     continue;
                 }
-                let peer2_p2p_state = &driver.inner().node(*peer2).unwrap().state().p2p;
+                let peer2_p2p_state = &driver.inner().node(*peer2).unwrap().state().p2p.unwrap();
 
                 if has_active_peer(peer2_p2p_state, peer_id1) {
                     assert!(
@@ -259,8 +259,7 @@ impl MaxNumberOfPeersIncoming {
                 .filter(|peer| {
                     peer.state()
                         .p2p
-                        .peers
-                        .get(&nut_peer_id)
+                        .get_peer(&nut_peer_id)
                         .and_then(|peer| peer.status.as_ready())
                         .is_some()
                 })

--- a/node/testing/src/scenarios/p2p/basic_outgoing_connections.rs
+++ b/node/testing/src/scenarios/p2p/basic_outgoing_connections.rs
@@ -253,11 +253,7 @@ impl ConnectToInitialPeers {
             &mut driver,
             MAX,
             RustNodeTestingConfig::berkeley_default(),
-            |state| {
-                let config = &state.p2p.config;
-                let peer_id = config.identity_pub_key.peer_id();
-                peer_id
-            },
+            |state| state.p2p.my_id(),
         );
 
         // wait for all peers to listen
@@ -286,7 +282,14 @@ impl ConnectToInitialPeers {
         if !connected {
             println!(
                 "{:#?}",
-                driver.inner().node(node_ut).unwrap().state().p2p.peers
+                driver
+                    .inner()
+                    .node(node_ut)
+                    .unwrap()
+                    .state()
+                    .p2p
+                    .unwrap()
+                    .peers
             );
         }
         assert!(connected, "did not connect to peers: {:?}", peer_ids);
@@ -341,7 +344,14 @@ impl ConnectToInitialPeersBecomeReady {
         if !connected {
             println!(
                 "{:#?}",
-                driver.inner().node(node_ut).unwrap().state().p2p.peers
+                driver
+                    .inner()
+                    .node(node_ut)
+                    .unwrap()
+                    .state()
+                    .p2p
+                    .unwrap()
+                    .peers
             );
         }
         assert!(connected, "did not connect to peers: {:?}", peer_ids);

--- a/node/testing/src/scenarios/p2p/kademlia.rs
+++ b/node/testing/src/scenarios/p2p/kademlia.rs
@@ -200,7 +200,9 @@ fn fake_kad_peer(
     identity_key: Keypair,
     port: Option<u16>,
 ) -> anyhow::Result<libp2p::Swarm<Behaviour>> {
-    let psk = PreSharedKey::new(openmina_core::preshared_key(openmina_core::CHAIN_ID));
+    let psk = PreSharedKey::new(openmina_core::preshared_key(
+        openmina_core::BERKELEY_CHAIN_ID,
+    ));
     let _identify = libp2p::identify::Behaviour::new(libp2p::identify::Config::new(
         "ipfs/0.1.0".to_string(),
         identity_key.public(),

--- a/node/testing/src/scenarios/p2p/kademlia.rs
+++ b/node/testing/src/scenarios/p2p/kademlia.rs
@@ -56,7 +56,7 @@ impl IncomingFindNode {
                 .unwrap()
                 .state()
                 .p2p
-                .config
+                .config()
                 .libp2p_port
                 .unwrap(),
             peer_id1.to_libp2p_string(),
@@ -200,9 +200,7 @@ fn fake_kad_peer(
     identity_key: Keypair,
     port: Option<u16>,
 ) -> anyhow::Result<libp2p::Swarm<Behaviour>> {
-    let psk = PreSharedKey::new(openmina_core::preshared_key(
-        openmina_core::BERKELEY_CHAIN_ID,
-    ));
+    let psk = PreSharedKey::new(openmina_core::BERKELEY_CHAIN_ID.preshared_key());
     let _identify = libp2p::identify::Behaviour::new(libp2p::identify::Config::new(
         "ipfs/0.1.0".to_string(),
         identity_key.public(),

--- a/node/testing/src/scenarios/p2p/pubsub.rs
+++ b/node/testing/src/scenarios/p2p/pubsub.rs
@@ -23,9 +23,7 @@ impl P2pReceiveBlock {
             .unwrap()
             .state()
             .p2p
-            .config
-            .identity_pub_key
-            .peer_id();
+            .my_id();
 
         let config = RustNodeTestingConfig::berkeley_default()
             // make sure it will not ask initial peers
@@ -37,9 +35,11 @@ impl P2pReceiveBlock {
         let mut driver = Driver::new(runner);
         driver
             .wait_for(Duration::from_secs(20 * 60), |node, _, state| {
+                let Some(p2p) = state.p2p.ready() else {
+                    return false;
+                };
                 node == receiver_openmina_node
-                    && state
-                        .p2p
+                    && p2p
                         .network
                         .scheduler
                         .broadcast_state

--- a/node/testing/src/scenarios/solo_node/basic_connectivity_initial_joining.rs
+++ b/node/testing/src/scenarios/solo_node/basic_connectivity_initial_joining.rs
@@ -68,9 +68,7 @@ impl SoloNodeBasicConnectivityInitialJoining {
                 .expect("must exist")
                 .state()
                 .p2p
-                .config
-                .identity_pub_key
-                .peer_id(),
+                .my_id(),
         );
         eprintln!("launch Openmina node, id: {node_id}, peer_id: {peer_id}");
 
@@ -111,13 +109,14 @@ impl SoloNodeBasicConnectivityInitialJoining {
             let known_peers: usize = node
                 .state()
                 .p2p
-                .network
-                .scheduler
-                .discovery_state()
-                .unwrap()
-                .routing_table
-                .closest_peers(&my_id.into())
-                .count();
+                .ready()
+                .and_then(|p2p| p2p.network.scheduler.discovery_state())
+                .map_or(0, |discovery_state| {
+                    discovery_state
+                        .routing_table
+                        .closest_peers(&my_id.into())
+                        .count()
+                });
 
             println!("step: {step}");
             println!("known peers: {known_peers}");

--- a/node/testing/src/scenarios/solo_node/bootstrap.rs
+++ b/node/testing/src/scenarios/solo_node/bootstrap.rs
@@ -34,9 +34,11 @@ impl SoloNodeBootstrap {
             .unwrap();
 
         let node_id = runner.add_rust_node(
-            RustNodeTestingConfig::berkeley_default().initial_peers(vec![ListenerNode::Custom(
-                P2pConnectionOutgoingInitOpts::LibP2P(replayer),
-            )]),
+            RustNodeTestingConfig::berkeley_default()
+                .initial_peers(vec![ListenerNode::Custom(
+                    P2pConnectionOutgoingInitOpts::LibP2P(replayer),
+                )])
+                .with_daemon_json("/var/lib/coda/berkeley.json"),
         );
         eprintln!("launch Openmina node with default configuration, id: {node_id}");
 

--- a/node/testing/src/scenarios/solo_node/sync_to_genesis.rs
+++ b/node/testing/src/scenarios/solo_node/sync_to_genesis.rs
@@ -48,8 +48,7 @@ impl SoloNodeSyncToGenesis {
             .unwrap()
             .chain_id_async()
             .await
-            .unwrap()
-            .into_bytes();
+            .unwrap();
         let rust_node = runner.add_rust_node(RustNodeTestingConfig {
             chain_id,
             initial_time,

--- a/node/testing/src/scenarios/solo_node/sync_to_genesis.rs
+++ b/node/testing/src/scenarios/solo_node/sync_to_genesis.rs
@@ -43,14 +43,7 @@ impl SoloNodeSyncToGenesis {
             .await
             .unwrap();
 
-        let chain_id = runner
-            .ocaml_node(ocaml_node)
-            .unwrap()
-            .chain_id_async()
-            .await
-            .unwrap();
         let rust_node = runner.add_rust_node(RustNodeTestingConfig {
-            chain_id,
             initial_time,
             genesis: node::config::BERKELEY_CONFIG.clone(),
             max_peers: 100,

--- a/node/testing/src/scenarios/solo_node/sync_to_genesis_custom.rs
+++ b/node/testing/src/scenarios/solo_node/sync_to_genesis_custom.rs
@@ -63,7 +63,7 @@ impl SoloNodeSyncToGenesisCustom {
         runner.set_initial_time(initial_time);
 
         let rust_node = runner.add_rust_node(RustNodeTestingConfig {
-            chain_id: chain_id.into_bytes(),
+            chain_id,
             initial_time,
             genesis: node::config::BERKELEY_CONFIG.clone(),
             max_peers: 100,

--- a/node/testing/src/scenarios/solo_node/sync_to_genesis_custom.rs
+++ b/node/testing/src/scenarios/solo_node/sync_to_genesis_custom.rs
@@ -56,14 +56,10 @@ impl SoloNodeSyncToGenesisCustom {
             .await
             .unwrap();
 
-        let chain_id = runner.ocaml_node(ocaml_node).unwrap().chain_id().unwrap();
-
         // set here to be used in other child scenarios
-        runner.set_chain_id(chain_id.clone());
         runner.set_initial_time(initial_time);
 
         let rust_node = runner.add_rust_node(RustNodeTestingConfig {
-            chain_id,
             initial_time,
             genesis: node::config::BERKELEY_CONFIG.clone(),
             max_peers: 100,

--- a/node/testing/src/simulator/mod.rs
+++ b/node/testing/src/simulator/mod.rs
@@ -3,6 +3,7 @@ pub use config::*;
 use mina_p2p_messages::v2::{
     CurrencyFeeStableV1, UnsignedExtendedUInt64Int64ForVersionTagsStableV1,
 };
+use openmina_core::ChainId;
 
 use std::{collections::BTreeSet, time::Duration};
 
@@ -41,9 +42,9 @@ impl Simulator {
         {
             chain_id
         } else if let Some(node) = runner.ocaml_node(ClusterOcamlNodeId::new_unchecked(0)) {
-            node.chain_id_async().await.unwrap().into_bytes()
+            node.chain_id_async().await.unwrap()
         } else {
-            "<unknown_chain_id>".into()
+            ChainId::from_bytes("<unknown chain_id>".as_bytes())
         };
 
         RustNodeTestingConfig {

--- a/node/testing/src/simulator/mod.rs
+++ b/node/testing/src/simulator/mod.rs
@@ -3,7 +3,6 @@ pub use config::*;
 use mina_p2p_messages::v2::{
     CurrencyFeeStableV1, UnsignedExtendedUInt64Int64ForVersionTagsStableV1,
 };
-use openmina_core::ChainId;
 
 use std::{collections::BTreeSet, time::Duration};
 
@@ -11,7 +10,7 @@ use node::{ActionKind, BlockProducerConfig, SnarkerConfig, SnarkerStrategy, Stat
 use rand::{Rng, SeedableRng};
 
 use crate::{
-    cluster::{ClusterNodeId, ClusterOcamlNodeId},
+    cluster::ClusterNodeId,
     node::{Node, RustNodeBlockProducerTestingConfig, RustNodeTestingConfig},
     scenario::{ListenerNode, ScenarioStep},
     scenarios::{ClusterRunner, RunCfg},
@@ -34,21 +33,8 @@ impl Simulator {
         self.initial_time
     }
 
-    async fn seed_config_async(&self, runner: &ClusterRunner<'_>) -> RustNodeTestingConfig {
-        let chain_id = if let Some(chain_id) = runner
-            .nodes_iter()
-            .next()
-            .map(|(_, node)| node.config().chain_id.clone())
-        {
-            chain_id
-        } else if let Some(node) = runner.ocaml_node(ClusterOcamlNodeId::new_unchecked(0)) {
-            node.chain_id_async().await.unwrap()
-        } else {
-            ChainId::from_bytes("<unknown chain_id>".as_bytes())
-        };
-
+    async fn seed_config_async(&self, _runner: &ClusterRunner<'_>) -> RustNodeTestingConfig {
         RustNodeTestingConfig {
-            chain_id,
             initial_time: self.initial_time(),
             genesis: self.config.genesis.clone(),
             max_peers: 1000,

--- a/p2p/src/network/kad/p2p_network_kad_actions.rs
+++ b/p2p/src/network/kad/p2p_network_kad_actions.rs
@@ -83,30 +83,36 @@ pub enum P2pNetworkKademliaAction {
 }
 
 impl EnablingCondition<P2pState> for P2pNetworkKademliaAction {
-    fn is_enabled(&self, state: &P2pState, _time: redux::Timestamp) -> bool {
-        let Some(state) = &state.network.scheduler.discovery_state else {
+    fn is_enabled(&self, state: &P2pState, time: redux::Timestamp) -> bool {
+        let Some(discovery_state) = &state.network.scheduler.discovery_state else {
             return false;
         };
         match self {
             P2pNetworkKademliaAction::AnswerFindNodeRequest {
                 peer_id, stream_id, ..
-            } => state.find_kad_stream_state(peer_id, stream_id).is_some(),
+            } => discovery_state
+                .find_kad_stream_state(peer_id, stream_id)
+                .is_some(),
             P2pNetworkKademliaAction::UpdateFindNodeRequest {
                 addr: _,
                 peer_id,
                 stream_id,
                 ..
             } => {
-                state.find_kad_stream_state(peer_id, stream_id).is_some()
-                    && state.request(peer_id).is_some()
+                discovery_state
+                    .find_kad_stream_state(peer_id, stream_id)
+                    .is_some()
+                    && discovery_state.request(peer_id).is_some()
             }
-            P2pNetworkKademliaAction::StartBootstrap { .. } => {
-                // TODO: also can run bootstrap on timely basis.
-                matches!(state.status, super::P2pNetworkKadStatus::Init)
-            }
+            P2pNetworkKademliaAction::StartBootstrap { .. } => discovery_state
+                .status
+                .can_bootstrap(time, &state.config.timeouts),
             P2pNetworkKademliaAction::BootstrapFinished { .. } => {
                 // TODO: also can run bootstrap on timely basis.
-                matches!(state.status, super::P2pNetworkKadStatus::Bootstrapping(_))
+                matches!(
+                    discovery_state.status,
+                    super::P2pNetworkKadStatus::Bootstrapping(_)
+                )
             }
             P2pNetworkKademliaAction::UpdateRoutingTable { .. } => true,
         }

--- a/p2p/src/network/kad/p2p_network_kad_state.rs
+++ b/p2p/src/network/kad/p2p_network_kad_state.rs
@@ -7,7 +7,10 @@ use super::{
     bootstrap::P2pNetworkKadBootstrapState, request::P2pNetworkKadRequestState,
     stream::P2pNetworkKadStreamState, P2pNetworkKadRoutingTable,
 };
-use crate::{bootstrap::P2pNetworkKadBootstrapStats, PeerId, StreamId};
+use crate::{
+    bootstrap::{P2pNetworkKadBootstrapRequestStat, P2pNetworkKadBootstrapStats},
+    is_time_passed, P2pTimeouts, PeerId, StreamId,
+};
 
 /// Kademlia status.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -25,6 +28,25 @@ pub enum P2pNetworkKadStatus {
         /// Stats for the latest bootstrap process.
         stats: P2pNetworkKadBootstrapStats,
     },
+}
+
+impl P2pNetworkKadStatus {
+    pub(crate) fn can_bootstrap(&self, now: Timestamp, timeouts: &P2pTimeouts) -> bool {
+        match self {
+            P2pNetworkKadStatus::Init => true,
+            P2pNetworkKadStatus::Bootstrapping(_) => false,
+            P2pNetworkKadStatus::Bootstrapped { time, stats } => {
+                let timeout = if stats.requests.iter().any(|req| {
+                        matches!(req, P2pNetworkKadBootstrapRequestStat::Successful(req) if !req.closest_peers.is_empty())
+                    }) {
+                        timeouts.kademlia_bootstrap
+                    } else {
+                        timeouts.kademlia_initial_bootstrap
+                    };
+                is_time_passed(now, *time, timeout)
+            }
+        }
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/p2p/src/network/p2p_network_reducer.rs
+++ b/p2p/src/network/p2p_network_reducer.rs
@@ -1,5 +1,5 @@
 use multiaddr::Multiaddr;
-use openmina_core::error;
+use openmina_core::{error, ChainId};
 
 use crate::{identity::PublicKey, PeerId};
 
@@ -10,7 +10,7 @@ impl P2pNetworkState {
         identity: PublicKey,
         addrs: Vec<Multiaddr>,
         known_peers: Vec<(PeerId, Multiaddr)>,
-        chain_id: &str,
+        chain_id: &ChainId,
         discovery: bool,
     ) -> Self {
         let peer_id = identity.peer_id();
@@ -24,7 +24,7 @@ impl P2pNetworkState {
             Blake2bVar::new(32)
                 .expect("valid constant")
                 .chain(b"/coda/0.0.1/")
-                .chain(chain_id)
+                .chain(chain_id.as_hex())
                 .finalize_variable(&mut key)
                 .expect("good buffer size");
             key.into()

--- a/p2p/src/network/p2p_network_reducer.rs
+++ b/p2p/src/network/p2p_network_reducer.rs
@@ -14,22 +14,7 @@ impl P2pNetworkState {
         discovery: bool,
     ) -> Self {
         let peer_id = identity.peer_id();
-        let pnet_key = {
-            use blake2::{
-                digest::{generic_array::GenericArray, Update, VariableOutput},
-                Blake2bVar,
-            };
-
-            let mut key = GenericArray::default();
-            Blake2bVar::new(32)
-                .expect("valid constant")
-                .chain(b"/coda/0.0.1/")
-                .chain(chain_id.as_hex())
-                .finalize_variable(&mut key)
-                .expect("good buffer size");
-            key.into()
-        };
-
+        let pnet_key = chain_id.preshared_key();
         let discovery_state = discovery.then(|| {
             let mut routing_table =
                 P2pNetworkKadRoutingTable::new(P2pNetworkKadEntry::new(peer_id, addrs));

--- a/p2p/src/network/p2p_network_service.rs
+++ b/p2p/src/network/p2p_network_service.rs
@@ -21,6 +21,7 @@ pub enum MioCmd {
 }
 
 pub trait P2pMioService: redux::Service {
+    fn start_mio(&mut self);
     fn send_mio_cmd(&mut self, cmd: MioCmd);
 }
 

--- a/p2p/src/p2p_actions.rs
+++ b/p2p/src/p2p_actions.rs
@@ -1,4 +1,5 @@
 use openmina_macros::ActionEvent;
+use redux::EnablingCondition;
 use serde::{Deserialize, Serialize};
 
 use super::channels::P2pChannelsAction;
@@ -8,6 +9,7 @@ use super::discovery::P2pDiscoveryAction;
 use super::network::P2pNetworkAction;
 use super::peer::P2pPeerAction;
 use crate::identify::P2pIdentifyAction;
+use crate::P2pState;
 
 pub type P2pActionWithMeta = redux::ActionWithMeta<P2pAction>;
 pub type P2pActionWithMetaRef<'a> = redux::ActionWithMeta<&'a P2pAction>;
@@ -15,6 +17,7 @@ pub type P2pActionWithMetaRef<'a> = redux::ActionWithMeta<&'a P2pAction>;
 #[derive(Serialize, Deserialize, Debug, Clone, derive_more::From, ActionEvent)]
 #[allow(clippy::large_enum_variant)]
 pub enum P2pAction {
+    Initialization(P2pInitializeAction),
     Connection(P2pConnectionAction),
     Disconnection(P2pDisconnectionAction),
     Discovery(P2pDiscoveryAction),
@@ -22,4 +25,17 @@ pub enum P2pAction {
     Channels(P2pChannelsAction),
     Peer(P2pPeerAction),
     Network(P2pNetworkAction),
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, derive_more::From, ActionEvent)]
+#[action_event(fields(display(chain_id)))]
+pub enum P2pInitializeAction {
+    Initialize { chain_id: openmina_core::ChainId },
+}
+
+impl EnablingCondition<P2pState> for P2pInitializeAction {
+    fn is_enabled(&self, _state: &P2pState, _time: redux::Timestamp) -> bool {
+        // this action cannot be called for initialized p2p state
+        false
+    }
 }

--- a/p2p/src/p2p_config.rs
+++ b/p2p/src/p2p_config.rs
@@ -1,6 +1,5 @@
 use std::{collections::BTreeSet, time::Duration};
 
-use openmina_core::ChainId;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -28,9 +27,6 @@ pub struct P2pConfig {
     pub max_peers: usize,
 
     pub timeouts: P2pTimeouts,
-
-    /// Chain id
-    pub chain_id: ChainId,
 
     /// Use peers discovery.
     pub peer_discovery: bool,

--- a/p2p/src/p2p_config.rs
+++ b/p2p/src/p2p_config.rs
@@ -1,5 +1,6 @@
 use std::{collections::BTreeSet, time::Duration};
 
+use openmina_core::ChainId;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -29,7 +30,7 @@ pub struct P2pConfig {
     pub timeouts: P2pTimeouts,
 
     /// Chain id
-    pub chain_id: String,
+    pub chain_id: ChainId,
 
     /// Use peers discovery.
     pub peer_discovery: bool,

--- a/p2p/src/p2p_config.rs
+++ b/p2p/src/p2p_config.rs
@@ -49,6 +49,7 @@ pub struct P2pTimeouts {
     pub snark: Option<Duration>,
     pub initial_peers: Option<Duration>,
     pub kademlia_bootstrap: Option<Duration>,
+    pub kademlia_initial_bootstrap: Option<Duration>,
     pub select: Option<Duration>,
 }
 
@@ -67,6 +68,7 @@ impl Default for P2pTimeouts {
             snark: Some(Duration::from_secs(5)),
             initial_peers: Some(Duration::from_secs(5)),
             kademlia_bootstrap: Some(Duration::from_secs(60)),
+            kademlia_initial_bootstrap: Some(Duration::from_secs(5)),
             select: Some(Duration::from_secs(5)),
         }
     }

--- a/p2p/src/p2p_effects.rs
+++ b/p2p/src/p2p_effects.rs
@@ -6,9 +6,8 @@ use crate::{
         outgoing::P2pConnectionOutgoingAction, P2pConnectionAction, P2pConnectionService,
     },
     disconnection::P2pDisconnectionService,
-    is_time_passed, P2pAction, P2pCryptoService, P2pMioService, P2pNetworkKadKey,
-    P2pNetworkKadStatus, P2pNetworkKademliaAction, P2pNetworkSelectAction, P2pNetworkService,
-    P2pStore, PeerId,
+    P2pAction, P2pCryptoService, P2pMioService, P2pNetworkKadKey, P2pNetworkKademliaAction,
+    P2pNetworkSelectAction, P2pNetworkService, P2pStore, PeerId,
 };
 
 pub fn p2p_timeout_effects<Store, S>(store: &mut Store, meta: &ActionMeta)
@@ -184,14 +183,7 @@ where
             .closest_peers(&P2pNetworkKadKey::from(&key))
             .any(|_| true)
         {
-            let bootstrap_kademlia = match &discovery_state.status {
-                P2pNetworkKadStatus::Init => true,
-                P2pNetworkKadStatus::Bootstrapping(_) => false,
-                P2pNetworkKadStatus::Bootstrapped { time, .. } => {
-                    is_time_passed(now, *time, config.timeouts.kademlia_bootstrap)
-                }
-            };
-            if bootstrap_kademlia {
+            if discovery_state.status.can_bootstrap(now, &config.timeouts) {
                 store.dispatch(P2pNetworkKademliaAction::StartBootstrap { key });
             }
         }

--- a/p2p/src/p2p_effects.rs
+++ b/p2p/src/p2p_effects.rs
@@ -210,6 +210,9 @@ where
 {
     let (action, meta) = action.split();
     match action {
+        P2pAction::Initialization(_) => {
+            // Noop
+        }
         P2pAction::Connection(action) => match action {
             P2pConnectionAction::Outgoing(action) => action.effects(&meta, store),
             P2pConnectionAction::Incoming(action) => action.effects(&meta, store),

--- a/p2p/src/p2p_reducer.rs
+++ b/p2p/src/p2p_reducer.rs
@@ -11,6 +11,9 @@ impl P2pState {
     pub fn reducer(&mut self, action: P2pActionWithMetaRef<'_>) {
         let (action, meta) = action.split();
         match action {
+            P2pAction::Initialization(_) => {
+                // noop
+            }
             P2pAction::Connection(action) => {
                 let my_id = self.my_id();
                 let Some(peer_id) = action.peer_id() else {

--- a/p2p/src/p2p_state.rs
+++ b/p2p/src/p2p_state.rs
@@ -1,5 +1,5 @@
 use multiaddr::multiaddr;
-use openmina_core::block::ArcBlockWithHash;
+use openmina_core::{block::ArcBlockWithHash, ChainId};
 use redux::Timestamp;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
@@ -25,7 +25,7 @@ pub struct P2pState {
 }
 
 impl P2pState {
-    pub fn new(config: P2pConfig) -> Self {
+    pub fn new(config: P2pConfig, chain_id: &ChainId) -> Self {
         let addrs = config
             .libp2p_port
             .map(|port| multiaddr!(Ip4([127, 0, 0, 1]), Tcp((port))))
@@ -69,7 +69,7 @@ impl P2pState {
             config.identity_pub_key.clone(),
             addrs,
             known_peers,
-            &config.chain_id,
+            chain_id,
             config.peer_discovery,
         );
         Self {

--- a/p2p/src/service_impl/webrtc_with_libp2p.rs
+++ b/p2p/src/service_impl/webrtc_with_libp2p.rs
@@ -1,4 +1,5 @@
 use openmina_core::channels::mpsc;
+use openmina_core::ChainId;
 
 use crate::{
     channels::{ChannelId, ChannelMsg, MsgId, P2pChannelsService},
@@ -28,7 +29,7 @@ pub trait P2pServiceWebrtcWithLibp2p: P2pServiceWebrtc {
     fn init<E: From<P2pEvent> + Send + 'static, S: TaskSpawner>(
         _libp2p_port: Option<u16>,
         secret_key: SecretKey,
-        _chain_id: Vec<u8>,
+        _chain_id: ChainId,
         event_source_sender: mpsc::UnboundedSender<E>,
         spawner: S,
     ) -> P2pServiceCtx {

--- a/p2p/testing/src/cluster.rs
+++ b/p2p/testing/src/cluster.rs
@@ -358,7 +358,6 @@ impl Cluster {
             ask_initial_peers_interval: Duration::from_secs(5),
             enabled_channels: p2p::channels::ChannelId::for_libp2p().collect(),
             max_peers: 100,
-            chain_id: self.chain_id.clone(),
             peer_discovery: config.discovery,
             timeouts: config.timeouts,
             initial_time: Duration::ZERO,
@@ -402,7 +401,7 @@ impl Cluster {
             },
             service,
             SystemTime::now(),
-            State(P2pState::new(config)),
+            State(P2pState::new(config, &self.chain_id)),
         );
 
         let node_id = RustNodeId(self.rust_nodes.len());
@@ -415,13 +414,8 @@ impl Cluster {
         let secret_key = Self::secret_key(config.peer_id, node_id.0, LIBP2P_NODE_SIG_BYTE);
         let libp2p_port = self.next_port()?;
 
-        let swarm = create_swarm(
-            secret_key,
-            libp2p_port,
-            config.port_reuse,
-            self.chain_id.clone(),
-        )
-        .map_err(|err| Error::Libp2pSwarm(err.to_string()))?;
+        let swarm = create_swarm(secret_key, libp2p_port, config.port_reuse, &self.chain_id)
+            .map_err(|err| Error::Libp2pSwarm(err.to_string()))?;
         self.libp2p_nodes.push(Libp2pNode::new(swarm));
 
         Ok(node_id)

--- a/p2p/testing/src/libp2p_node.rs
+++ b/p2p/testing/src/libp2p_node.rs
@@ -75,9 +75,6 @@ pub struct Libp2pBehaviour {
     pub kademlia: kad::Behaviour<MemoryStore>,
 
     #[behaviour(ignore)]
-    pub chain_id: ChainId,
-
-    #[behaviour(ignore)]
     port: u16,
 
     // TODO(vlad9486): move maps inside `RpcBehaviour`
@@ -94,12 +91,12 @@ pub(crate) fn create_swarm(
     secret_key: p2p::identity::SecretKey,
     port: u16,
     port_reuse: bool,
-    chain_id: ChainId,
+    chain_id: &ChainId,
 ) -> Result<Swarm, Box<dyn Error>> {
     let identity_keys = libp2p::identity::Keypair::ed25519_from_bytes(secret_key.to_bytes())
         .expect("secret key bytes must be valid");
 
-    let psk = libp2p::pnet::PreSharedKey::new(openmina_core::preshared_key(chain_id.clone()));
+    let psk = libp2p::pnet::PreSharedKey::new(chain_id.preshared_key());
     let identify = libp2p::identify::Behaviour::new(libp2p::identify::Config::new(
         "ipfs/0.1.0".to_string(),
         identity_keys.public(),
@@ -164,7 +161,6 @@ pub(crate) fn create_swarm(
         identify,
         kademlia,
         rpc,
-        chain_id,
         port,
         ongoing: Default::default(),
         ongoing_incoming: Default::default(),

--- a/p2p/testing/src/libp2p_node.rs
+++ b/p2p/testing/src/libp2p_node.rs
@@ -6,6 +6,7 @@ use libp2p::{
     Transport,
 };
 use mina_p2p_messages::rpc_kernel::RpcTag;
+use openmina_core::ChainId;
 use p2p::PeerId;
 
 use libp2p_rpc_behaviour::StreamId;
@@ -74,7 +75,7 @@ pub struct Libp2pBehaviour {
     pub kademlia: kad::Behaviour<MemoryStore>,
 
     #[behaviour(ignore)]
-    pub chain_id: String,
+    pub chain_id: ChainId,
 
     #[behaviour(ignore)]
     port: u16,
@@ -93,12 +94,12 @@ pub(crate) fn create_swarm(
     secret_key: p2p::identity::SecretKey,
     port: u16,
     port_reuse: bool,
-    chain_id: &str,
+    chain_id: ChainId,
 ) -> Result<Swarm, Box<dyn Error>> {
     let identity_keys = libp2p::identity::Keypair::ed25519_from_bytes(secret_key.to_bytes())
         .expect("secret key bytes must be valid");
 
-    let psk = libp2p::pnet::PreSharedKey::new(openmina_core::preshared_key(chain_id));
+    let psk = libp2p::pnet::PreSharedKey::new(openmina_core::preshared_key(chain_id.clone()));
     let identify = libp2p::identify::Behaviour::new(libp2p::identify::Config::new(
         "ipfs/0.1.0".to_string(),
         identity_keys.public(),
@@ -163,7 +164,7 @@ pub(crate) fn create_swarm(
         identify,
         kademlia,
         rpc,
-        chain_id: chain_id.to_string(),
+        chain_id,
         port,
         ongoing: Default::default(),
         ongoing_incoming: Default::default(),

--- a/p2p/testing/src/service.rs
+++ b/p2p/testing/src/service.rs
@@ -37,7 +37,7 @@ impl ClusterService {
     ) -> Self {
         let mio = {
             let event_sender = event_sender.clone();
-            MioService::run(move |mio_event| {
+            MioService::new(move |mio_event| {
                 let _ = event_sender.send(mio_event.into());
                 //.expect("cannot send mio event")
             })


### PR DESCRIPTION
This PR adds possibility to make delayed initialization for p2p part. This is needed for calculating chain_id in the state machine.

fixes #418 