### PR TITLE
chore(node): Replace serde_cbor with ciborium

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,6 +944,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2352,9 +2379,13 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "1.8.3"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
 
 [[package]]
 name = "hash-tool"
@@ -3633,6 +3664,7 @@ dependencies = [
  "blake2",
  "bs58 0.4.0",
  "chrono",
+ "ciborium",
  "crc32fast",
  "derive_more",
  "getrandom 0.2.14",
@@ -3657,7 +3689,6 @@ dependencies = [
  "rand_seeder",
  "rayon",
  "serde",
- "serde_cbor",
  "serde_json",
  "serde_with 3.7.0",
  "sha2 0.10.8",
@@ -3957,6 +3988,7 @@ name = "node"
 version = "0.4.0"
 dependencies = [
  "anyhow",
+ "ciborium",
  "derive_more",
  "lazy_static",
  "linkme",
@@ -3972,7 +4004,6 @@ dependencies = [
  "regex",
  "rust-format",
  "serde",
- "serde_cbor",
  "serde_json",
  "serde_with 3.7.0",
  "snark",
@@ -4412,6 +4443,7 @@ dependencies = [
  "anyhow",
  "axum",
  "chrono",
+ "ciborium",
  "clap 4.5.2",
  "console",
  "ctrlc",
@@ -4435,7 +4467,6 @@ dependencies = [
  "redux",
  "reqwest",
  "serde",
- "serde_cbor",
  "serde_json",
  "strum",
  "strum_macros",
@@ -5830,16 +5861,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half",
- "serde",
 ]
 
 [[package]]

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -59,7 +59,7 @@ uuid = { version = "1", features = [ "v4" ] }
 
 serde = { version = "1.0", features = ["rc"] }
 serde_json = { version = "1.0", features = ["float_roundtrip"] }
-serde_cbor = "0.11.2"
+ciborium = "0.2.2"
 
 backtrace = "0.3"
 derive_more = "0.99.17"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -28,7 +28,7 @@ snark = { path = "../snark" }
 p2p = { path = "../p2p" }
 openmina-node-account = { path = "./account" }
 tokio = { version = "1.26.0" }
-serde_cbor = "0.11.2"
+ciborium = "0.2.2"
 
 [build-dependencies]
 regex = "1"

--- a/node/testing/Cargo.toml
+++ b/node/testing/Cargo.toml
@@ -19,7 +19,7 @@ serde = "1.0.147"
 serde_json = { version = "1.0.82", features = ["unbounded_depth", "arbitrary_precision"] }
 thiserror = "1.0.37"
 anyhow = "1.0.70"
-serde_cbor = "0.11.2"
+ciborium = "0.2.2"
 rand = "0.8"
 tokio = { version = "1.26.0" }
 num_cpus = "1.0"

--- a/node/testing/src/cluster/mod.rs
+++ b/node/testing/src/cluster/mod.rs
@@ -71,7 +71,7 @@ fn read_index<T: DeserializeOwned>(name: &str) -> Option<T> {
                 }
             }
         })
-        .and_then(|file| match serde_cbor::from_reader(file) {
+        .and_then(|file| match ciborium::de::from_reader(file) {
             Ok(v) => Some(v),
             Err(e) => {
                 warn!(system_time(); "cannot read verifier index for {name}: {e}");
@@ -100,7 +100,7 @@ fn write_index<T: Serialize>(name: &str, index: &T) -> Option<()> {
                 }
             }
         })
-        .and_then(|file| match serde_cbor::to_writer(file, index) {
+        .and_then(|file| match ciborium::ser::into_writer(index, file) {
             Ok(_) => Some(()),
             Err(e) => {
                 warn!(system_time(); "cannot write verifier index for {name}: {e}");


### PR DESCRIPTION
serde_cbor is unmaintained while ciborium is actively maintained. Also serde_cbor may be negativelly affecting our build times.