### PR TITLE
fix: Update rustls dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5680,9 +5680,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.8"
+version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446e14c5cda4f3f30fe71863c34ec70f5ac79d6087097ad0bb433e1be5edf04c"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring 0.17.5",


### PR DESCRIPTION
Fixes https://github.com/openmina/openmina/security/dependabot/27