### PR TITLE
Added compile time check for size limit of Action

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4176,6 +4176,7 @@ dependencies = [
  "serde_json",
  "serde_with 3.7.0",
  "snark",
+ "static_assertions",
  "strum 0.26.2",
  "strum_macros 0.26.4",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ serde = "1.0.190"
 serde_json = "1.0.107"
 serde_with = { version = "3.7.0", features = ["hex"] }
 linkme = "0.3.22"
+static_assertions = "1.1.0"
 
 [profile.fuzz]
 inherits = "release"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -29,6 +29,7 @@ p2p = { path = "../p2p" }
 openmina-node-account = { path = "./account" }
 tokio = { version = "1.26.0" }
 postcard = { version = "1.0.8", features = ["use-std"] }
+static_assertions.workspace = true
 
 [build-dependencies]
 regex = "1"

--- a/node/src/action.rs
+++ b/node/src/action.rs
@@ -19,6 +19,10 @@ pub trait ActionKindGet {
     fn kind(&self) -> crate::ActionKind;
 }
 
+// Static limit for size of [`Action`] set to 512 bytes, if [`Action`] size is bigger code won't compile
+// compile error: "attempt to compute `0_usize - 1_usize`, which would overflow"
+static_assertions::const_assert!(std::mem::size_of::<Action>() <= 512);
+
 #[derive(derive_more::From, Serialize, Deserialize, Debug, Clone)]
 pub enum Action {
     CheckTimeouts(CheckTimeoutsAction),

--- a/node/src/watched_accounts/watched_accounts_actions.rs
+++ b/node/src/watched_accounts/watched_accounts_actions.rs
@@ -38,7 +38,7 @@ pub enum WatchedAccountsAction {
     },
     LedgerInitialStateGetSuccess {
         pub_key: NonZeroCurvePoint,
-        data: Option<MinaBaseAccountBinableArgStableV2>,
+        data: Option<Box<MinaBaseAccountBinableArgStableV2>>,
     },
     TransactionsIncludedInBlock {
         pub_key: NonZeroCurvePoint,
@@ -56,7 +56,7 @@ pub enum WatchedAccountsAction {
     BlockLedgerQuerySuccess {
         pub_key: NonZeroCurvePoint,
         block_hash: StateHash,
-        ledger_account: MinaBaseAccountBinableArgStableV2,
+        ledger_account: Box<MinaBaseAccountBinableArgStableV2>,
     },
 }
 

--- a/node/src/watched_accounts/watched_accounts_reducer.rs
+++ b/node/src/watched_accounts/watched_accounts_reducer.rs
@@ -59,7 +59,7 @@ impl WatchedAccountsState {
                 account.initial_state = WatchedAccountLedgerInitialState::Success {
                     time: meta.time(),
                     block: block.clone(),
-                    data: data.clone().map(Box::new),
+                    data: data.clone(),
                 };
             }
             WatchedAccountsAction::TransactionsIncludedInBlock { pub_key, block } => {
@@ -148,7 +148,7 @@ impl WatchedAccountsState {
                     } => WatchedAccountBlockState::LedgerAccountGetSuccess {
                         block: block.clone(),
                         transactions: std::mem::take(transactions),
-                        ledger_account: Box::new(ledger_account.clone()),
+                        ledger_account: ledger_account.clone(),
                     },
                     _ => return,
                 };


### PR DESCRIPTION
Added limit size for [`Action`](https://github.com/openmina/openmina/blob/develop/node/src/action.rs#L23), if size of `Action` is bigger than `512` bytes code won't compile with error:
```
attempt to compute `0_usize - 1_usize`, which would overflow
```