### PR TITLE
Implement genesis config caching.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4164,6 +4164,7 @@ dependencies = [
  "mina-p2p-messages",
  "mina-signer",
  "mina-tree",
+ "multihash 0.18.1",
  "num_enum 0.5.11",
  "openmina-core",
  "openmina-node-account",

--- a/ledger/src/proofs/caching.rs
+++ b/ledger/src/proofs/caching.rs
@@ -462,3 +462,18 @@ where
 pub fn openmina_cache_path<P: AsRef<Path>>(path: P) -> Option<PathBuf> {
     std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".cache/openmina").join(path))
 }
+
+pub fn ensure_path_exists<P: AsRef<Path> + Clone>(path: P) -> Result<(), std::io::Error> {
+    match std::fs::metadata(path.clone()) {
+        Ok(meta) if meta.is_dir() => Ok(()),
+        Ok(_) => Err(std::io::Error::new(
+            std::io::ErrorKind::AlreadyExists,
+            "Path exists but is not a directory",
+        )),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            std::fs::create_dir_all(path)?;
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
+}

--- a/ledger/src/proofs/caching.rs
+++ b/ledger/src/proofs/caching.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use ark_ec::{short_weierstrass_jacobian::GroupAffine, AffineCurve, ModelParameters};
 use ark_poly::{univariate::DensePolynomial, Radix2EvaluationDomain};
@@ -453,4 +457,8 @@ where
 {
     let srs: SRSCached = postcard::from_bytes(bytes).unwrap();
     (&srs).into()
+}
+
+pub fn openmina_cache_path<P: AsRef<Path>>(path: P) -> Option<PathBuf> {
+    std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".cache/openmina").join(path))
 }

--- a/ledger/src/proofs/verifier_index.rs
+++ b/ledger/src/proofs/verifier_index.rs
@@ -1,7 +1,7 @@
 use std::{
     fs::File,
     io::{Read, Write},
-    path::{Path, PathBuf},
+    path::Path,
     sync::Arc,
 };
 
@@ -34,7 +34,7 @@ use crate::{
 };
 
 use super::{
-    caching::{verifier_index_from_bytes, verifier_index_to_bytes},
+    caching::{openmina_cache_path, verifier_index_from_bytes, verifier_index_to_bytes},
     transaction::InnerCurve,
 };
 use super::{
@@ -45,10 +45,6 @@ use super::{
 pub enum VerifierKind {
     Blockchain,
     Transaction,
-}
-
-fn openmina_cache_path<P: AsRef<Path>>(path: P) -> Option<PathBuf> {
-    std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".cache/openmina").join(path))
 }
 
 fn read_index(path: &Path, digest: &[u8]) -> anyhow::Result<VerifierIndex<Pallas>> {

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -17,6 +17,7 @@ time = { version = "0.3.36", features = ["parsing"] }
 anyhow = "1.0.70"
 num_enum = "0.5.7"
 redux = { workspace = true }
+multihash = { version = "0.18.1", features = ["blake2b"] }
 mina-hasher = { workspace = true }
 mina-signer = { workspace = true }
 ledger = { workspace = true }

--- a/node/src/daemon_json/json_ledger.rs
+++ b/node/src/daemon_json/json_ledger.rs
@@ -1,5 +1,7 @@
 use core::str::FromStr;
 use mina_hasher::Fp;
+use mina_p2p_messages::binprot::BinProtWrite;
+use multihash::{Blake2b256, Hasher};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use std::fmt::{self, Display, Formatter};
@@ -10,6 +12,8 @@ use ledger::{
     VotingFor, ZkAppAccount, ZkAppUri,
 };
 use openmina_node_account::{AccountPublicKey, AccountSecretKey};
+
+use crate::ledger::LEDGER_DEPTH;
 
 type RawCurrency = String;
 type RawSlot = String;
@@ -60,6 +64,37 @@ impl Ledger {
                 accounts
             }
         }
+    }
+
+    /// Typically a ledger is identified by its hash, but if hash is
+    /// not given in config, we construct a name by hashing the ledger
+    /// config so that we can recognise a ledger we already have
+    /// cached without reconstructing it (which is expensive).
+    /// Note that the name contains some constants - the purpose of this
+    /// is to invalidate all caches when these constants change.
+    /// See: https://github.com/MinaProtocol/mina/blob/develop/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml#L105
+    pub fn ledger_name(&self) -> String {
+        self.hash.clone().unwrap_or_else(|| {
+            let mut hash = Blake2b256::default();
+            hash.update(LEDGER_DEPTH.to_string().as_bytes());
+            let balances = self
+                .balances
+                .clone()
+                .unwrap_or_default()
+                .iter()
+                .fold(String::new(), |acc, (i, balance)| {
+                    format!("{} {} {}", acc, i, balance)
+                });
+            hash.update(balances.as_bytes());
+            let empty_account = ledger::Account::empty();
+            hash.update(empty_account.hash().to_string().as_bytes());
+            let mut empty_account_enc: Vec<u8> = Vec::new();
+            empty_account
+                .binprot_write(&mut empty_account_enc)
+                .expect("failed to write account");
+            hash.update(empty_account_enc.as_slice());
+            format!("{:x?}", hash.finalize())
+        })
     }
 }
 

--- a/node/src/daemon_json/mod.rs
+++ b/node/src/daemon_json/mod.rs
@@ -4,7 +4,8 @@ mod json_genesis;
 mod json_ledger;
 pub use json_genesis::Genesis;
 pub use json_ledger::{
-    Account, AccountConfigError, AccountPermissions, AccountTiming, Ledger, Zkapp,
+    build_ledger_name, Account, AccountConfigError, AccountPermissions, AccountTiming, Ledger,
+    Zkapp,
 };
 
 /// This type represents a JSON object loaded from daemon.json
@@ -36,6 +37,22 @@ pub struct EpochData {
     pub hash: Option<String>,
     pub s3_data_hash: Option<String>,
     pub seed: String,
+}
+
+impl EpochData {
+    pub fn ledger_name(&self) -> String {
+        self.hash.clone().unwrap_or_else(|| {
+            build_ledger_name(
+                self.accounts.as_ref().map(Vec::len).unwrap_or(0),
+                self.accounts
+                    .clone()
+                    .unwrap_or_default()
+                    .iter()
+                    .map(|a| a.balance.clone())
+                    .enumerate(),
+            )
+        })
+    }
 }
 
 #[cfg(test)]

--- a/node/src/transition_frontier/genesis/transition_frontier_genesis_config.rs
+++ b/node/src/transition_frontier/genesis/transition_frontier_genesis_config.rs
@@ -2,12 +2,11 @@ use std::{
     borrow::Cow,
     fs::File,
     io::{Read, Write},
-    path::PathBuf,
     str::FromStr,
 };
 
 use crate::{account::AccountSecretKey, daemon_json::EpochData};
-use ledger::{scan_state::currency::Balance, BaseLedger};
+use ledger::{proofs::caching::openmina_cache_path, scan_state::currency::Balance, BaseLedger};
 use mina_hasher::Fp;
 use mina_p2p_messages::{
     binprot::{
@@ -283,13 +282,8 @@ impl GenesisConfig {
                     next_epoch_seed,
                 };
                 let prebuilt = PrebuiltGenesisConfig::try_from(*config.clone())?;
-                let cache_filename = std::env::var_os("HOME")
-                    .map(|home| {
-                        PathBuf::from(home)
-                            .join(".cache/openmina/ledgers")
-                            .join(ledger_hash.to_string() + ".bin")
-                    })
-                    .unwrap();
+                let cache_filename =
+                    openmina_cache_path(format!("ledgers/{}.bin", ledger_hash)).unwrap();
                 let filename_str = cache_filename
                     .clone()
                     .into_os_string()


### PR DESCRIPTION
When genesis config is loaded and genesis ledger reconstructed from JSON config, it is also cached on disk. When the same JSON loaded again, the node finds the cache on disk and loads it instead, which is significantly faster than building the ledgers from JSON. 