### PR TITLE
fix: Restore original `Action::is_enabled` condition during replays w…

### DIFF
--- a/node/src/action.rs
+++ b/node/src/action.rs
@@ -57,15 +57,13 @@ pub struct CheckTimeoutsAction {}
 
 impl redux::EnablingCondition<crate::State> for CheckTimeoutsAction {}
 
-//#[cfg(feature = "replay")]
-//impl redux::EnablingCondition<crate::State> for Action {
-//    fn is_enabled(&self, _: &crate::State, _time: redux::Timestamp) -> bool {
-//        true
-//    }
-//}
-
 impl redux::EnablingCondition<crate::State> for Action {
     fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        #[cfg(feature = "replay")]
+        if crate::replay_status::is_enabled() {
+            return true;
+        }
+
         match self {
             Action::CheckTimeouts(a) => a.is_enabled(state, time),
             Action::EventSource(a) => a.is_enabled(state, time),

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -90,3 +90,18 @@ where
         }
     }
 }
+
+#[cfg(feature = "replay")]
+pub mod replay_status {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    static REPLAY_STATUS: AtomicBool = AtomicBool::new(false);
+
+    pub fn toggle_enabled(value: bool) {
+        REPLAY_STATUS.store(value, Ordering::Relaxed);
+    }
+
+    pub fn is_enabled() -> bool {
+        REPLAY_STATUS.load(Ordering::Relaxed)
+    }
+}

--- a/node/testing/src/scenarios/record_replay/bootstrap.rs
+++ b/node/testing/src/scenarios/record_replay/bootstrap.rs
@@ -57,12 +57,14 @@ impl RecordReplayBootstrap {
         let node = runner.node(node_id).unwrap();
 
         let recording_dir = node.work_dir().child("recorder");
+        node::replay_status::toggle_enabled(true);
         let replayed_node = replay_state_with_input_actions(
             recording_dir.as_os_str().to_str().unwrap(),
             None,
             |_, _| Ok(()),
         )
         .expect("replay failed");
+        node::replay_status::toggle_enabled(false);
 
         assert_eq!(
             node.state().last_action(),


### PR DESCRIPTION
…here the result is always `true`