### PR TITLE
fix: Restore original `Action::is_enabled` condition during replays w…

### DIFF
--- a/node/native/src/replay.rs
+++ b/node/native/src/replay.rs
@@ -125,6 +125,7 @@ pub fn replay_state_with_input_actions(
                 eprintln!("Warning! Executing last action for which we might not have all effect actions recorded.");
             }
             let action = input_action.take().unwrap();
+            node::replay_status::set_next_force_enabled();
             store.dispatch(action);
         }
     }

--- a/node/src/action.rs
+++ b/node/src/action.rs
@@ -57,15 +57,13 @@ pub struct CheckTimeoutsAction {}
 
 impl redux::EnablingCondition<crate::State> for CheckTimeoutsAction {}
 
-//#[cfg(feature = "replay")]
-//impl redux::EnablingCondition<crate::State> for Action {
-//    fn is_enabled(&self, _: &crate::State, _time: redux::Timestamp) -> bool {
-//        true
-//    }
-//}
-
 impl redux::EnablingCondition<crate::State> for Action {
     fn is_enabled(&self, state: &crate::State, time: redux::Timestamp) -> bool {
+        #[cfg(feature = "replay")]
+        if crate::replay_status::pop_next_force_enabled() {
+            return true;
+        }
+
         match self {
             Action::CheckTimeouts(a) => a.is_enabled(state, time),
             Action::EventSource(a) => a.is_enabled(state, time),

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -90,3 +90,18 @@ where
         }
     }
 }
+
+#[cfg(feature = "replay")]
+pub mod replay_status {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    static FORCE_NEXT_ENABLED: AtomicBool = AtomicBool::new(false);
+
+    pub fn set_next_force_enabled() {
+        FORCE_NEXT_ENABLED.store(true, Ordering::Relaxed);
+    }
+
+    pub fn pop_next_force_enabled() -> bool {
+        FORCE_NEXT_ENABLED.fetch_and(false, Ordering::Relaxed)
+    }
+}


### PR DESCRIPTION
…here the result is always `true`