### PR TITLE
Improved readme usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,63 +1,53 @@
 
-# The Open Mina Node
+# The OpenMina Node
 
 [![Openmina Daily](https://github.com/openmina/openmina/actions/workflows/daily.yaml/badge.svg)](https://github.com/openmina/openmina/actions/workflows/daily.yaml) [![Changelog][changelog-badge]][changelog] [![release-badge]][release-link] [![Apache licensed]][Apache link]
 
-The Open Mina Node is a Mina node written completely in Rust and capable of verifying blocks of transactions, producing blocks and generating SNARKs.
+The OpenMina Node is a Mina node written entirely in Rust, capable of verifying blocks of transactions, producing blocks and generating SNARKs.
 
-In the design of the Open Mina node, we are utilizing much of the same logic as in the Mina Web Node. The key difference is that unlike the Web Node, which is an in-browser node with limited resources, the Open Mina node is able to perform resource-intensive tasks such as SNARK proof generation.
+Unlike the resource-limited Mina Web Node, OpenMina handles resource-intensive tasks like SNARK proof generation.
 
-
-## Overview of the Node’s current functionalities
-
-Currently, with the Open Mina node, you can:
-
-
-
-* Connect to the network and sync up to the best tip block
-* Validate and apply new blocks and transactions to update consensus and ledger state.
-* Produce SNARKs to complete SNARK work.
-* Broadcast messages: blocks, SNARK pool
+| The OpenMina node allows you to                                                             | In Development                                               | Future Plans                                                                                                                |
+|---------------------------------------------------------------------------------------------|--------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| &#9745; **Connect** to the network and sync up to the best tip block                              | &#9744; Produce SNARKs in Rust (currently we use OCaml subprocess for that) | &#9744; Direct transfer of MINA funds                                                                                          |
+| &#9745; **Validate** and apply new blocks and transactions to update consensus and ledger state   |                                                              | &#9744; Block production                                                                                                       |
+| &#9745; **Produce SNARKs** to complete SNARK work                                                 |                                                              | &#9744; The ability to record/replay all blocks                                                                                      |
+| &#9745; **Broadcast** messages: blocks, SNARK pool                                                |                                                              | &#9744; SnarkyJS support for Rust node, enabling direct injection of simple transactions, such as transferring Mina funds      |
+| &#9745; **SNARK proof generation** for transactions                                                                                             |                                                              |                                                                          |
 
 
-We are working on the following:
+## Table of Contents
+- Try Yourself
+  - [Block Producer Demo](#producer-demo)
+  - [Quick-start a Node with Docker Compose](#)
+  - [Building a Node from Source](#)
+- Learn about the Repository
+  - [Repository Structure](#repository-structure)
+  - [Documentation](#documentation)
+  - [License](#license)
 
+## Block Producer Demo
+This demo runs in a private network with block proofs disabled, eliminating the need to wait for staking ledger inclusion.
 
-* Produce SNARKs in Rust (currently we use OCaml subprocess for that)
+[Follow the detailed guide](docs/producer-demo.md).
 
+## Quick-start a Node with Docker Compose
 
-In the future, we plan to implement:
-
-* Direct transfer of MINA funds
-* Block production
-* SNARK proof generation for transactions
-* SnarkyJS support for Rust node, thanks to which you will be able to directly inject simple transactions, such as transferring Mina funds from one account to another.
-* The ability to record/replay all blocks
-
-## Producer demo
-
-See the detailed [guide](docs/producer-demo.md).
-
-## How to launch (with docker compose):
-
-Run:
-
+#### 1. Run:
 ```
 docker compose up
 ```
+#### 2. Visit http://localhost:8070 in your browser.
+- By default, `docker compose up` will use the latest node and frontend images available (tagged with `latest`), but specific versions can be selected by using the `OPENMINA_TAG` and `OPENMINA_FRONTEND_TAG` variables.
+- The node will be running on the Berkeley network.
 
-Then visit http://localhost:8070 in your browser.
-
-By default, `docker compose up` will use the latest node and frontend images available (tagged with `latest`), but specific versions can be selected by using the `OPENMINA_TAG` and `OPENMINA_FRONTEND_TAG` variables.
-
-## How to launch (without docker compose):
+## Building a Node from Source
 
 This installation guide has been tested on Debian and Ubuntu and should work on most distributions of Linux.
 
-**Pre-requisites:**
+### 1. Install node pre-requisites:
 
 Ubuntu or Debian-based Linux distribution with the following packages installed:
-
 - `curl`
 - `git`
 - `libssl-dev`
@@ -65,31 +55,27 @@ Ubuntu or Debian-based Linux distribution with the following packages installed:
 - `protobuf-compiler`
 - `build-essential`
 
-Example (debian-based):
+####  MacOS
 
+If Homebrew is not installed:
+
+```sh
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+``` sh
+brew install curl git openssl pkg-config protobuf gcc make
+```
+
+#### Linux (Debian-based)
 ``` sh
 # Either using "sudo" or as the "root" user
 sudo apt install curl git libssl-dev pkg-config protobuf-compiler build-essential
 ```
 
-Example (macOS):
-
-If you have not yet installed homebrew:
-
-```sh
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-```
-
-``` sh
-brew install curl git openssl pkg-config protobuf gcc make
-```
-
+### 2. Build and Run the Node:
 **Steps (for Debian-based Linux distros and macOS):**
 
 Open up the command line and enter the following:
-
-And then:
-
 ```sh
 # Install rustup and set the default Rust toolchain to 1.77 (newer versions work too)
 curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.77
@@ -102,49 +88,46 @@ cd openmina/
 cargo run --release -p cli node
 ```
 
-## How to launch the UI:
+### 3. Install Dashboard pre-requisites:
 
-## Prerequisites
+#### 3A. Node.js v20.11.1
 
-### 1. Node.js v20.11.1
-
-#### MacOS
+##### MacOS
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 brew install node@20.11.1
 ```
-
-#### Linux
+##### Linux (Debian-based)
 ```bash
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
 source ~/.bashrc
 nvm install 20.11.1
 ```
-
-#### Windows
+##### Windows
 Download [Node.js v20.11.1](https://nodejs.org/) from the official website, open the installer and follow the prompts to complete the installation.
 
-### 2. Angular CLI v16.2.0
+#### 3B. Angular CLI v16.2.0
 ```bash
 npm install -g @angular/cli@16.2.0
 ```
 
-### 3. Installation
-Open a terminal and navigate to this project's root directory
+### 4. Build and Run Dashboard Application
 
+#### 4A. Open a terminal and navigate to this project's root directory:
 ```bash
 cd PROJECT_LOCATION/openmina/frontend
 ```
-Install the dependencies
+#### 4B. Install the dependencies:
 ```bash
 npm install
 ```
 
-## Run the application
+#### 4C. Run the application:
 
 ```bash
 npm start
 ```
+<kbd> ![Image](https://github.com/openmina/mina-frontend/assets/1679939/40428a22-0691-473a-a15c-c2e610a2217b)
 
 ## Repository Structure
 
@@ -160,9 +143,163 @@ npm start
 - [cli/](cli) - OpenMina cli.
 - [frontend/](frontend) - OpenMina frontend.
 
-
 [Details regarding architecture](ARCHITECTURE.md)
 
+## The Open Mina Documentation
+
+- [Why we are developing Open Mina](docs/why-openmina.md)
+- What is Open Mina?
+  - [Openmina Node](#the-open-mina-node)
+  - [The Mina Web Node](https://github.com/openmina/webnode/blob/main/README.md)
+- Core components
+  - [P2P communication](https://github.com/openmina/openmina/blob/documentation/docs/p2p_service.md)
+    - [GossipSub](https://github.com/openmina/mina-wiki/blob/3ea9041e52fb2e606918f6c60bd3a32b8652f016/p2p/mina-gossip.md)
+  - [Scan state](docs/scan-state.md)
+  - [SNARKs](docs/snark-work.md)
+- Developer tools
+  - [Debugger](https://github.com/openmina/mina-network-debugger/blob/main/README.md)
+  - [Front End](https://github.com/openmina/mina-frontend/blob/main/README.md)
+    - [Dashboard](https://github.com/openmina/mina-frontend/blob/main/docs/MetricsTracing.md#Dashboard)
+- [Testing](docs/testing/testing.md)
+- How to run
+  - [Launch Openmina node](#how-to-launch-without-docker-compose)
+  - [Launch Node with UI](#how-to-launch-with-docker-compose)
+  - [Debugger](https://github.com/openmina/mina-network-debugger?tab=readme-ov-file#Preparing-for-build)
+  - [Web Node](https://github.com/openmina/webnode/blob/main/README.md#try-out-the-mina-web-node)
+- External links
+  - [Medium](https://medium.com/openmina)
+  - [Twitter](https://twitter.com/viable_systems)
+
+
+[changelog]: ./CHANGELOG.md
+[changelog-badge]: https://img.shields.io/badge/changelog-Changelog-%23E05735
+
+[release-badge]: https://img.shields.io/github/v/release/openmina/openmina
+[release-link]: https://github.com/openmina/openmina/releases/latest
+
+[Apache licensed]: https://img.shields.io/badge/license-Apache_2.0-blue.svg
+[Apache link]: https://github.com/openmina/openmina/blob/master/LICENSE
+
+---
+
+## Block Producer Demo
+This demo runs in a private network with block proofs disabled, eliminating the need to wait for staking ledger inclusion.
+
+[Follow the detailed guide](docs/producer-demo.md).
+
+## Quick-start a Node with Docker Compose
+
+#### 1. Run:
+```
+docker compose up
+```
+#### 2. Visit http://localhost:8070 in your browser.
+- By default, `docker compose up` will use the latest node and frontend images available (tagged with `latest`), but specific versions can be selected by using the `OPENMINA_TAG` and `OPENMINA_FRONTEND_TAG` variables.
+- The node will be running on the Berkeley network.
+
+## Building a Node from Source
+
+This installation guide has been tested on Debian and Ubuntu and should work on most distributions of Linux.
+
+### 1. Install node pre-requisites:
+
+Ubuntu or Debian-based Linux distribution with the following packages installed:
+- `curl`
+- `git`
+- `libssl-dev`
+- `pkg-config`
+- `protobuf-compiler`
+- `build-essential`
+
+####  MacOS
+
+If Homebrew is not installed:
+
+```sh
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+``` sh
+brew install curl git openssl pkg-config protobuf gcc make
+```
+
+#### Linux (Debian-based)
+``` sh
+# Either using "sudo" or as the "root" user
+sudo apt install curl git libssl-dev pkg-config protobuf-compiler build-essential
+```
+
+### 2. Build and Run the Node:
+**Steps (for Debian-based Linux distros and macOS):**
+
+Open up the command line and enter the following:
+```sh
+# Install rustup and set the default Rust toolchain to 1.77 (newer versions work too)
+curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.77
+# Setup the current shell with rustup
+source "$HOME/.cargo/env"
+# Clone the openmina repository
+git clone https://github.com/openmina/openmina.git
+cd openmina/
+# Build and run the node
+cargo run --release -p cli node
+```
+
+### 3. Install Dashboard pre-requisites:
+
+#### 3A. Node.js v20.11.1
+
+##### MacOS
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+brew install node@20.11.1
+```
+##### Linux (Debian-based)
+```bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
+source ~/.bashrc
+nvm install 20.11.1
+```
+##### Windows
+Download [Node.js v20.11.1](https://nodejs.org/) from the official website, open the installer and follow the prompts to complete the installation.
+
+#### 3B. Angular CLI v16.2.0
+```bash
+npm install -g @angular/cli@16.2.0
+```
+
+### 4. Build and Run Dashboard Application
+
+#### 4A. Open a terminal and navigate to this project's root directory:
+```bash
+cd PROJECT_LOCATION/openmina/frontend
+```
+#### 4B. Install the dependencies:
+```bash
+npm install
+```
+
+#### 4C. Run the application:
+
+```bash
+npm start
+```
+<kbd> ![Image](https://github.com/openmina/mina-frontend/assets/1679939/40428a22-0691-473a-a15c-c2e610a2217b)
+
+## Repository Structure
+
+- [core/](core) - Provides basic types needed to be shared across different
+  components of the node.
+- [ledger/](ledger) - Mina ledger implementation in Rust.
+- [snark/](snark) - Snark/Proof verification.
+- [p2p/](p2p) - P2p implementation for OpenMina node.
+- [node/](node) - Combines all the business logic of the node.
+  - [native/](node/native) - OS specific pieces of the node, which is
+    used to run the node natively (Linux/Mac/Windows).
+  - [testing/](node/testing) - Testing framework for OpenMina node.
+- [cli/](cli) - OpenMina cli.
+- [frontend/](frontend) - OpenMina frontend.
+
+[Details regarding architecture](ARCHITECTURE.md)
 
 ## The Open Mina Documentation
 

--- a/docs/producer-demo.md
+++ b/docs/producer-demo.md
@@ -3,18 +3,33 @@
 This demo showcases the block production capabilities of OpenMina nodes within a private network. It launches three OpenMina nodes on your local machine, operating in a private network environment. For the purpose of this demonstration, block proofs are disabled. This setup allows you to observe block production immediately, without the need to wait for your account to be included in the staking ledger on testnets.
 
 ## Table of Contents
-1. [Prerequisites](#prerequisites)
-    - [Docker Installation on Debian-based Linux](#docker-installation-on-debian-based-linux)
-    - [Docker Installation on Windows](#docker-installation-on-windows)
-    - [Docker Installation on macOS](#docker-installation-on-macos)
+1. [Prerequisite - Docker Installation](#prerequisite)
+    - [macOS](#docker-installation-on-macos)
+    - [Linux (Debian-based)](#docker-installation-on-debian-based-linux)
+    - [Windows](#docker-installation-on-windows)
 2. [Running the Producer Demo](#running-the-producer-demo)
-    - [Running on Debian-based Linux](#running-on-debian-based-linux)
-    - [Running on Windows](#running-on-windows)
-    - [Running on macOS](#running-on-macos)
+    - [macOS](#running-on-macos)
+    - [Linux (Debian-based)](#running-on-debian-based-linux)
+    - [Windows](#running-on-windows)
 
-## Prerequisites
+## Prerequisite - Docker Installation
 
-### Docker Installation on Debian-based Linux
+### macOS
+
+1. **Download Docker Desktop for Mac from the [Docker Website](https://www.docker.com/products/docker-desktop/).**
+
+2. **Open the downloaded `.dmg` file and drag Docker to the Applications folder.**
+
+3. **Open Docker from the Applications folder and follow the installation steps.**
+
+4. **Open up a terminal window by using the shortcut Command + Space and type in terminal**
+
+5. **Verify the installation by running the following command in your terminal:**
+    ```sh
+    docker --version
+    ```
+
+### Linux (Debian-based)
 
 1. **Set up Docker's apt repository:**
 
@@ -53,7 +68,7 @@ This demo showcases the block production capabilities of OpenMina nodes within a
     docker run hello-world
     ```
 
-### Docker Installation on Windows
+### Windows
 
 1. **Download Docker Desktop for Windows from the [Docker Website](https://www.docker.com/products/docker-desktop/).**
 
@@ -61,24 +76,32 @@ This demo showcases the block production capabilities of OpenMina nodes within a
 
 3. **After installation, Docker will start automatically. Verify that Docker Desktop is running by checking the Docker icon in your system tray.**
 
-### Docker Installation on macOS
-
-1. **Download Docker Desktop for Mac from the [Docker Website](https://www.docker.com/products/docker-desktop/).**
-
-2. **Open the downloaded `.dmg` file and drag Docker to the Applications folder.**
-
-3. **Open Docker from the Applications folder and follow the installation steps.**
-
-4. **Open up a terminal window by using the shortcut Command + Space and type in terminal**
-
-5. **Verify the installation by running the following command in your terminal:**
-    ```sh
-    docker --version
-    ```
 
 ## Running the Producer Demo
 
-### Running on Debian-based Linux
+### macOS
+
+1. **Open a terminal by pressing command + space on your keyboard and type in terminal**
+
+2. **Clone this repository:**
+    ```bash
+    git clone https://github.com/openmina/openmina.git
+    ```
+
+3. **Navigate to the repository:**
+
+    ```bash
+    cd openmina
+    ```
+
+4. **Run the following command to start the demo:**
+    ```sh
+    docker compose -f docker-compose.local.producers.yml up
+    ```
+
+5. **Open you browser and visit http://localhost:8070**
+
+### Linux (Debian-based)
 
 1. **Clone this repository:**
     ```bash
@@ -98,7 +121,7 @@ This demo showcases the block production capabilities of OpenMina nodes within a
 
 4. **Open you browser and visit http://localhost:8070**
 
-### Running on Windows
+### Windows
 
 1. **Open the command prompt by pressing the windows button on your keyboard and type in command prompt**
 
@@ -120,24 +143,4 @@ This demo showcases the block production capabilities of OpenMina nodes within a
 
 5. **Open you browser and visit http://localhost:8070**
 
-### Running on macOS
-
-1. **Open a terminal by pressing command + space on your keyboard and type in terminal**
-
-2. **Clone this repository:**
-    ```bash
-    git clone https://github.com/openmina/openmina.git
-    ```
-
-3. **Navigate to the repository:**
-
-    ```bash
-    cd openmina
-    ```
-
-4. **Run the following command to start the demo:**
-    ```sh
-    docker compose -f docker-compose.local.producers.yml up
-    ```
-
-5. **Open you browser and visit http://localhost:8070**
+<kbd> ![Image](https://github.com/openmina/mina-frontend/assets/1679939/40428a22-0691-473a-a15c-c2e610a2217b)


### PR DESCRIPTION
**WHAT**
[Readme docs](https://github.com/openmina/openmina?tab=readme-ov-file#the-open-mina-node) and [Producer Demo docs](https://github.com/openmina/openmina/blob/main/docs/producer-demo.md)

**WHY**
I went through these docs a few times as a user, and had some ideas to improve structure so it prioritizes macOS and it is easier to follow

**HOW**
- First, I condensed the start and added TOC, TOC is a nice touch to showcase what is actually inside and we have two slightly distinct categories: (1)Trying stuff, (2)Exploring and Understanding Code
- Second, I added some context to block producer section, so it is more obvious what to expect in the detailed guide
- Third, I restructured and Renamed Titles around building a node, I wanted headlines to be as informative as it gets - So I replaced generic how to launch with/without docker compose with more specific titles
  - Quick-start a Node with Docker Compose
  - Building a Node from Source
  - I made the UI section part of Building a Node from source, so it nicely flows. Although, I am aware its rather an optional step, so do I believe anyone who is buildint a node from source code understands that dashboard is just an extra step