### PR TITLE
p2p-fuzzer: optionally fuzz YamuxFlags when sending packets

### DIFF
--- a/fuzzer/src/lib.rs
+++ b/fuzzer/src/lib.rs
@@ -12,6 +12,7 @@ pub struct FuzzerConf {
     pub select_multiplexing_mutation_rate: Option<u32>,
     pub select_stream_mutation_rate: Option<u32>,
     pub yamux_frame_mutation_rate: Option<u32>,
+    pub yamux_flags_mutation_rate: Option<u32>,
     pub identify_msg_mutation_rate: Option<u32>,
     pub kad_data_mutation_rate: Option<u32>,
     pub rpc_data_mutation_rate: Option<u32>,

--- a/p2p/src/fuzzer.rs
+++ b/p2p/src/fuzzer.rs
@@ -1,7 +1,7 @@
 use openmina_fuzzer::{FuzzerState, MutationStrategy};
 use rand::Rng;
 
-use crate::Data;
+use crate::{Data, YamuxFlags};
 
 pub fn mutate_pnet(fuzzer: &mut FuzzerState, data: &mut Vec<u8>) {
     if fuzzer.gen_ratio(fuzzer.conf.pnet_mutation_rate) {
@@ -182,6 +182,15 @@ pub fn mutate_identify_msg(fuzzer: &mut FuzzerState, data: &mut Data) {
                 data.0 = fuzzer.shrink(data.0.as_ref()).as_slice().into();
             }
         }
+    }
+}
+
+pub fn mutate_yamux_flags(fuzzer: &mut FuzzerState, flags: &mut YamuxFlags) {
+    if fuzzer.gen_ratio(fuzzer.conf.yamux_flags_mutation_rate) {
+        let new_flags = YamuxFlags::from_bits_truncate(fuzzer.rng.gen());
+        println!("[i] Mutating flags {:?} -> {:?}", flags, new_flags);
+
+        *flags = new_flags;
     }
 }
 

--- a/p2p/src/network/identify/stream/p2p_network_identify_stream_effects.rs
+++ b/p2p/src/network/identify/stream/p2p_network_identify_stream_effects.rs
@@ -132,11 +132,14 @@ impl P2pNetworkIdentifyStreamAction {
                         crate::fuzzer::mutate_identify_msg
                     );
 
+                    let flags =
+                        fuzzed_maybe!(Default::default(), crate::fuzzer::mutate_yamux_flags);
+
                     store.dispatch(P2pNetworkYamuxAction::OutgoingData {
                         addr,
                         stream_id,
                         data,
-                        flags: Default::default(),
+                        flags,
                     });
 
                     store.dispatch(P2pNetworkIdentifyStreamAction::Close {

--- a/p2p/src/network/kad/stream/p2p_network_kad_stream_effects.rs
+++ b/p2p/src/network/kad/stream/p2p_network_kad_stream_effects.rs
@@ -112,11 +112,13 @@ impl P2pNetworkKademliaStreamAction {
             ) => {
                 // send data to the network
                 let data = fuzzed_maybe!(bytes.clone().into(), crate::fuzzer::mutate_kad_data);
+                let flags = fuzzed_maybe!(Default::default(), crate::fuzzer::mutate_yamux_flags);
+
                 store.dispatch(P2pNetworkYamuxAction::OutgoingData {
                     addr,
                     stream_id,
                     data,
-                    flags: Default::default(),
+                    flags,
                 });
                 store.dispatch(A::WaitIncoming {
                     addr,

--- a/p2p/src/network/pubsub/p2p_network_pubsub_effects.rs
+++ b/p2p/src/network/pubsub/p2p_network_pubsub_effects.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use openmina_core::{block::BlockWithHash, fuzz_maybe};
+use openmina_core::{block::BlockWithHash, fuzz_maybe, fuzzed_maybe};
 
 use crate::{
     channels::{snark::P2pChannelsSnarkAction, transaction::P2pChannelsTransactionAction},
@@ -120,12 +120,14 @@ impl P2pNetworkPubsubAction {
                     return;
                 };
                 fuzz_maybe!(&mut data, crate::fuzzer::mutate_pubsub);
+                let flags = fuzzed_maybe!(Default::default(), crate::fuzzer::mutate_yamux_flags);
+
                 if let Some(stream_id) = state.outgoing_stream_id.as_ref().copied() {
                     store.dispatch(P2pNetworkYamuxAction::OutgoingData {
                         addr: state.addr,
                         stream_id,
                         data,
-                        flags: Default::default(),
+                        flags,
                     });
                 }
             }

--- a/p2p/src/network/rpc/p2p_network_rpc_effects.rs
+++ b/p2p/src/network/rpc/p2p_network_rpc_effects.rs
@@ -9,7 +9,7 @@ use mina_p2p_messages::{
     v2,
     versioned::Ver,
 };
-use openmina_core::{error, fuzz_maybe};
+use openmina_core::{error, fuzz_maybe, fuzzed_maybe};
 
 use crate::{
     channels::rpc::{
@@ -387,11 +387,13 @@ impl P2pNetworkRpcAction {
                 ..
             } => {
                 fuzz_maybe!(&mut data, crate::fuzzer::mutate_rpc_data);
+                let flags = fuzzed_maybe!(Default::default(), crate::fuzzer::mutate_yamux_flags);
+
                 store.dispatch(P2pNetworkYamuxAction::OutgoingData {
                     addr,
                     stream_id,
                     data,
-                    flags: Default::default(),
+                    flags,
                 });
             }
         }

--- a/p2p/src/network/yamux/p2p_network_yamux_effects.rs
+++ b/p2p/src/network/yamux/p2p_network_yamux_effects.rs
@@ -1,4 +1,4 @@
-use openmina_core::fuzzed_maybe;
+use openmina_core::{fuzz_maybe, fuzzed_maybe};
 
 use super::p2p_network_yamux_state::{YamuxFrame, YamuxFrameInner};
 
@@ -131,6 +131,9 @@ impl P2pNetworkYamuxAction {
                 } else if stream.incoming && !stream.established {
                     flags.insert(YamuxFlags::ACK);
                 }
+
+                fuzz_maybe!(&mut flags, crate::fuzzer::mutate_yamux_flags);
+
                 let frame = YamuxFrame {
                     flags,
                     stream_id,


### PR DESCRIPTION
Some time ago @akoptelov suggested to extend the p2p-fuzzer to flip the `FIN` flag of *yamux* packets.

Following this suggestion, this patch to produces random mutations to any of the `YamuxFlags`.