### PR TITLE
P2p fuzz fixes

### DIFF
--- a/fuzzer/src/lib.rs
+++ b/fuzzer/src/lib.rs
@@ -89,7 +89,7 @@ impl FuzzerState {
 
     pub fn extend_random(&mut self, data: &[u8]) -> Vec<u8> {
         let extend_size = self.rng.gen_range(1..self.conf.max_extend_size);
-        let random_pos = self.rng.gen_range(0..data.len());
+        let random_pos = self.rng.gen_range(0..=data.len());
 
         let mut random_bytes = vec![0u8; extend_size];
         self.rng.fill(&mut random_bytes[..]);
@@ -103,9 +103,9 @@ impl FuzzerState {
     }
 
     pub fn extend_copy(&mut self, data: &[u8]) -> Vec<u8> {
-        let random_pos = self.rng.gen_range(0..data.len());
-        let copy_pos = self.rng.gen_range(0..data.len() - 1);
-        let copy_size = self.rng.gen_range(1..data.len() - copy_pos);
+        let random_pos = self.rng.gen_range(0..=data.len());
+        let copy_pos = self.rng.gen_range(0..=data.len() - 1);
+        let copy_size = self.rng.gen_range(1..=data.len() - copy_pos);
         let mut extend_size = self.rng.gen_range(copy_size..self.conf.max_extend_size);
         let mut result = Vec::with_capacity(data.len() + extend_size);
 
@@ -122,8 +122,8 @@ impl FuzzerState {
     }
 
     pub fn shrink(&mut self, data: &[u8]) -> Vec<u8> {
-        let pos = self.rng.gen_range(0..data.len() - 1);
-        let size = self.rng.gen_range(1..data.len() - pos);
+        let pos = self.rng.gen_range(0..=data.len() - 1);
+        let size = self.rng.gen_range(1..=data.len() - pos);
         let mut result = data[..pos].to_vec();
 
         result.extend_from_slice(&data[pos + size..]);

--- a/p2p/src/fuzzer.rs
+++ b/p2p/src/fuzzer.rs
@@ -5,8 +5,11 @@ use crate::{Data, YamuxFlags};
 
 pub fn mutate_pnet(fuzzer: &mut FuzzerState, data: &mut Vec<u8>) {
     if fuzzer.gen_ratio(fuzzer.conf.pnet_mutation_rate) {
-        let mutation_strategy: MutationStrategy =
-            fuzzer.rng.gen_range(MutationStrategy::range()).into();
+        let mutation_strategy: MutationStrategy = if !data.is_empty() {
+            fuzzer.rng.gen_range(MutationStrategy::range()).into()
+        } else {
+            MutationStrategy::ExtendRandom
+        };
 
         println!(
             "[i] Mutating PNET data of len {} with strategy {:?}",
@@ -31,8 +34,11 @@ pub fn mutate_pnet(fuzzer: &mut FuzzerState, data: &mut Vec<u8>) {
 
 pub fn mutate_noise(fuzzer: &mut FuzzerState, data: &mut Data) {
     if fuzzer.gen_ratio(fuzzer.conf.noise_mutation_rate) {
-        let mutation_strategy: MutationStrategy =
-            fuzzer.rng.gen_range(MutationStrategy::range()).into();
+        let mutation_strategy: MutationStrategy = if !data.is_empty() {
+            fuzzer.rng.gen_range(MutationStrategy::range()).into()
+        } else {
+            MutationStrategy::ExtendRandom
+        };
 
         println!(
             "[i] Mutating Noise data of len {} with strategy {:?}",
@@ -57,8 +63,11 @@ pub fn mutate_noise(fuzzer: &mut FuzzerState, data: &mut Data) {
 
 pub fn mutate_select_authentication(fuzzer: &mut FuzzerState, data: &mut Data) {
     if fuzzer.gen_ratio(fuzzer.conf.select_authentication_mutation_rate) {
-        let mutation_strategy: MutationStrategy =
-            fuzzer.rng.gen_range(MutationStrategy::range()).into();
+        let mutation_strategy: MutationStrategy = if !data.is_empty() {
+            fuzzer.rng.gen_range(MutationStrategy::range()).into()
+        } else {
+            MutationStrategy::ExtendRandom
+        };
 
         println!(
             "[i] Mutating Select authentication data of len {} with strategy {:?}",
@@ -83,8 +92,11 @@ pub fn mutate_select_authentication(fuzzer: &mut FuzzerState, data: &mut Data) {
 
 pub fn mutate_select_multiplexing(fuzzer: &mut FuzzerState, data: &mut Data) {
     if fuzzer.gen_ratio(fuzzer.conf.select_multiplexing_mutation_rate) {
-        let mutation_strategy: MutationStrategy =
-            fuzzer.rng.gen_range(MutationStrategy::range()).into();
+        let mutation_strategy: MutationStrategy = if !data.is_empty() {
+            fuzzer.rng.gen_range(MutationStrategy::range()).into()
+        } else {
+            MutationStrategy::ExtendRandom
+        };
 
         println!(
             "[i] Mutating Select multiplexing data of len {} with strategy {:?}",
@@ -109,8 +121,11 @@ pub fn mutate_select_multiplexing(fuzzer: &mut FuzzerState, data: &mut Data) {
 
 pub fn mutate_select_stream(fuzzer: &mut FuzzerState, data: &mut Data) {
     if fuzzer.gen_ratio(fuzzer.conf.select_stream_mutation_rate) {
-        let mutation_strategy: MutationStrategy =
-            fuzzer.rng.gen_range(MutationStrategy::range()).into();
+        let mutation_strategy: MutationStrategy = if !data.is_empty() {
+            fuzzer.rng.gen_range(MutationStrategy::range()).into()
+        } else {
+            MutationStrategy::ExtendRandom
+        };
 
         println!(
             "[i] Mutating Select stream data of len {} with strategy {:?}",
@@ -135,8 +150,11 @@ pub fn mutate_select_stream(fuzzer: &mut FuzzerState, data: &mut Data) {
 
 pub fn mutate_yamux_frame(fuzzer: &mut FuzzerState, data: &mut Data) {
     if fuzzer.gen_ratio(fuzzer.conf.yamux_frame_mutation_rate) {
-        let mutation_strategy: MutationStrategy =
-            fuzzer.rng.gen_range(MutationStrategy::range()).into();
+        let mutation_strategy: MutationStrategy = if !data.is_empty() {
+            fuzzer.rng.gen_range(MutationStrategy::range()).into()
+        } else {
+            MutationStrategy::ExtendRandom
+        };
 
         println!(
             "[i] Mutating Yamux frame data of len {} with strategy {:?}",
@@ -161,8 +179,11 @@ pub fn mutate_yamux_frame(fuzzer: &mut FuzzerState, data: &mut Data) {
 
 pub fn mutate_identify_msg(fuzzer: &mut FuzzerState, data: &mut Data) {
     if fuzzer.gen_ratio(fuzzer.conf.identify_msg_mutation_rate) {
-        let mutation_strategy: MutationStrategy =
-            fuzzer.rng.gen_range(MutationStrategy::range()).into();
+        let mutation_strategy: MutationStrategy = if !data.is_empty() {
+            fuzzer.rng.gen_range(MutationStrategy::range()).into()
+        } else {
+            MutationStrategy::ExtendRandom
+        };
 
         println!(
             "[i] Mutating Identify data of len {} with strategy {:?}",
@@ -196,8 +217,11 @@ pub fn mutate_yamux_flags(fuzzer: &mut FuzzerState, flags: &mut YamuxFlags) {
 
 pub fn mutate_kad_data(fuzzer: &mut FuzzerState, data: &mut Data) {
     if fuzzer.gen_ratio(fuzzer.conf.kad_data_mutation_rate) {
-        let mutation_strategy: MutationStrategy =
-            fuzzer.rng.gen_range(MutationStrategy::range()).into();
+        let mutation_strategy: MutationStrategy = if !data.is_empty() {
+            fuzzer.rng.gen_range(MutationStrategy::range()).into()
+        } else {
+            MutationStrategy::ExtendRandom
+        };
 
         println!(
             "[i] Mutating Kad data of len {} with strategy {:?}",
@@ -222,8 +246,11 @@ pub fn mutate_kad_data(fuzzer: &mut FuzzerState, data: &mut Data) {
 
 pub fn mutate_rpc_data(fuzzer: &mut FuzzerState, data: &mut Data) {
     if fuzzer.gen_ratio(fuzzer.conf.rpc_data_mutation_rate) {
-        let mutation_strategy: MutationStrategy =
-            fuzzer.rng.gen_range(MutationStrategy::range()).into();
+        let mutation_strategy: MutationStrategy = if !data.is_empty() {
+            fuzzer.rng.gen_range(MutationStrategy::range()).into()
+        } else {
+            MutationStrategy::ExtendRandom
+        };
 
         println!(
             "[i] Mutating RPC data of len {} with strategy {:?}",
@@ -248,8 +275,11 @@ pub fn mutate_rpc_data(fuzzer: &mut FuzzerState, data: &mut Data) {
 
 pub fn mutate_pubsub(fuzzer: &mut FuzzerState, data: &mut Data) {
     if fuzzer.gen_ratio(fuzzer.conf.pubsub_mutation_rate) {
-        let mutation_strategy: MutationStrategy =
-            fuzzer.rng.gen_range(MutationStrategy::range()).into();
+        let mutation_strategy: MutationStrategy = if !data.is_empty() {
+            fuzzer.rng.gen_range(MutationStrategy::range()).into()
+        } else {
+            MutationStrategy::ExtendRandom
+        };
 
         println!(
             "[i] Mutating PubSub data of len {} with strategy {:?}",

--- a/p2p/src/network/scheduler/p2p_network_scheduler_actions.rs
+++ b/p2p/src/network/scheduler/p2p_network_scheduler_actions.rs
@@ -178,7 +178,8 @@ impl redux::EnablingCondition<P2pState> for P2pNetworkSchedulerAction {
                 .map_or(false, |conn_state| conn_state.closed.is_some()),
             P2pNetworkSchedulerAction::PruneStreams { peer_id } => {
                 state.peers.get(peer_id).map_or(false, |peer_state| {
-                    matches!(peer_state.status, P2pPeerStatus::Disconnected { .. })
+                    peer_state.status.is_error()
+                        || matches!(peer_state.status, P2pPeerStatus::Disconnected { .. })
                 })
             }
             P2pNetworkSchedulerAction::PruneStream { peer_id, stream_id } => state


### PR DESCRIPTION
Fixes for bugs hit while running the p2p fuzzer against the OCaml fuzzer. Surprisingly the bugs found so far are in the Rust implementation, including the fuzzer itself.

- Fixes issues when handling ranges in fuzzer/mutators.
- Fixes enabling condition that filtered PruneStreams actions when the peer is in error state.