### PR TITLE
Added handshake in data sent during multiplex negotiation

### DIFF
--- a/p2p/src/network/select/p2p_network_select_effects.rs
+++ b/p2p/src/network/select/p2p_network_select_effects.rs
@@ -297,11 +297,13 @@ impl P2pNetworkSelectAction {
                         error: error.clone(),
                     });
                 } else if let Some(token) = &state.to_send {
-                    store.dispatch(P2pNetworkSelectAction::OutgoingTokens {
-                        addr,
-                        kind,
-                        tokens: vec![token.clone()],
-                    });
+                    let tokens = match token.clone() {
+                        Token::Protocol(Protocol::Mux(token)) => {
+                            vec![Token::Handshake, Token::Protocol(Protocol::Mux(token))]
+                        }
+                        token => vec![token],
+                    };
+                    store.dispatch(P2pNetworkSelectAction::OutgoingTokens { addr, kind, tokens });
                 }
             }
             P2pNetworkSelectAction::OutgoingTokens { addr, kind, tokens } => {


### PR DESCRIPTION
Fixes #543, added `Token::Handshake` in data sent when negotiating multiplexing protocol.

If handshake is not sent with multiplexing protocol during negoation with OCaml node, OCaml node throws error when trying to dial rust node in [`go-multistream@v0.3.3/client.go`](https://github.com/multiformats/go-multistream/blob/master/client.go):
```
func readMultistreamHeader(r io.Reader) error {
	tok, err := ReadNextToken(r)
	if err != nil {
		return err
	}

	if tok != ProtocolID {
		return errors.New("received mismatch in protocol id")
	}
	return nil
}
```

With error: `received mismatch in protocol id`