### PR TITLE
P2P: Introduce ConnectionAddr type to differentiate incoming/outgoing…

### DIFF
--- a/p2p/src/identify/p2p_identify_actions.rs
+++ b/p2p/src/identify/p2p_identify_actions.rs
@@ -1,13 +1,15 @@
-use crate::{network::identify::P2pNetworkIdentify, P2pState, PeerId};
+use crate::{network::identify::P2pNetworkIdentify, ConnectionAddr, P2pState, PeerId};
 use openmina_macros::ActionEvent;
 use serde::{Deserialize, Serialize};
-use std::net::SocketAddr;
 
 #[derive(Serialize, Deserialize, Debug, Clone, ActionEvent)]
 #[action_event(fields(display(peer_id), display(addr), debug(info)))]
 pub enum P2pIdentifyAction {
     /// Open a new yamux stream to the remote peer to request its identity
-    NewRequest { peer_id: PeerId, addr: SocketAddr },
+    NewRequest {
+        peer_id: PeerId,
+        addr: ConnectionAddr,
+    },
     /// Updates the P2P peer information based on the Identify message sent to us.
     UpdatePeerInformation {
         peer_id: PeerId,

--- a/p2p/src/network/identify/stream/p2p_network_identify_stream_actions.rs
+++ b/p2p/src/network/identify/stream/p2p_network_identify_stream_actions.rs
@@ -1,41 +1,40 @@
-use crate::{Data, P2pAction, P2pState, PeerId, StreamId};
+use crate::{ConnectionAddr, Data, P2pAction, P2pState, PeerId, StreamId};
 use openmina_core::ActionEvent;
 use redux::EnablingCondition;
 use serde::{Deserialize, Serialize};
-use std::net::SocketAddr;
 
 /// Identify stream related actions.
 #[derive(Debug, Clone, Serialize, Deserialize, ActionEvent)]
 pub enum P2pNetworkIdentifyStreamAction {
     /// Creates a new stream state.
     New {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         peer_id: PeerId,
         stream_id: StreamId,
         incoming: bool,
     },
     /// Handles incoming data from the stream.
     IncomingData {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         peer_id: PeerId,
         stream_id: StreamId,
         data: Data,
     },
     /// Start closing the stream (send FIN).
     Close {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         peer_id: PeerId,
         stream_id: StreamId,
     },
     /// Remote peer sent FIN to close the stream.
     RemoteClose {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         peer_id: PeerId,
         stream_id: StreamId,
     },
     /// Removes the closed stream from the state.
     Prune {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         peer_id: PeerId,
         stream_id: StreamId,
     },
@@ -56,7 +55,7 @@ macro_rules! enum_field {
 }
 
 impl P2pNetworkIdentifyStreamAction {
-    enum_field!(addr: SocketAddr);
+    enum_field!(addr: ConnectionAddr);
     enum_field!(peer_id: PeerId);
     enum_field!(stream_id: StreamId);
 }

--- a/p2p/src/network/kad/bootstrap/p2p_network_kad_bootstrap_effects.rs
+++ b/p2p/src/network/kad/bootstrap/p2p_network_kad_bootstrap_effects.rs
@@ -19,9 +19,8 @@ impl P2pNetworkKadBootstrapAction {
             .bootstrap_state()
             .ok_or_else(|| format!("action {self:?} is not allowed if not bootstrapping"))?;
 
-        use P2pNetworkKadBootstrapAction as A;
         match self {
-            A::CreateRequests => {
+            P2pNetworkKadBootstrapAction::CreateRequests => {
                 if bootstrap_state.requests.is_empty() {
                     // no request is added, and none is in progress -> bootstrap is done.
                     store.dispatch(P2pNetworkKademliaAction::BootstrapFinished {});
@@ -43,14 +42,14 @@ impl P2pNetworkKadBootstrapAction {
                 }
                 Ok(())
             }
-            A::RequestDone { .. } => {
+            P2pNetworkKadBootstrapAction::RequestDone { .. } => {
                 if bootstrap_state.successful_requests < 20 {
-                    store.dispatch(A::CreateRequests);
+                    store.dispatch(P2pNetworkKadBootstrapAction::CreateRequests);
                 }
                 Ok(())
             }
-            A::RequestError { .. } => {
-                store.dispatch(A::CreateRequests);
+            P2pNetworkKadBootstrapAction::RequestError { .. } => {
+                store.dispatch(P2pNetworkKadBootstrapAction::CreateRequests);
                 Ok(())
             }
         }

--- a/p2p/src/network/kad/bootstrap/p2p_network_kad_bootstrap_reducer.rs
+++ b/p2p/src/network/kad/bootstrap/p2p_network_kad_bootstrap_reducer.rs
@@ -49,10 +49,9 @@ impl P2pNetworkKadBootstrapState {
         filter_addrs: bool,
     ) -> Result<(), String> {
         let (action, meta) = action.split();
-        use P2pNetworkKadBootstrapAction as A;
 
         match action {
-            A::CreateRequests {} => {
+            P2pNetworkKadBootstrapAction::CreateRequests {} => {
                 let requests_to_create = 3_usize.saturating_sub(self.requests.len());
                 let peer_id_req_vec = routing_table
                     .closest_peers(&self.kademlia_key) // for the next request we take closest peer
@@ -82,7 +81,7 @@ impl P2pNetworkKadBootstrapState {
                 }
                 Ok(())
             }
-            A::RequestDone {
+            P2pNetworkKadBootstrapAction::RequestDone {
                 peer_id,
                 closest_peers,
             } => {
@@ -118,7 +117,7 @@ impl P2pNetworkKadBootstrapState {
 
                 Ok(())
             }
-            A::RequestError { peer_id, error } => {
+            P2pNetworkKadBootstrapAction::RequestError { peer_id, error } => {
                 let Some(req) = self.requests.remove(peer_id) else {
                     return Err(format!("cannot find reques for peer {peer_id}"));
                 };

--- a/p2p/src/network/kad/p2p_network_kad_actions.rs
+++ b/p2p/src/network/kad/p2p_network_kad_actions.rs
@@ -1,13 +1,11 @@
-use std::net::SocketAddr;
-
 use multiaddr::Multiaddr;
 use openmina_core::ActionEvent;
 use redux::EnablingCondition;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    kad::stream::P2pNetworkKademliaStreamAction, request::P2pNetworkKadRequestAction, P2pAction,
-    P2pNetworkAction, P2pNetworkKadEntry, P2pState, PeerId, StreamId,
+    kad::stream::P2pNetworkKademliaStreamAction, request::P2pNetworkKadRequestAction,
+    ConnectionAddr, P2pAction, P2pNetworkAction, P2pNetworkKadEntry, P2pState, PeerId, StreamId,
 };
 
 use super::bootstrap::P2pNetworkKadBootstrapAction;
@@ -53,7 +51,7 @@ pub enum P2pNetworkKademliaAction {
     ///
     /// Answers peer's `FIND_NODE` request by querying routing table for closest nodes.
     AnswerFindNodeRequest {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         peer_id: PeerId,
         stream_id: StreamId,
         key: PeerId,
@@ -62,7 +60,7 @@ pub enum P2pNetworkKademliaAction {
     ///
     /// Udates result of scheduled outgoing `FIND_NODE` request to a peer.
     UpdateFindNodeRequest {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         peer_id: PeerId,
         stream_id: StreamId,
         closest_peers: Vec<P2pNetworkKadEntry>,

--- a/p2p/src/network/kad/request/p2p_network_kad_request_actions.rs
+++ b/p2p/src/network/kad/request/p2p_network_kad_request_actions.rs
@@ -4,7 +4,7 @@ use openmina_core::ActionEvent;
 use redux::EnablingCondition;
 use serde::{Deserialize, Serialize};
 
-use crate::{P2pAction, P2pNetworkKadEntry, P2pState, PeerId, StreamId};
+use crate::{ConnectionAddr, P2pAction, P2pNetworkKadEntry, P2pState, PeerId, StreamId};
 
 #[derive(Clone, Debug, Serialize, Deserialize, ActionEvent)]
 #[action_event(fields(display(peer_id), display(addr), display(key), stream_id, error))]
@@ -19,7 +19,7 @@ pub enum P2pNetworkKadRequestAction {
     },
     MuxReady {
         peer_id: PeerId,
-        addr: SocketAddr,
+        addr: ConnectionAddr,
     },
     StreamIsCreating {
         peer_id: PeerId,
@@ -28,7 +28,7 @@ pub enum P2pNetworkKadRequestAction {
     StreamReady {
         peer_id: PeerId,
         stream_id: StreamId,
-        addr: SocketAddr,
+        addr: ConnectionAddr,
     },
     RequestSent {
         peer_id: PeerId,

--- a/p2p/src/network/kad/request/p2p_network_kad_request_reducer.rs
+++ b/p2p/src/network/kad/request/p2p_network_kad_request_reducer.rs
@@ -10,28 +10,40 @@ impl P2pNetworkKadRequestState {
         action: ActionWithMeta<&P2pNetworkKadRequestAction>,
     ) -> Result<(), String> {
         let (action, _meta) = action.split();
-        use super::P2pNetworkKadRequestStatus as S;
-        use P2pNetworkKadRequestAction as A;
 
         match action {
-            A::New { .. } => {}
-            A::PeerIsConnecting { .. } => self.status = S::WaitingForConnection,
-            A::MuxReady { .. } => {}
-            A::StreamIsCreating { stream_id, .. } => {
-                self.status = S::WaitingForKadStream(*stream_id)
+            P2pNetworkKadRequestAction::New { .. } => {}
+            P2pNetworkKadRequestAction::PeerIsConnecting { .. } => {
+                self.status = super::P2pNetworkKadRequestStatus::WaitingForConnection
             }
-            A::StreamReady { .. } => {
+            P2pNetworkKadRequestAction::MuxReady { .. } => {}
+            P2pNetworkKadRequestAction::StreamIsCreating { stream_id, .. } => {
+                self.status = super::P2pNetworkKadRequestStatus::WaitingForKadStream(*stream_id)
+            }
+            P2pNetworkKadRequestAction::StreamReady { .. } => {
                 let find_node = P2pNetworkKademliaRpcRequest::FindNode { key: self.key };
                 let message = super::super::Message::from(&find_node);
                 self.status = quick_protobuf::serialize_into_vec(&message).map_or_else(
-                    |e| S::Error(format!("error serializing message: {e}")),
-                    S::Request,
+                    |e| {
+                        super::P2pNetworkKadRequestStatus::Error(format!(
+                            "error serializing message: {e}"
+                        ))
+                    },
+                    super::P2pNetworkKadRequestStatus::Request,
                 );
             }
-            A::RequestSent { .. } => self.status = S::WaitingForReply,
-            A::ReplyReceived { data, .. } => self.status = S::Reply(data.clone()),
-            A::Prune { .. } => return Err(String::from("should never happen")),
-            A::Error { error, .. } => self.status = S::Error(error.clone()),
+            P2pNetworkKadRequestAction::RequestSent { .. } => {
+                self.status = super::P2pNetworkKadRequestStatus::WaitingForReply
+            }
+            P2pNetworkKadRequestAction::ReplyReceived { data, .. } => {
+                self.status = super::P2pNetworkKadRequestStatus::Reply(data.clone())
+            }
+            P2pNetworkKadRequestAction::Prune { .. } => {
+                return Err(String::from("should never happen"))
+            }
+            P2pNetworkKadRequestAction::Error { error, .. } => {
+                self.status = super::P2pNetworkKadRequestStatus::Error(error.clone())
+            }
         }
 
         Ok(())

--- a/p2p/src/network/kad/stream/p2p_network_kad_stream_actions.rs
+++ b/p2p/src/network/kad/stream/p2p_network_kad_stream_actions.rs
@@ -1,12 +1,10 @@
-use std::net::SocketAddr;
-
 use openmina_core::ActionEvent;
 use redux::EnablingCondition;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    Data, P2pAction, P2pNetworkKademliaRpcReply, P2pNetworkKademliaRpcRequest, P2pState, PeerId,
-    StreamId,
+    ConnectionAddr, Data, P2pAction, P2pNetworkKademliaRpcReply, P2pNetworkKademliaRpcRequest,
+    P2pState, PeerId, StreamId,
 };
 
 /// Kademlia stream related actions.
@@ -15,7 +13,7 @@ use crate::{
 pub enum P2pNetworkKademliaStreamAction {
     /// Creates a new stream state.
     New {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         peer_id: PeerId,
         stream_id: StreamId,
         incoming: bool,
@@ -23,55 +21,55 @@ pub enum P2pNetworkKademliaStreamAction {
 
     /// Handles incoming data from the stream.
     IncomingData {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         peer_id: PeerId,
         stream_id: StreamId,
         data: Data,
     },
     /// Remote peer sent FIN to close the stream.
     RemoteClose {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         peer_id: PeerId,
         stream_id: StreamId,
     },
 
     /// Reinitializes existing stream state.
     WaitIncoming {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         peer_id: PeerId,
         stream_id: StreamId,
     },
     /// Sets the state to wait for outgoing data.
     WaitOutgoing {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         peer_id: PeerId,
         stream_id: StreamId,
     },
 
     /// Sends request to the stream.
     SendRequest {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         peer_id: PeerId,
         stream_id: StreamId,
         data: P2pNetworkKademliaRpcRequest,
     },
     /// Sends response to the stream.
     SendResponse {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         peer_id: PeerId,
         stream_id: StreamId,
         data: P2pNetworkKademliaRpcReply,
     },
     /// Outgoing data is ready to be sent via the stream.
     OutgoingDataReady {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         peer_id: PeerId,
         stream_id: StreamId,
     },
 
     /// Start closing outgoing stream (first closing our half of the stream)
     Close {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         peer_id: PeerId,
         stream_id: StreamId,
     },
@@ -79,7 +77,7 @@ pub enum P2pNetworkKademliaStreamAction {
     /// Removes the closed stream from the state.
     #[action_event(level = trace)]
     Prune {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         peer_id: PeerId,
         stream_id: StreamId,
     },
@@ -105,7 +103,7 @@ macro_rules! enum_field {
 }
 
 impl P2pNetworkKademliaStreamAction {
-    enum_field!(addr: SocketAddr);
+    enum_field!(addr: ConnectionAddr);
     enum_field!(peer_id: PeerId);
     enum_field!(stream_id: StreamId);
 }

--- a/p2p/src/network/noise/p2p_network_noise_actions.rs
+++ b/p2p/src/network/noise/p2p_network_noise_actions.rs
@@ -1,17 +1,13 @@
-use std::net::SocketAddr;
-
+use super::p2p_network_noise_state::{Pk, Sk};
+use crate::{ConnectionAddr, Data, P2pNetworkAction, P2pState, PeerId};
 use openmina_core::ActionEvent;
 use serde::{Deserialize, Serialize};
-
-use crate::{Data, P2pNetworkAction, P2pState, PeerId};
-
-use super::p2p_network_noise_state::{Pk, Sk};
 
 #[derive(Serialize, Deserialize, Debug, Clone, ActionEvent)]
 #[action_event(level = debug, fields(display(addr), incoming, debug(data), display(peer_id)))]
 pub enum P2pNetworkNoiseAction {
     Init {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         incoming: bool,
         ephemeral_sk: Sk,
         ephemeral_pk: Pk,
@@ -21,46 +17,46 @@ pub enum P2pNetworkNoiseAction {
     },
     /// remote peer sends the data to the noise
     IncomingData {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         data: Data,
     },
     IncomingChunk {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         data: Data,
     },
     OutgoingChunk {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         data: Vec<Data>,
     },
     OutgoingChunkSelectMux {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         data: Vec<Data>,
     },
     // internals sends the data to the remote peer thru noise
     OutgoingData {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         data: Data,
     },
     OutgoingDataSelectMux {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         data: Data,
     },
     // the remote peer sends the data to internals thru noise
     #[action_event(fields(display(addr), debug(data), debug(peer_id)))]
     DecryptedData {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         peer_id: Option<PeerId>,
         data: Data,
     },
     HandshakeDone {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         peer_id: PeerId,
         incoming: bool,
     },
 }
 
 impl P2pNetworkNoiseAction {
-    pub fn addr(&self) -> &SocketAddr {
+    pub fn addr(&self) -> &ConnectionAddr {
         match self {
             Self::Init { addr, .. } => addr,
             Self::IncomingData { addr, .. } => addr,

--- a/p2p/src/network/noise/p2p_network_noise_effects.rs
+++ b/p2p/src/network/noise/p2p_network_noise_effects.rs
@@ -40,8 +40,8 @@ impl P2pNetworkNoiseAction {
             ..
         }) = &state.inner
         {
-            if ((matches!(self, Self::IncomingChunk { .. }) && *incoming)
-                || (matches!(self, Self::OutgoingChunk { .. }) && !*incoming))
+            if ((matches!(self, P2pNetworkNoiseAction::IncomingChunk { .. }) && *incoming)
+                || (matches!(self, P2pNetworkNoiseAction::OutgoingChunk { .. }) && !*incoming))
                 && *send_nonce == 0
                 && *recv_nonce == 0
             {
@@ -68,7 +68,7 @@ impl P2pNetworkNoiseAction {
             ))
         );
 
-        if let Self::HandshakeDone {
+        if let P2pNetworkNoiseAction::HandshakeDone {
             addr,
             peer_id,
             incoming,
@@ -83,7 +83,7 @@ impl P2pNetworkNoiseAction {
             return;
         }
 
-        if let Self::DecryptedData {
+        if let P2pNetworkNoiseAction::DecryptedData {
             addr,
             peer_id,
             data,
@@ -117,19 +117,20 @@ impl P2pNetworkNoiseAction {
         }
 
         match self {
-            Self::Init { addr, .. } | Self::OutgoingData { addr, .. } => {
+            P2pNetworkNoiseAction::Init { addr, .. }
+            | P2pNetworkNoiseAction::OutgoingData { addr, .. } => {
                 let mut outgoing = outgoing;
                 while let Some(data) = outgoing.pop_front() {
                     store.dispatch(P2pNetworkNoiseAction::OutgoingChunk { addr, data });
                 }
             }
-            Self::OutgoingDataSelectMux { addr, .. } => {
+            P2pNetworkNoiseAction::OutgoingDataSelectMux { addr, .. } => {
                 let mut outgoing = outgoing;
                 if let Some(data) = outgoing.pop_front() {
                     store.dispatch(P2pNetworkNoiseAction::OutgoingChunkSelectMux { addr, data });
                 }
             }
-            Self::IncomingData { addr, .. } => {
+            P2pNetworkNoiseAction::IncomingData { addr, .. } => {
                 let mut incoming = incoming;
                 while let Some(data) = incoming.pop_front() {
                     store.dispatch(P2pNetworkNoiseAction::IncomingChunk {
@@ -138,7 +139,7 @@ impl P2pNetworkNoiseAction {
                     });
                 }
             }
-            Self::IncomingChunk { addr, .. } => {
+            P2pNetworkNoiseAction::IncomingChunk { addr, .. } => {
                 if let Some(error) = handshake_error {
                     store.dispatch(P2pNetworkSchedulerAction::Error {
                         addr,
@@ -151,7 +152,7 @@ impl P2pNetworkNoiseAction {
                     let addr = *self.addr();
                     store.dispatch(P2pConnectionIncomingAction::FinalizePendingLibp2p {
                         peer_id,
-                        addr,
+                        addr: addr.sock_addr,
                     });
                     // check that peer management decide to accept this connection
                     let this_connection_is_kept = store
@@ -160,7 +161,7 @@ impl P2pNetworkNoiseAction {
                         .get(&peer_id)
                         .and_then(|peer_state| peer_state.status.as_connecting())
                         .and_then(|connecting| connecting.as_incoming())
-                        .map_or(false, |incoming| matches!(incoming, P2pConnectionIncomingState::FinalizePendingLibp2p { addr: a, .. } if a == &addr));
+                        .map_or(false, |incoming| matches!(incoming, P2pConnectionIncomingState::FinalizePendingLibp2p { addr: a, .. } if a == &addr.sock_addr));
                     if !this_connection_is_kept {
                         return;
                     }
@@ -199,7 +200,8 @@ impl P2pNetworkNoiseAction {
                     });
                 }
             }
-            Self::OutgoingChunk { addr, data } | Self::OutgoingChunkSelectMux { addr, data } => {
+            P2pNetworkNoiseAction::OutgoingChunk { addr, data }
+            | P2pNetworkNoiseAction::OutgoingChunkSelectMux { addr, data } => {
                 let data = fuzzed_maybe!(
                     data.iter()
                         .fold(vec![], |mut v, item| {

--- a/p2p/src/network/noise/p2p_network_noise_state.rs
+++ b/p2p/src/network/noise/p2p_network_noise_state.rs
@@ -25,6 +25,7 @@ pub struct P2pNetworkNoiseState {
 
     pub inner: Option<P2pNetworkNoiseStateInner>,
     pub handshake_optimized: bool,
+    pub expected_peer_id: Option<PeerId>,
 }
 
 impl P2pNetworkNoiseState {
@@ -40,7 +41,11 @@ impl P2pNetworkNoiseState {
 }
 
 impl P2pNetworkNoiseState {
-    pub fn new(local_pk: PublicKey, handshake_optimized: bool) -> Self {
+    pub fn new(
+        local_pk: PublicKey,
+        handshake_optimized: bool,
+        expected_peer_id: Option<PeerId>,
+    ) -> Self {
         P2pNetworkNoiseState {
             local_pk,
             buffer: Default::default(),
@@ -49,6 +54,7 @@ impl P2pNetworkNoiseState {
             decrypted_chunks: Default::default(),
             inner: Default::default(),
             handshake_optimized,
+            expected_peer_id,
         }
     }
 }
@@ -192,6 +198,8 @@ pub enum NoiseError {
     InvalidSignature,
     #[error("remote and local public keys are same")]
     SelfConnection,
+    #[error("remote peer id doesn't match expected peer id")]
+    RemotePeerIdMismatch,
 }
 
 pub struct ResponderOutput {

--- a/p2p/src/network/p2p_network_effects.rs
+++ b/p2p/src/network/p2p_network_effects.rs
@@ -9,21 +9,21 @@ impl P2pNetworkAction {
         Store::Service: P2pMioService + P2pCryptoService + P2pNetworkService,
     {
         match self {
-            Self::Scheduler(v) => v.effects(meta, store),
-            Self::Pnet(v) => v.effects(meta, store),
-            Self::Select(v) => v.effects(meta, store),
-            Self::Noise(v) => v.effects(meta, store),
-            Self::Yamux(v) => v.effects(meta, store),
-            Self::Identify(v) => match v.effects(meta, store) {
+            P2pNetworkAction::Scheduler(v) => v.effects(meta, store),
+            P2pNetworkAction::Pnet(v) => v.effects(meta, store),
+            P2pNetworkAction::Select(v) => v.effects(meta, store),
+            P2pNetworkAction::Noise(v) => v.effects(meta, store),
+            P2pNetworkAction::Yamux(v) => v.effects(meta, store),
+            P2pNetworkAction::Identify(v) => match v.effects(meta, store) {
                 Ok(_) => {}
                 Err(e) => error!(meta.time(); "error dispatching Identify stream action: {e}"),
             },
-            Self::Kad(v) => match v.effects(meta, store) {
+            P2pNetworkAction::Kad(v) => match v.effects(meta, store) {
                 Ok(_) => {}
                 Err(e) => error!(meta.time(); "error dispatching Kademlia action: {e}"),
             },
-            Self::Pubsub(v) => v.effects(meta, store),
-            Self::Rpc(v) => v.effects(meta, store),
+            P2pNetworkAction::Pubsub(v) => v.effects(meta, store),
+            P2pNetworkAction::Rpc(v) => v.effects(meta, store),
         }
     }
 }

--- a/p2p/src/network/p2p_network_service.rs
+++ b/p2p/src/network/p2p_network_service.rs
@@ -1,5 +1,7 @@
 use std::net::{IpAddr, SocketAddr};
 
+use crate::ConnectionAddr;
+
 /// The state machine sends commands to the service.
 pub enum MioCmd {
     /// Bind a new listener to a new socket on the interface
@@ -13,11 +15,11 @@ pub enum MioCmd {
     /// Create a new outgoing connection to the socket.
     Connect(SocketAddr),
     /// Receive some data from the connection in the buffer.
-    Recv(SocketAddr, Box<[u8]>),
+    Recv(ConnectionAddr, Box<[u8]>),
     /// Send the data in the connection.
-    Send(SocketAddr, Box<[u8]>),
+    Send(ConnectionAddr, Box<[u8]>),
     /// Disconnect the remote peer.
-    Disconnect(SocketAddr),
+    Disconnect(ConnectionAddr),
 }
 
 pub trait P2pMioService: redux::Service {

--- a/p2p/src/network/pnet/p2p_network_pnet_actions.rs
+++ b/p2p/src/network/pnet/p2p_network_pnet_actions.rs
@@ -1,34 +1,31 @@
-use std::net::SocketAddr;
-
+use crate::{ConnectionAddr, Data, P2pState};
 use openmina_core::ActionEvent;
 use serde::{Deserialize, Serialize};
-
-use crate::{Data, P2pState};
 
 #[derive(Serialize, Deserialize, Debug, Clone, ActionEvent)]
 #[action_event(fields(display(addr), debug(data), incoming), level = trace)]
 pub enum P2pNetworkPnetAction {
     IncomingData {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         data: Data,
     },
     OutgoingData {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         data: Data,
     },
     #[action_event(level = debug)]
     SetupNonce {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         nonce: Data,
         incoming: bool,
     },
     Timeout {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
     },
 }
 
 impl P2pNetworkPnetAction {
-    pub fn addr(&self) -> &SocketAddr {
+    pub fn addr(&self) -> &ConnectionAddr {
         match self {
             Self::IncomingData { addr, .. } => addr,
             Self::OutgoingData { addr, .. } => addr,

--- a/p2p/src/network/pubsub/p2p_network_pubsub_actions.rs
+++ b/p2p/src/network/pubsub/p2p_network_pubsub_actions.rs
@@ -1,26 +1,21 @@
-use std::net::SocketAddr;
-
+use super::pb;
+use crate::{token::BroadcastAlgorithm, ConnectionAddr, Data, P2pState, PeerId, StreamId};
 use mina_p2p_messages::gossip::GossipNetMessageV2;
 use openmina_core::ActionEvent;
-
 use serde::{Deserialize, Serialize};
-
-use crate::{token::BroadcastAlgorithm, Data, P2pState, PeerId, StreamId};
-
-use super::pb;
 
 #[derive(Serialize, Deserialize, Debug, Clone, ActionEvent)]
 pub enum P2pNetworkPubsubAction {
     NewStream {
         incoming: bool,
         peer_id: PeerId,
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         stream_id: StreamId,
         protocol: BroadcastAlgorithm,
     },
     IncomingData {
         peer_id: PeerId,
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         stream_id: StreamId,
         data: Data,
     },

--- a/p2p/src/network/pubsub/p2p_network_pubsub_state.rs
+++ b/p2p/src/network/pubsub/p2p_network_pubsub_state.rs
@@ -1,15 +1,9 @@
-use std::{
-    collections::{BTreeMap, BTreeSet, VecDeque},
-    net::SocketAddr,
-};
-
+use super::pb;
+use crate::{token::BroadcastAlgorithm, ConnectionAddr, PeerId, StreamId};
 use mina_p2p_messages::v2;
 use openmina_core::{snark::Snark, transaction::Transaction};
 use serde::{Deserialize, Serialize};
-
-use crate::{token::BroadcastAlgorithm, PeerId, StreamId};
-
-use super::pb;
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 #[derive(Default, Serialize, Deserialize, Debug, Clone)]
 pub struct P2pNetworkPubsubState {
@@ -33,7 +27,7 @@ impl P2pNetworkPubsubState {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct P2pNetworkPubsubClientState {
     pub protocol: BroadcastAlgorithm,
-    pub addr: SocketAddr,
+    pub addr: ConnectionAddr,
     pub outgoing_stream_id: Option<StreamId>,
     pub message: pb::Rpc,
     pub buffer: Vec<u8>,

--- a/p2p/src/network/rpc/p2p_network_rpc_actions.rs
+++ b/p2p/src/network/rpc/p2p_network_rpc_actions.rs
@@ -1,5 +1,3 @@
-use std::net::SocketAddr;
-
 use mina_p2p_messages::rpc_kernel::{QueryHeader, QueryID, ResponseHeader};
 use openmina_core::{action_debug, action_trace, ActionEvent};
 use serde::{Deserialize, Serialize};
@@ -11,21 +9,21 @@ use crate::{P2pState, PeerId};
 #[action_event(fields(display(addr), display(peer_id), incoming, stream_id, debug(data), fin))]
 pub enum P2pNetworkRpcAction {
     Init {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         peer_id: PeerId,
         stream_id: StreamId,
         incoming: bool,
     },
     #[action_event(level = trace)]
     IncomingData {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         peer_id: PeerId,
         stream_id: StreamId,
         data: Data,
     },
     #[action_event(expr(log_message(context, message, addr, peer_id, stream_id)))]
     IncomingMessage {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         peer_id: PeerId,
         stream_id: StreamId,
         message: RpcMessage,
@@ -35,7 +33,7 @@ pub enum P2pNetworkRpcAction {
         stream_id: StreamId,
     },
     HeartbeatSend {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         peer_id: PeerId,
         stream_id: StreamId,
     },
@@ -50,7 +48,7 @@ pub enum P2pNetworkRpcAction {
         data: Data,
     },
     OutgoingData {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         peer_id: PeerId,
         stream_id: StreamId,
         data: Data,
@@ -167,7 +165,7 @@ impl redux::EnablingCondition<P2pState> for P2pNetworkRpcAction {
 fn log_message<T>(
     context: &T,
     message: &RpcMessage,
-    addr: &SocketAddr,
+    addr: &ConnectionAddr,
     peer_id: &PeerId,
     stream_id: &u32,
 ) where

--- a/p2p/src/network/rpc/p2p_network_rpc_effects.rs
+++ b/p2p/src/network/rpc/p2p_network_rpc_effects.rs
@@ -233,7 +233,7 @@ impl P2pNetworkRpcAction {
         let incoming = state.incoming.front().cloned();
 
         match self {
-            Self::Init {
+            P2pNetworkRpcAction::Init {
                 addr,
                 peer_id,
                 stream_id,
@@ -247,7 +247,7 @@ impl P2pNetworkRpcAction {
                     fin: false,
                 });
             }
-            Self::IncomingData {
+            P2pNetworkRpcAction::IncomingData {
                 addr,
                 peer_id,
                 stream_id,
@@ -262,7 +262,7 @@ impl P2pNetworkRpcAction {
                     });
                 }
             }
-            Self::IncomingMessage {
+            P2pNetworkRpcAction::IncomingMessage {
                 addr,
                 peer_id,
                 stream_id,
@@ -323,8 +323,8 @@ impl P2pNetworkRpcAction {
                     });
                 }
             }
-            Self::PrunePending { .. } => {}
-            Self::HeartbeatSend {
+            P2pNetworkRpcAction::PrunePending { .. } => {}
+            P2pNetworkRpcAction::HeartbeatSend {
                 addr,
                 peer_id,
                 stream_id,
@@ -337,7 +337,7 @@ impl P2pNetworkRpcAction {
                     fin: false,
                 });
             }
-            Self::OutgoingQuery {
+            P2pNetworkRpcAction::OutgoingQuery {
                 peer_id,
                 query,
                 data,
@@ -355,7 +355,7 @@ impl P2pNetworkRpcAction {
                     fin: false,
                 });
             }
-            Self::OutgoingResponse {
+            P2pNetworkRpcAction::OutgoingResponse {
                 peer_id,
                 response,
                 data,
@@ -380,7 +380,7 @@ impl P2pNetworkRpcAction {
                     fin: false,
                 });
             }
-            Self::OutgoingData {
+            P2pNetworkRpcAction::OutgoingData {
                 addr,
                 stream_id,
                 mut data,

--- a/p2p/src/network/rpc/p2p_network_rpc_state.rs
+++ b/p2p/src/network/rpc/p2p_network_rpc_state.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::{BTreeMap, VecDeque},
-    net::SocketAddr,
     str,
     time::Duration,
 };
@@ -23,7 +22,7 @@ const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(10);
 #[serde_with::serde_as]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct P2pNetworkRpcState {
-    pub addr: SocketAddr,
+    pub addr: ConnectionAddr,
     pub stream_id: StreamId,
     pub last_id: P2pRpcId,
     pub last_heartbeat_sent: Option<redux::Timestamp>,
@@ -37,7 +36,7 @@ pub struct P2pNetworkRpcState {
 }
 
 impl P2pNetworkRpcState {
-    pub fn new(addr: SocketAddr, stream_id: StreamId) -> Self {
+    pub fn new(addr: ConnectionAddr, stream_id: StreamId) -> Self {
         P2pNetworkRpcState {
             addr,
             stream_id,

--- a/p2p/src/network/scheduler/p2p_network_scheduler_actions.rs
+++ b/p2p/src/network/scheduler/p2p_network_scheduler_actions.rs
@@ -11,7 +11,10 @@ use super::{
     p2p_network_scheduler_state::{P2pNetworkConnectionCloseReason, P2pNetworkConnectionError},
 };
 
-use crate::{disconnection::P2pDisconnectionReason, P2pPeerStatus, P2pState, PeerId, StreamId};
+use crate::{
+    disconnection::P2pDisconnectionReason, ConnectionAddr, P2pPeerStatus, P2pState, PeerId,
+    StreamId,
+};
 
 #[derive(Serialize, Deserialize, Debug, Clone, ActionEvent)]
 #[action_event(fields(display(ip), display(listener), display(addr), debug(result), select_kind = debug(kind), display(error)))]
@@ -34,7 +37,7 @@ pub enum P2pNetworkSchedulerAction {
     },
     #[action_event(fields(debug(addr), debug(result)))]
     IncomingDidAccept {
-        addr: Option<SocketAddr>,
+        addr: Option<ConnectionAddr>,
         result: Result<(), String>,
     },
     /// Initialize outgoing connection.
@@ -43,29 +46,30 @@ pub enum P2pNetworkSchedulerAction {
     },
     /// Outgoint TCP stream is established.
     OutgoingDidConnect {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         result: Result<(), String>,
     },
     IncomingDataIsReady {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
     },
     IncomingDataDidReceive {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         result: Result<Data, String>,
     },
     SelectDone {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         kind: SelectKind,
         protocol: Option<token::Protocol>,
         incoming: bool,
+        expected_peer_id: Option<PeerId>,
     },
     SelectError {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         kind: SelectKind,
         error: String,
     },
     YamuxDidInit {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         peer_id: PeerId,
         message_size_limit: Limit<usize>,
     },
@@ -73,7 +77,7 @@ pub enum P2pNetworkSchedulerAction {
     /// Action that initiate the specified peer disconnection.
     Disconnect {
         /// Connection address.
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         /// Reason why disconneciton is triggered.
         reason: P2pDisconnectionReason,
     },
@@ -81,7 +85,7 @@ pub enum P2pNetworkSchedulerAction {
     /// Fatal connection error.
     Error {
         /// Connection address.
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         /// Reason why disconneciton is triggered.
         error: P2pNetworkConnectionError,
     },
@@ -91,7 +95,7 @@ pub enum P2pNetworkSchedulerAction {
     /// Action that signals that the peer is disconnected.
     Disconnected {
         /// Connection address.
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         /// Reason why the peer disconnected.
         reason: P2pNetworkConnectionCloseReason,
     },
@@ -99,7 +103,7 @@ pub enum P2pNetworkSchedulerAction {
     /// Prune connection.
     Prune {
         /// Connection address.
-        addr: SocketAddr,
+        addr: ConnectionAddr,
     },
     /// Prune streams.
     PruneStreams {
@@ -133,9 +137,14 @@ impl redux::EnablingCondition<P2pState> for P2pNetworkSchedulerAction {
                     !state.network.scheduler.connections.contains_key(addr)
                 })
             }
-            P2pNetworkSchedulerAction::OutgoingConnect { addr } => {
-                !state.network.scheduler.connections.contains_key(addr)
-            }
+            P2pNetworkSchedulerAction::OutgoingConnect { addr } => !state
+                .network
+                .scheduler
+                .connections
+                .contains_key(&ConnectionAddr {
+                    sock_addr: *addr,
+                    incoming: false,
+                }),
             P2pNetworkSchedulerAction::OutgoingDidConnect { addr, result } => state
                 .network
                 .scheduler
@@ -151,6 +160,7 @@ impl redux::EnablingCondition<P2pState> for P2pNetworkSchedulerAction {
                 kind,
                 protocol,
                 incoming,
+                expected_peer_id,
             } => true,
             P2pNetworkSchedulerAction::SelectError { addr, kind, error } => true,
             P2pNetworkSchedulerAction::YamuxDidInit { addr, peer_id, .. } => true,

--- a/p2p/src/network/scheduler/p2p_network_scheduler_reducer.rs
+++ b/p2p/src/network/scheduler/p2p_network_scheduler_reducer.rs
@@ -42,7 +42,10 @@ impl P2pNetworkSchedulerState {
             }
             P2pNetworkSchedulerAction::OutgoingConnect { addr } => {
                 self.connections.insert(
-                    *addr,
+                    ConnectionAddr {
+                        sock_addr: *addr,
+                        incoming: false,
+                    },
                     P2pNetworkConnectionState {
                         incoming: false,
                         pnet: P2pNetworkPnetState::new(self.pnet_key, meta.time()),
@@ -80,6 +83,7 @@ impl P2pNetworkSchedulerState {
                 kind,
                 protocol,
                 incoming,
+                expected_peer_id,
                 ..
             } => {
                 let Some(connection) = self.connections.get_mut(addr) else {
@@ -87,9 +91,12 @@ impl P2pNetworkSchedulerState {
                 };
                 match protocol {
                     Some(token::Protocol::Auth(token::AuthKind::Noise)) => {
-                        connection.auth = Some(P2pNetworkAuthState::Noise(
-                            P2pNetworkNoiseState::new(self.local_pk.clone(), false),
-                        ));
+                        connection.auth =
+                            Some(P2pNetworkAuthState::Noise(P2pNetworkNoiseState::new(
+                                self.local_pk.clone(),
+                                false,
+                                *expected_peer_id,
+                            )));
                     }
                     Some(token::Protocol::Mux(
                         token::MuxKind::Yamux1_0_0 | token::MuxKind::YamuxNoNewLine1_0_0,

--- a/p2p/src/network/scheduler/p2p_network_scheduler_state.rs
+++ b/p2p/src/network/scheduler/p2p_network_scheduler_state.rs
@@ -12,6 +12,17 @@ use super::super::*;
 
 pub type StreamState<T> = BTreeMap<PeerId, BTreeMap<StreamId, T>>;
 
+#[derive(Serialize, Deserialize, PartialEq, PartialOrd, Eq, Ord, Debug, Clone, Copy)]
+pub struct ConnectionAddr {
+    pub sock_addr: SocketAddr,
+    pub incoming: bool,
+}
+impl std::fmt::Display for ConnectionAddr {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{} (incoming: {})", self.sock_addr, self.incoming)
+    }
+}
+
 #[serde_with::serde_as]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct P2pNetworkSchedulerState {
@@ -20,7 +31,7 @@ pub struct P2pNetworkSchedulerState {
     pub local_pk: PublicKey,
     #[serde_as(as = "serde_with::hex::Hex")]
     pub pnet_key: [u8; 32],
-    pub connections: BTreeMap<SocketAddr, P2pNetworkConnectionState>,
+    pub connections: BTreeMap<ConnectionAddr, P2pNetworkConnectionState>,
     pub broadcast_state: P2pNetworkPubsubState,
     pub identify_state: identify::P2pNetworkIdentifyState,
     pub discovery_state: Option<P2pNetworkKadState>,
@@ -33,7 +44,10 @@ impl P2pNetworkSchedulerState {
         self.discovery_state.as_ref()
     }
 
-    pub fn find_peer(&self, peer_id: &PeerId) -> Option<(&SocketAddr, &P2pNetworkConnectionState)> {
+    pub fn find_peer(
+        &self,
+        peer_id: &PeerId,
+    ) -> Option<(&ConnectionAddr, &P2pNetworkConnectionState)> {
         self.connections
             .iter()
             .find(|(_, conn_state)| conn_state.peer_id() == Some(peer_id))

--- a/p2p/src/network/select/p2p_network_select_actions.rs
+++ b/p2p/src/network/select/p2p_network_select_actions.rs
@@ -1,11 +1,7 @@
-use std::net::SocketAddr;
-
+use super::{super::*, *};
+use crate::{Data, P2pState, PeerId};
 use openmina_core::ActionEvent;
 use serde::{Deserialize, Serialize};
-
-use crate::{Data, P2pState, PeerId};
-
-use super::{super::*, *};
 
 #[derive(derive_more::From, Serialize, Deserialize, Debug, Clone, ActionEvent)]
 #[action_event(fields(display(addr), select_kind = debug(kind), debug(data), send_handshake, fin, debug(token), debug(tokens)))]
@@ -17,62 +13,62 @@ pub enum P2pNetworkSelectAction {
     /// When Noise protocol is done and we have a `peer_id`.
     /// For each yamux stream opened, we have a `peer_id` and `stream_id` at this point.
     Init {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         kind: SelectKind,
         incoming: bool,
         send_handshake: bool,
     },
     #[action_event(level = trace)]
     IncomingDataAuth {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         data: Data,
         fin: bool,
     },
     #[action_event(level = trace)]
     IncomingDataMux {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         peer_id: Option<PeerId>,
         data: Data,
         fin: bool,
     },
     #[action_event(level = trace)]
     IncomingData {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         peer_id: PeerId,
         stream_id: StreamId,
         data: Data,
         fin: bool,
     },
     IncomingPayloadAuth {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         fin: bool,
         data: Data,
     },
     IncomingPayloadMux {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         peer_id: Option<PeerId>,
         fin: bool,
         data: Data,
     },
     IncomingPayload {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         peer_id: PeerId,
         stream_id: StreamId,
         fin: bool,
         data: Data,
     },
     IncomingToken {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         kind: SelectKind,
         token: token::Token,
     },
     OutgoingTokens {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         kind: SelectKind,
         tokens: Vec<token::Token>,
     },
     Timeout {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         kind: SelectKind,
     },
 }
@@ -107,7 +103,7 @@ impl SelectKind {
 }
 
 impl P2pNetworkSelectAction {
-    pub fn addr(&self) -> &SocketAddr {
+    pub fn addr(&self) -> &ConnectionAddr {
         match self {
             Self::Init { addr, .. } => addr,
             Self::IncomingDataAuth { addr, .. } => addr,

--- a/p2p/src/network/select/p2p_network_select_effects.rs
+++ b/p2p/src/network/select/p2p_network_select_effects.rs
@@ -1,5 +1,3 @@
-use std::net::SocketAddr;
-
 use openmina_core::{fuzz_maybe, fuzzed_maybe};
 
 use crate::{
@@ -13,14 +11,14 @@ use super::{super::*, p2p_network_select_state::P2pNetworkSelectStateInner, *};
 impl P2pNetworkSelectState {
     pub fn incoming_data(
         &self,
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         kind: SelectKind,
         data: Data,
         fin: bool,
         effects: &mut Vec<P2pNetworkSelectAction>,
     ) {
         fn forward_data_action(
-            addr: SocketAddr,
+            addr: ConnectionAddr,
             kind: SelectKind,
             data: Data,
             fin: bool,
@@ -352,11 +350,17 @@ impl P2pNetworkSelectAction {
             P2pNetworkSelectAction::Timeout { .. } => {}
         }
         if let Some(protocol) = report {
+            let expected_peer_id = store
+                .state()
+                .peer_with_connection(addr)
+                .map(|(peer_id, _)| peer_id);
+
             store.dispatch(P2pNetworkSchedulerAction::SelectDone {
                 addr,
                 kind: select_kind,
                 protocol,
                 incoming,
+                expected_peer_id,
             });
         }
     }

--- a/p2p/src/network/yamux/p2p_network_yamux_actions.rs
+++ b/p2p/src/network/yamux/p2p_network_yamux_actions.rs
@@ -1,47 +1,45 @@
-use std::net::SocketAddr;
-
 use openmina_core::ActionEvent;
 use serde::{Deserialize, Serialize};
 
 use super::p2p_network_yamux_state::{StreamId, YamuxFlags, YamuxFrame, YamuxPing};
-use crate::{token, Data, P2pState};
+use crate::{token, ConnectionAddr, Data, P2pState};
 
 #[derive(Serialize, Deserialize, Debug, Clone, ActionEvent)]
 #[action_event(fields(display(addr), stream_id, debug(data), fin, debug(stream_kind)))]
 pub enum P2pNetworkYamuxAction {
     IncomingData {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         data: Data,
     },
     OutgoingData {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         stream_id: StreamId,
         data: Data,
         flags: YamuxFlags,
     },
     #[action_event(level = trace)]
     IncomingFrame {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         frame: YamuxFrame,
     },
     #[action_event(level = trace)]
     OutgoingFrame {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         frame: YamuxFrame,
     },
     PingStream {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         ping: YamuxPing,
     },
     OpenStream {
-        addr: SocketAddr,
+        addr: ConnectionAddr,
         stream_id: StreamId,
         stream_kind: token::StreamKind,
     },
 }
 
 impl P2pNetworkYamuxAction {
-    pub fn addr(&self) -> &SocketAddr {
+    pub fn addr(&self) -> &ConnectionAddr {
         match self {
             Self::IncomingData { addr, .. } => addr,
             Self::OutgoingData { addr, .. } => addr,

--- a/p2p/src/network/yamux/p2p_network_yamux_effects.rs
+++ b/p2p/src/network/yamux/p2p_network_yamux_effects.rs
@@ -27,12 +27,12 @@ impl P2pNetworkYamuxAction {
         };
 
         match self {
-            Self::IncomingData { addr, .. } => {
+            P2pNetworkYamuxAction::IncomingData { addr, .. } => {
                 for frame in state.incoming.clone() {
                     store.dispatch(P2pNetworkYamuxAction::IncomingFrame { addr, frame });
                 }
             }
-            Self::IncomingFrame { addr, frame } => {
+            P2pNetworkYamuxAction::IncomingFrame { addr, frame } => {
                 let frame = &frame;
                 let Some(stream) = state.streams.get(&frame.stream_id).cloned() else {
                     return;
@@ -52,7 +52,7 @@ impl P2pNetworkYamuxAction {
                         streams.values().filter(|s| s.select.is_incoming()).count();
                     match (max_streams, incoming_streams_number) {
                         (Limit::Some(limit), actual) if actual > limit => {
-                            store.dispatch(Self::OutgoingFrame {
+                            store.dispatch(P2pNetworkYamuxAction::OutgoingFrame {
                                 addr,
                                 frame: YamuxFrame {
                                     flags: YamuxFlags::FIN,
@@ -112,12 +112,12 @@ impl P2pNetworkYamuxAction {
                     _ => {}
                 }
             }
-            Self::OutgoingFrame { addr, frame } => {
+            P2pNetworkYamuxAction::OutgoingFrame { addr, frame } => {
                 let data =
                     fuzzed_maybe!(frame.into_bytes().into(), crate::fuzzer::mutate_yamux_frame);
                 store.dispatch(P2pNetworkNoiseAction::OutgoingData { addr, data });
             }
-            Self::OutgoingData {
+            P2pNetworkYamuxAction::OutgoingData {
                 addr,
                 stream_id,
                 data,
@@ -141,13 +141,13 @@ impl P2pNetworkYamuxAction {
                 };
                 store.dispatch(P2pNetworkYamuxAction::OutgoingFrame { addr, frame });
             }
-            Self::PingStream { addr, ping } => {
+            P2pNetworkYamuxAction::PingStream { addr, ping } => {
                 store.dispatch(P2pNetworkYamuxAction::OutgoingFrame {
                     addr,
                     frame: ping.clone().into_frame(),
                 });
             }
-            Self::OpenStream {
+            P2pNetworkYamuxAction::OpenStream {
                 addr, stream_id, ..
             } => {
                 store.dispatch(P2pNetworkSelectAction::Init {

--- a/p2p/src/p2p_event.rs
+++ b/p2p/src/p2p_event.rs
@@ -4,6 +4,7 @@ use std::net::{IpAddr, SocketAddr};
 use derive_more::From;
 use serde::{Deserialize, Serialize};
 
+use crate::ConnectionAddr;
 use crate::{
     channels::{transaction::TransactionPropagationChannelMsg, ChannelId, ChannelMsg, MsgId},
     connection::P2pConnectionResponse,
@@ -33,19 +34,19 @@ pub enum MioEvent {
     /// The remote peer is trying to connect to us.
     IncomingConnectionIsReady { listener: SocketAddr },
     /// We accepted the connection from the remote peer.
-    IncomingConnectionDidAccept(Option<SocketAddr>, Result<(), String>),
+    IncomingConnectionDidAccept(Option<ConnectionAddr>, Result<(), String>),
     /// The remote peer is trying to send us some data.
-    IncomingDataIsReady(SocketAddr),
+    IncomingDataIsReady(ConnectionAddr),
     /// We received the data from the remote peer.
-    IncomingDataDidReceive(SocketAddr, Result<crate::Data, String>),
+    IncomingDataDidReceive(ConnectionAddr, Result<crate::Data, String>),
 
     /// We connected to the remote peer by the address.
-    OutgoingConnectionDidConnect(SocketAddr, Result<(), String>),
+    OutgoingConnectionDidConnect(ConnectionAddr, Result<(), String>),
     /// We sent some data to the remote peer.
-    OutgoingDataDidSend(SocketAddr, Result<(), String>),
+    OutgoingDataDidSend(ConnectionAddr, Result<(), String>),
 
     /// The remote peer is disconnected gracefully or with an error.
-    ConnectionDidClose(SocketAddr, Result<(), String>),
+    ConnectionDidClose(ConnectionAddr, Result<(), String>),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/p2p/src/service_impl/mio/token.rs
+++ b/p2p/src/service_impl/mio/token.rs
@@ -1,10 +1,12 @@
 use std::{collections::BTreeMap, net::SocketAddr};
 
+use crate::ConnectionAddr;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Token {
     Waker,
     Listener(SocketAddr),
-    Connection(SocketAddr),
+    Connection(ConnectionAddr),
 }
 
 #[derive(Default)]


### PR DESCRIPTION
The following PR includes the following changes:

## Minor Fixes and Enhancements
This includes the revision of expressions such as `Self::*action-variant*`, which have been updated to their explicit forms.

## Introduction of ConnectionAddr
The `ConnectionAddr` type essentially links a `SockAddr` to a `bool`, differentiating incoming connections from outgoing ones. Most actions and collections that previously utilized `SockAddr` to track a specific connection now employ `ConnectionAddr`.

This modification mitigates potential collisions that could occur if multiple connections with the same `ip:port` pair occur simultaneously. For instance, while OpenMina does not employ port-reuse (source port for outgoing connections is always different) the OCaml node reuses the same listening port as the source port for outgoing connections. If the OCaml node attempts to connect to us (OpenMina) concurrently with our connection to it, the OpenMina node could encounter two `SockAddr` with identical `ip:port`. This situation is feasible as OpenMina continues to use a random source port. This issue could be proactively mitigated (at the TCP level) if OpenMina adopted port-reuse in the same manner as the OCaml node. In such a scenario, the differentiation of connections introduced by this change wouldn't be necessary.

Related issue: https://github.com/openmina/openmina/issues/399

## Enforcing Peer-ID Verification
The peer-id, in conjunction with the peer's IP and port, constitutes a portion of a peer's (multi)address. Until now, when connecting to a peer, we have not verified that the peer-id reported by it (during the Noise handshake) aligns with the peer-id specified as part of its address. This update introduces such a check, and the Noise handshake will now fail (resulting in the peer's disconnection) if the peer-ids do not match.

### Limitations

This check is only performed for IDs we are aware of: either those from the initial peer list, or discovered by Kademlia.
We are unable to verify an incoming connection from a peer that hasn't been discovered before (we allow these to pass through).
A potential issue could arise if a malicious peer exploits the Kademlia protocol to report incorrect peer IDs (for valid IP addresses), thereby contaminating other nodes' routing tables. The nodes may attempt to connect to a valid IP and terminate the connection upon realizing the node's peer-id does not match the one obtained from Kademlia. This potential issue warrants further investigation

