### PR TITLE
tweak: More consensus logging

### DIFF
--- a/node/src/consensus/consensus_actions.rs
+++ b/node/src/consensus/consensus_actions.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use mina_p2p_messages::v2::{MinaBlockBlockStableV2, StateHash};
 use openmina_core::block::ArcBlockWithHash;
+use openmina_core::{action_event, ActionEvent};
 use serde::{Deserialize, Serialize};
 use snark::block_verify::SnarkBlockVerifyError;
 
@@ -11,8 +12,12 @@ use crate::snark::block_verify::SnarkBlockVerifyId;
 pub type ConsensusActionWithMeta = redux::ActionWithMeta<ConsensusAction>;
 pub type ConsensusActionWithMetaRef<'a> = redux::ActionWithMeta<&'a ConsensusAction>;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+// NOTE: `debug(hash)` must be used instead of `display(hash)` because
+// for some reason the later breaks CI. `hash = display(&hash)` works too.
+#[derive(Serialize, Deserialize, Debug, Clone, ActionEvent)]
+#[action_event(level = debug, fields(debug(hash), debug(error)))]
 pub enum ConsensusAction {
+    #[action_event(level = info)]
     BlockReceived {
         hash: StateHash,
         block: Arc<MinaBlockBlockStableV2>,
@@ -26,9 +31,11 @@ pub enum ConsensusAction {
         req_id: SnarkBlockVerifyId,
         hash: StateHash,
     },
+    #[action_event(level = info)]
     BlockSnarkVerifySuccess {
         hash: StateHash,
     },
+    #[action_event(level = warn)]
     BlockSnarkVerifyError {
         hash: StateHash,
         error: SnarkBlockVerifyError,
@@ -42,6 +49,7 @@ pub enum ConsensusAction {
     LongRangeForkResolve {
         hash: StateHash,
     },
+    #[action_event(level = info)]
     BestTipUpdate {
         hash: StateHash,
     },

--- a/node/src/consensus/consensus_reducer.rs
+++ b/node/src/consensus/consensus_reducer.rs
@@ -151,7 +151,9 @@ impl ConsensusState {
                             }),
                             None => (None, ConsensusShortRangeForkDecision::TakeNoBestTip),
                         };
-
+                    if let Some(best_tip_hash) = &best_tip_hash {
+                        openmina_core::log::info!(openmina_core::log::system_time(); best_tip_hash = best_tip_hash.to_string(), candidate_hash = candidate_hash.to_string(), decision = format!("{decision:?}"));
+                    }
                     if let Some(candidate) = state.blocks.get_mut(candidate_hash) {
                         if !decision.use_as_best_tip() {
                             candidate.chain_proof = None;

--- a/node/src/logger/logger_effects.rs
+++ b/node/src/logger/logger_effects.rs
@@ -77,6 +77,7 @@ pub fn logger_effects<S: Service>(store: &Store<S>, action: ActionWithMetaRef<'_
         },
         Action::ExternalSnarkWorker(action) => action.action_event(&context),
         Action::Snark(SnarkAction::WorkVerify(a)) => a.action_event(&context),
+        Action::Consensus(a) => a.action_event(&context),
         Action::TransitionFrontier(a) => a.action_event(&context),
         Action::BlockProducer(a) => a.action_event(&context),
         _ => {}


### PR DESCRIPTION
Note: initially used to debug an issue on CI where the scenario tests would fail when `display(hash)` was used for consensus actions.