### PR TITLE
Added CID in kademlia find node request

### DIFF
--- a/node/testing/src/node/ocaml/mod.rs
+++ b/node/testing/src/node/ocaml/mod.rs
@@ -403,11 +403,8 @@ impl Drop for OcamlNode {
     }
 }
 
-#[cfg(test)]
 #[test]
 fn run_ocaml() {
-    use std::io::{BufRead, BufReader};
-
     use crate::node::DaemonJson;
 
     let mut node = OcamlNode::start(OcamlNodeConfig {
@@ -422,12 +419,6 @@ fn run_ocaml() {
         block_producer: None,
     })
     .unwrap();
-    let stdout = node.child.stdout.take().unwrap();
-    std::thread::spawn(move || {
-        for line in BufRead::lines(BufReader::new(stdout)) {
-            println!("{}", line.unwrap());
-        }
-    });
 
     node.child.wait().unwrap();
 }

--- a/p2p/src/network/kad/p2p_network_kad_actions.rs
+++ b/p2p/src/network/kad/p2p_network_kad_actions.rs
@@ -8,7 +8,7 @@ use crate::{
     ConnectionAddr, P2pAction, P2pNetworkAction, P2pNetworkKadEntry, P2pState, PeerId, StreamId,
 };
 
-use super::bootstrap::P2pNetworkKadBootstrapAction;
+use super::{bootstrap::P2pNetworkKadBootstrapAction, CID};
 
 /// Kademlia actions.
 #[derive(Debug, Clone, Serialize, Deserialize, derive_more::From, ActionEvent)]
@@ -42,7 +42,7 @@ impl From<P2pNetworkKadAction> for P2pAction {
     display(addr),
     display(peer_id),
     stream_id,
-    display(key),
+    debug(key),
     debug(closest_peers),
     debug(addrs)
 ))]
@@ -54,7 +54,7 @@ pub enum P2pNetworkKademliaAction {
         addr: ConnectionAddr,
         peer_id: PeerId,
         stream_id: StreamId,
-        key: PeerId,
+        key: CID,
     },
     /// Udate result of scheduled outgoing `FIND_NODE`.
     ///

--- a/p2p/src/network/kad/request/p2p_network_kad_request_reducer.rs
+++ b/p2p/src/network/kad/request/p2p_network_kad_request_reducer.rs
@@ -21,7 +21,7 @@ impl P2pNetworkKadRequestState {
                 self.status = super::P2pNetworkKadRequestStatus::WaitingForKadStream(*stream_id)
             }
             P2pNetworkKadRequestAction::StreamReady { .. } => {
-                let find_node = P2pNetworkKademliaRpcRequest::FindNode { key: self.key };
+                let find_node = P2pNetworkKademliaRpcRequest::find_node(self.key);
                 let message = super::super::Message::from(&find_node);
                 self.status = quick_protobuf::serialize_into_vec(&message).map_or_else(
                     |e| {

--- a/p2p/src/network/kad/stream/p2p_network_kad_stream_effects.rs
+++ b/p2p/src/network/kad/stream/p2p_network_kad_stream_effects.rs
@@ -57,7 +57,7 @@ impl P2pNetworkKademliaStreamAction {
                     },
                 ),
             ) => {
-                let key = *key;
+                let key = key.clone();
                 store.dispatch(P2pNetworkKademliaStreamAction::WaitOutgoing {
                     addr,
                     peer_id,
@@ -155,7 +155,9 @@ impl P2pNetworkKademliaStreamAction {
             ) => Ok(()),
             (
                 P2pNetworkKademliaStreamAction::Close {
-                    addr, stream_id, ..
+                    addr,
+                    stream_id,
+                    peer_id,
                 },
                 P2pNetworkKadStreamState::Incoming(
                     P2pNetworkKadIncomingStreamState::ResponseBytesAreReady { bytes },
@@ -170,6 +172,11 @@ impl P2pNetworkKademliaStreamAction {
                     stream_id,
                     data: Data(Box::new([0; 0])),
                     flags: YamuxFlags::FIN,
+                });
+                store.dispatch(P2pNetworkKademliaStreamAction::Prune {
+                    addr,
+                    peer_id,
+                    stream_id,
                 });
                 Ok(())
             }

--- a/p2p/src/network/kad/stream/p2p_network_kad_stream_state.rs
+++ b/p2p/src/network/kad/stream/p2p_network_kad_stream_state.rs
@@ -74,7 +74,7 @@ pub struct P2pNetworkKadIncomingStreamError(
 );
 
 #[derive(Debug, Clone, PartialEq, thiserror::Error, Serialize, Deserialize)]
-#[error("kademlia incoming stream: {0}")]
+#[error("kademlia outgoing stream: {0}")]
 pub struct P2pNetworkKadOutgoingStreamError(
     #[from] P2pNetworkStreamProtobufError<P2pNetworkKademliaRpcFromMessageError>,
 );


### PR DESCRIPTION
Added CID for kademlia find node request, to better support OCaml node.

Removed different implementation of `P2pNetworkKadKey` for `PeerId` and `&PeerId`
```rs
impl From<PeerId> for P2pNetworkKadKey {
    fn from(value: PeerId) -> Self {
        let digest = Sha256::digest(value.to_bytes());
        P2pNetworkKadKey(<U256 as ArrayEncoding>::from_be_byte_array(digest))
    }
}

impl From<&PeerId> for P2pNetworkKadKey {
    fn from(value: &PeerId) -> Self {
        P2pNetworkKadKey(U256::from_be_byte_array(Sha256::digest(
            libp2p_identity::PeerId::from(*value).to_bytes(),
        )))
    }
}
```

This would generate different `P2pNetworkKadKey`:
```
[p2p/src/network/kad/p2p_network_kad_internals.rs:585:9] peer_id = PeerId(2bEgBrPTzL8wov2D4Kz34WVLCxR4uCarsBmHYXWKQA5wvBQzd9H)
[p2p/src/network/kad/p2p_network_kad_internals.rs:586:9] P2pNetworkKadKey::from(&peer_id) = cdccbd10232bd071aed6568b53784ec01421ff4d2ad73a77faa1899f8060fb11
[p2p/src/network/kad/p2p_network_kad_internals.rs:587:9] P2pNetworkKadKey::from(peer_id) = eae8886abfcb13c61cdbaebc72e70097f34a48480df92d30d85c4847f19da361
```


Fixed `run_ocaml` test.