### PR TITLE
Added test to prevent self connection on kademlia

### DIFF
--- a/p2p/src/network/kad/p2p_network_kad_effects.rs
+++ b/p2p/src/network/kad/p2p_network_kad_effects.rs
@@ -29,15 +29,13 @@ impl P2pNetworkKademliaAction {
     where
         Store: crate::P2pStore<S>,
     {
-        // use super::P2pNetworkKadStatus::*;
-        use super::P2pNetworkKademliaAction::*;
         let Some(state) = &store.state().network.scheduler.discovery_state else {
             return Err(String::from("peer discovery is not configured"));
         };
 
         match (self, &state.status) {
             (
-                AnswerFindNodeRequest {
+                P2pNetworkKademliaAction::AnswerFindNodeRequest {
                     addr,
                     peer_id,
                     stream_id,
@@ -63,7 +61,7 @@ impl P2pNetworkKademliaAction {
                 Ok(())
             }
             (
-                UpdateFindNodeRequest {
+                P2pNetworkKademliaAction::UpdateFindNodeRequest {
                     addr: _,
                     peer_id,
                     stream_id,
@@ -79,7 +77,7 @@ impl P2pNetworkKademliaAction {
                 });
                 Ok(())
             }
-            (StartBootstrap { .. }, _) => {
+            (P2pNetworkKademliaAction::StartBootstrap { .. }, _) => {
                 if store
                     .state()
                     .network
@@ -94,8 +92,8 @@ impl P2pNetworkKademliaAction {
 
                 Ok(())
             }
-            (BootstrapFinished {}, _) => Ok(()),
-            (UpdateRoutingTable { .. }, _) => Ok(()),
+            (P2pNetworkKademliaAction::BootstrapFinished {}, _) => Ok(()),
+            (P2pNetworkKademliaAction::UpdateRoutingTable { .. }, _) => Ok(()),
         }
     }
 }

--- a/p2p/src/network/p2p_network_reducer.rs
+++ b/p2p/src/network/p2p_network_reducer.rs
@@ -66,7 +66,8 @@ impl P2pNetworkState {
                 };
                 let time = meta.time();
                 if let Err(err) = state.reducer(meta.with_action(a), limits) {
-                    error!(time; "{err}");
+                    let self_id = self.scheduler.local_pk.peer_id();
+                    error!(time; "node_id: {self_id}, {err}");
                 }
             }
             P2pNetworkAction::Pubsub(a) => {

--- a/p2p/src/peer/p2p_peer_actions.rs
+++ b/p2p/src/peer/p2p_peer_actions.rs
@@ -36,10 +36,13 @@ impl P2pPeerAction {
 impl redux::EnablingCondition<P2pState> for P2pPeerAction {
     fn is_enabled(&self, state: &P2pState, _time: redux::Timestamp) -> bool {
         match self {
-            Self::Discovered { peer_id, .. } => state
-                .peers
-                .get(peer_id)
-                .map_or(true, |p| p.dial_opts.is_none()),
+            Self::Discovered { peer_id, .. } => {
+                peer_id != &state.my_id()
+                    && state
+                        .peers
+                        .get(peer_id)
+                        .map_or(true, |p| p.dial_opts.is_none())
+            }
             Self::Ready { peer_id, .. } => state
                 .peers
                 .get(peer_id)

--- a/p2p/testing/src/event.rs
+++ b/p2p/testing/src/event.rs
@@ -71,7 +71,7 @@ pub(super) trait RustNodeEventStore {
     fn store_event(&mut self, event: RustNodeEvent);
 }
 
-pub(super) fn event_mapper_effect(store: &mut super::redux::Store, action: P2pAction) {
+pub fn event_mapper_effect(store: &mut super::redux::Store, action: P2pAction) {
     let store_event = |store: &mut super::redux::Store, event| store.service().store_event(event);
     match action {
         P2pAction::Peer(P2pPeerAction::Ready { peer_id, incoming }) => {

--- a/p2p/testing/src/lib.rs
+++ b/p2p/testing/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod event;
 pub mod libp2p_node;
 mod log;
-mod redux;
+pub mod redux;
 pub mod rust_node;
 pub mod test_node;
 

--- a/p2p/testing/src/redux.rs
+++ b/p2p/testing/src/redux.rs
@@ -13,9 +13,14 @@ use redux::{ActionMeta, EnablingCondition, SubStore};
 
 use crate::service::ClusterService;
 
-pub(crate) struct State(pub(crate) P2pState);
+pub struct State(pub(crate) P2pState);
+pub type Store = redux::Store<State, ClusterService, Action>;
 
-pub(crate) type Store = redux::Store<State, ClusterService, Action>;
+impl State {
+    pub fn state(&self) -> &P2pState {
+        &self.0
+    }
+}
 
 impl EnablingCondition<State> for Action {
     fn is_enabled(&self, state: &State, time: redux::Timestamp) -> bool {
@@ -69,7 +74,7 @@ impl SubstateAccess<P2pState> for State {
 }
 
 #[derive(Debug, derive_more::From)]
-pub(crate) enum Action {
+pub enum Action {
     P2p(P2pAction),
     Idle(IdleAction),
 }
@@ -81,7 +86,7 @@ impl From<redux::AnyAction> for Action {
 }
 
 #[derive(Debug)]
-pub(crate) struct IdleAction;
+pub struct IdleAction;
 
 impl EnablingCondition<State> for IdleAction {
     fn is_enabled(&self, _state: &State, _time: redux::Timestamp) -> bool {

--- a/p2p/testing/src/rust_node.rs
+++ b/p2p/testing/src/rust_node.rs
@@ -6,14 +6,14 @@ use std::{
 
 use futures::Stream;
 use p2p::{P2pAction, P2pEvent, P2pLimits, P2pState, P2pTimeouts, PeerId};
-use redux::{EnablingCondition, SubStore};
+use redux::{Effects, EnablingCondition, SubStore};
 use tokio::sync::mpsc;
 
 use crate::{
     cluster::{Listener, PeerIdConfig},
     event::RustNodeEvent,
-    redux::IdleAction,
-    redux::Store,
+    redux::{Action, IdleAction, State, Store},
+    service::ClusterService,
     test_node::TestNode,
 };
 
@@ -27,6 +27,7 @@ pub struct RustNodeConfig {
     pub timeouts: P2pTimeouts,
     pub limits: P2pLimits,
     pub discovery: bool,
+    pub override_fn: Option<Effects<State, ClusterService, Action>>,
 }
 
 impl RustNodeConfig {
@@ -55,6 +56,11 @@ impl RustNodeConfig {
 
     pub fn with_discovery(mut self, discovery: bool) -> Self {
         self.discovery = discovery;
+        self
+    }
+
+    pub fn with_override(mut self, override_fn: Effects<State, ClusterService, Action>) -> Self {
+        self.override_fn = Some(override_fn);
         self
     }
 }


### PR DESCRIPTION
Added condition for `P2pPeerAction::Discovered` to not allow for self discovery and added test with "bad" node.