### PR TITLE
feat(transition_frontier): Reuse the previous root snarked ledger on sync

### DIFF
--- a/node/src/block_producer/block_producer_effects.rs
+++ b/node/src/block_producer/block_producer_effects.rs
@@ -281,7 +281,14 @@ pub fn block_producer_effects<S: crate::Service>(
                 return;
             };
 
+            let previous_root_snarked_ledger_hash = store
+                .state()
+                .transition_frontier
+                .root()
+                .map(|b| b.snarked_ledger_hash().clone());
+
             if store.dispatch(TransitionFrontierSyncAction::BestTipUpdate {
+                previous_root_snarked_ledger_hash,
                 best_tip: best_tip.clone(),
                 root_block,
                 blocks_inbetween,

--- a/node/src/consensus/consensus_reducer.rs
+++ b/node/src/consensus/consensus_reducer.rs
@@ -299,7 +299,13 @@ fn transition_frontier_new_best_tip_handler(
             blocks_inbetween,
         });
     } else {
+        let previous_root_snarked_ledger_hash = state
+            .transition_frontier
+            .root()
+            .map(|b| b.snarked_ledger_hash().clone());
+
         dispatcher.push(TransitionFrontierSyncAction::BestTipUpdate {
+            previous_root_snarked_ledger_hash,
             best_tip,
             root_block,
             blocks_inbetween,

--- a/node/src/ledger/ledger_manager.rs
+++ b/node/src/ledger/ledger_manager.rs
@@ -42,7 +42,7 @@ pub(super) enum LedgerRequest {
         snarked_ledger_hash: LedgerHash,
     }, // expected response: Success
     CopySnarkedLedgerContentsForSync {
-        origin_snarked_ledger_hash: LedgerHash,
+        origin_snarked_ledger_hash: Vec<LedgerHash>,
         target_snarked_ledger_hash: LedgerHash,
         overwrite: bool,
     }, // expected response: SnarkedLedgerContentsCopied
@@ -244,6 +244,16 @@ impl LedgerRequest {
                 target_snarked_ledger_hash,
                 overwrite,
             } => {
+                let origin_snarked_ledger_hash = origin_snarked_ledger_hash
+                    .iter()
+                    .find(|hash| ledger_ctx.contains_snarked_ledger(hash))
+                    .unwrap_or_else(|| {
+                        origin_snarked_ledger_hash
+                            .first()
+                            .expect("origin_snarked_ledger_hash cannot be empty")
+                    })
+                    .clone();
+
                 let res = ledger_ctx.copy_snarked_ledger_contents_for_sync(
                     origin_snarked_ledger_hash,
                     target_snarked_ledger_hash,
@@ -443,7 +453,7 @@ impl<T: LedgerService> TransitionFrontierSyncLedgerSnarkedService for T {
 
     fn copy_snarked_ledger_contents_for_sync(
         &self,
-        origin_snarked_ledger_hash: LedgerHash,
+        origin_snarked_ledger_hash: Vec<LedgerHash>,
         target_snarked_ledger_hash: LedgerHash,
         overwrite: bool,
     ) -> Result<bool, String> {

--- a/node/src/ledger/ledger_service.rs
+++ b/node/src/ledger/ledger_service.rs
@@ -205,6 +205,10 @@ impl LedgerCtx {
             })
     }
 
+    pub fn contains_snarked_ledger(&self, hash: &LedgerHash) -> bool {
+        self.snarked_ledgers.contains_key(hash)
+    }
+
     /// Returns the mask for a snarked ledger being synchronized or an error if it is not present
     pub fn pending_sync_snarked_ledger_mask(&self, hash: &LedgerHash) -> Result<Mask, String> {
         self.sync.pending_sync_snarked_ledger_mask(hash)

--- a/node/src/transition_frontier/sync/ledger/snarked/transition_frontier_sync_ledger_snarked_service.rs
+++ b/node/src/transition_frontier/sync/ledger/snarked/transition_frontier_sync_ledger_snarked_service.rs
@@ -8,12 +8,12 @@ pub trait TransitionFrontierSyncLedgerSnarkedService: redux::Service {
     fn compute_snarked_ledger_hashes(&self, snarked_ledger_hash: &LedgerHash)
         -> Result<(), String>;
 
-    /// Creates a new copy of the ledger stored under the `origin` hash
+    /// Creates a new copy of the ledger stored under the first found `origin` hash
     /// and stores it under the `target` hash. If `overwrite` is false,
     /// only copy the ledger if the target doesn't exist already.
     fn copy_snarked_ledger_contents_for_sync(
         &self,
-        origin: LedgerHash,
+        origin: Vec<LedgerHash>,
         target: LedgerHash,
         overwrite: bool,
     ) -> Result<bool, String>;

--- a/node/src/transition_frontier/sync/transition_frontier_sync_actions.rs
+++ b/node/src/transition_frontier/sync/transition_frontier_sync_actions.rs
@@ -1,4 +1,4 @@
-use mina_p2p_messages::v2::StateHash;
+use mina_p2p_messages::v2::{LedgerHash, StateHash};
 use openmina_core::block::ArcBlockWithHash;
 use openmina_core::consensus::consensus_take;
 use openmina_core::ActionEvent;
@@ -40,6 +40,8 @@ pub enum TransitionFrontierSyncAction {
         new_root_staged_ledger_hash = display(root_block.staged_ledger_hash()),
     ))]
     BestTipUpdate {
+        // Required to be able to reuse partially synced root ledgers
+        previous_root_snarked_ledger_hash: Option<LedgerHash>,
         best_tip: ArcBlockWithHash,
         root_block: ArcBlockWithHash,
         blocks_inbetween: Vec<StateHash>,

--- a/node/src/transition_frontier/sync/transition_frontier_sync_effects.rs
+++ b/node/src/transition_frontier/sync/transition_frontier_sync_effects.rs
@@ -1,3 +1,4 @@
+use mina_p2p_messages::v2::LedgerHash;
 use openmina_core::block::ArcBlockWithHash;
 use p2p::channels::rpc::{P2pChannelsRpcAction, P2pRpcId};
 use p2p::PeerId;
@@ -45,10 +46,19 @@ impl TransitionFrontierSyncAction {
                     store.dispatch(TransitionFrontierSyncAction::LedgerRootPending);
                 }
             }
-            TransitionFrontierSyncAction::BestTipUpdate { best_tip, .. } => {
+            TransitionFrontierSyncAction::BestTipUpdate {
+                previous_root_snarked_ledger_hash,
+                best_tip,
+                ..
+            } => {
                 // TODO(tizoc): this is currently required because how how complicated the BestTipUpdate reducer is,
                 // once that is simplified this should be handled in separate actions.
-                maybe_copy_ledgers_for_sync(store, best_tip).unwrap();
+                maybe_copy_ledgers_for_sync(
+                    store,
+                    previous_root_snarked_ledger_hash.clone(),
+                    best_tip,
+                )
+                .unwrap();
 
                 // if root snarked ledger changed.
                 store.dispatch(TransitionFrontierSyncLedgerAction::Init);
@@ -93,6 +103,7 @@ impl TransitionFrontierSyncAction {
             TransitionFrontierSyncAction::LedgerRootPending => {
                 prepare_transition_frontier_root_ledger_for_sync(
                     store,
+                    None,
                     &sync_best_tip(store.state()),
                 )
                 .unwrap();
@@ -354,6 +365,7 @@ fn sync_best_tip(state: &crate::State) -> ArcBlockWithHash {
 /// For snarked ledger sync targets, copy the previous snarked ledger if required
 fn maybe_copy_ledgers_for_sync<S>(
     store: &mut Store<S>,
+    previous_root_snarked_ledger_hash: Option<LedgerHash>,
     best_tip: &ArcBlockWithHash,
 ) -> Result<bool, String>
 where
@@ -370,7 +382,11 @@ where
         }
 
         TransitionFrontierSyncState::RootLedgerPending(_) => {
-            prepare_transition_frontier_root_ledger_for_sync(store, best_tip)
+            prepare_transition_frontier_root_ledger_for_sync(
+                store,
+                previous_root_snarked_ledger_hash,
+                best_tip,
+            )
         }
         _ => Ok(true),
     }
@@ -390,7 +406,7 @@ where
 
     store
         .service()
-        .copy_snarked_ledger_contents_for_sync(origin, target, false)
+        .copy_snarked_ledger_contents_for_sync(vec![origin], target, false)
 }
 
 /// Copies (if necessary) the staking ledger into the sync ledger state
@@ -412,26 +428,39 @@ where
 
     store
         .service()
-        .copy_snarked_ledger_contents_for_sync(origin, target, false)
+        .copy_snarked_ledger_contents_for_sync(vec![origin], target, false)
 }
 
 /// Copies (if necessary) the next epoch ledger into the sync ledger state
 /// for the transition frontier root ledger to use as a starting point.
 fn prepare_transition_frontier_root_ledger_for_sync<S>(
     store: &mut Store<S>,
+    previous_root_snarked_ledger_hash: Option<LedgerHash>,
     best_tip: &ArcBlockWithHash,
 ) -> Result<bool, String>
 where
     S: TransitionFrontierSyncLedgerSnarkedService,
 {
     let sync = &store.state().transition_frontier.sync;
-    let root_block = sync.root_block().unwrap();
-    let next_epoch_sync = SyncLedgerTarget::next_epoch(best_tip, root_block)
-        .unwrap_or_else(|| SyncLedgerTarget::staking_epoch(best_tip));
+    let root_block = sync
+        .root_block()
+        .expect("Sync root block cannot be missing");
+
+    // Attempt in order: previous root, next epoch ledger, staking ledger
+    let mut candidate_origins: Vec<LedgerHash> =
+        previous_root_snarked_ledger_hash.into_iter().collect();
+    if let Some(next_epoch) = SyncLedgerTarget::next_epoch(best_tip, root_block) {
+        candidate_origins.push(next_epoch.snarked_ledger_hash.clone());
+    }
+    candidate_origins.push(
+        SyncLedgerTarget::staking_epoch(best_tip)
+            .snarked_ledger_hash
+            .clone(),
+    );
+
     let target = root_block.snarked_ledger_hash().clone();
-    let origin = next_epoch_sync.snarked_ledger_hash;
 
     store
         .service()
-        .copy_snarked_ledger_contents_for_sync(origin, target, false)
+        .copy_snarked_ledger_contents_for_sync(candidate_origins, target, false)
 }

--- a/node/src/transition_frontier/sync/transition_frontier_sync_reducer.rs
+++ b/node/src/transition_frontier/sync/transition_frontier_sync_reducer.rs
@@ -40,6 +40,7 @@ impl TransitionFrontierSyncState {
             }
             // TODO(binier): refactor
             TransitionFrontierSyncAction::BestTipUpdate {
+                previous_root_snarked_ledger_hash: _,
                 best_tip,
                 root_block,
                 blocks_inbetween,


### PR DESCRIPTION
Fixes #554