### PR TITLE
Replace fallible from implementations by try_from version

### DIFF
--- a/cli/src/commands/misc.rs
+++ b/cli/src/commands/misc.rs
@@ -34,7 +34,7 @@ impl P2PKeyPair {
         let secret_key = self.p2p_secret_key.unwrap_or_else(SecretKey::rand);
         let public_key = secret_key.public_key();
         let peer_id = public_key.peer_id();
-        let libp2p_peer_id = PeerId::from(peer_id);
+        let libp2p_peer_id = PeerId::try_from(peer_id)?;
         println!("secret key: {secret_key}");
         println!("public key: {public_key}");
         println!("peer_id:    {peer_id}");

--- a/core/src/log.rs
+++ b/core/src/log.rs
@@ -140,3 +140,16 @@ pub trait ActionEvent {
 use tracing::Value;
 
 pub use crate::{debug, error, info, trace, warn};
+
+#[macro_export]
+macro_rules! bug_condition {
+    ($($arg:tt)*) => {{
+        if std::env::var("OPENMINA_PANIC_ON_BUG")
+        .map(|v| v.to_lowercase() == "true")
+        .unwrap_or(false) {
+            panic!($($arg)*)
+        } else {
+            $crate::log::inner::error!($($arg)*)
+        }
+    }};
+}

--- a/node/src/rpc/mod.rs
+++ b/node/src/rpc/mod.rs
@@ -539,8 +539,8 @@ pub type RpcDiscoveryBoostrapStatsResponse = Option<P2pNetworkKadBootstrapStats>
 
 pub mod discovery {
     use p2p::{
-        ConnectionType, P2pNetworkKadBucket, P2pNetworkKadDist, P2pNetworkKadEntry,
-        P2pNetworkKadKey, P2pNetworkKadRoutingTable, PeerId,
+        libp2p_identity::DecodingError, ConnectionType, P2pNetworkKadBucket, P2pNetworkKadDist,
+        P2pNetworkKadEntry, P2pNetworkKadKey, P2pNetworkKadRoutingTable, PeerId,
     };
     use serde::{Deserialize, Serialize};
 
@@ -550,17 +550,20 @@ pub mod discovery {
         buckets: Vec<RpcKBucket>,
     }
 
-    impl From<&P2pNetworkKadRoutingTable> for RpcDiscoveryRoutingTable {
-        fn from(value: &P2pNetworkKadRoutingTable) -> Self {
-            RpcDiscoveryRoutingTable {
-                this_key: value.this_key.clone(),
-                buckets: value
-                    .buckets
-                    .iter()
-                    .enumerate()
-                    .map(|(i, b)| (b, P2pNetworkKadDist::from(i), &value.this_key).into())
-                    .collect(),
+    impl TryFrom<&P2pNetworkKadRoutingTable> for RpcDiscoveryRoutingTable {
+        type Error = DecodingError;
+
+        fn try_from(value: &P2pNetworkKadRoutingTable) -> Result<Self, Self::Error> {
+            let mut buckets = Vec::new();
+
+            for (i, b) in value.buckets.iter().enumerate() {
+                buckets.push((b, P2pNetworkKadDist::from(i), &value.this_key).try_into()?);
             }
+
+            Ok(RpcDiscoveryRoutingTable {
+                this_key: value.this_key.clone(),
+                buckets,
+            })
         }
     }
 
@@ -571,26 +574,27 @@ pub mod discovery {
     }
 
     impl<const K: usize>
-        From<(
+        TryFrom<(
             &P2pNetworkKadBucket<K>,
             P2pNetworkKadDist,
             &P2pNetworkKadKey,
         )> for RpcKBucket
     {
-        fn from(
+        type Error = DecodingError;
+
+        fn try_from(
             (bucket, max_dist, this_key): (
                 &P2pNetworkKadBucket<K>,
                 P2pNetworkKadDist,
                 &P2pNetworkKadKey,
             ),
-        ) -> Self {
-            RpcKBucket {
-                max_dist,
-                entries: bucket
-                    .iter()
-                    .map(|entry| (entry, this_key).into())
-                    .collect(),
+        ) -> Result<Self, Self::Error> {
+            let mut entries = Vec::new();
+
+            for entry in bucket.iter() {
+                entries.push((entry, this_key).try_into()?);
             }
+            Ok(RpcKBucket { max_dist, entries })
         }
     }
 
@@ -604,16 +608,20 @@ pub mod discovery {
         connection: ConnectionType,
     }
 
-    impl From<(&P2pNetworkKadEntry, &P2pNetworkKadKey)> for RpcEntry {
-        fn from((value, this_key): (&P2pNetworkKadEntry, &P2pNetworkKadKey)) -> Self {
-            RpcEntry {
+    impl TryFrom<(&P2pNetworkKadEntry, &P2pNetworkKadKey)> for RpcEntry {
+        type Error = DecodingError;
+
+        fn try_from(
+            (value, this_key): (&P2pNetworkKadEntry, &P2pNetworkKadKey),
+        ) -> Result<Self, Self::Error> {
+            Ok(RpcEntry {
                 peer_id: value.peer_id,
-                libp2p: value.peer_id.into(),
+                libp2p: value.peer_id.try_into()?,
                 key: value.key.clone(),
                 dist: this_key - &value.key,
                 addrs: value.addrs.clone(),
                 connection: value.connection,
-            }
+            })
         }
     }
 }

--- a/node/testing/src/node/ocaml/mod.rs
+++ b/node/testing/src/node/ocaml/mod.rs
@@ -169,7 +169,7 @@ impl OcamlNode {
     }
 
     pub fn peer_id(&self) -> PeerId {
-        self.peer_id.into()
+        self.peer_id.try_into().unwrap()
     }
 
     pub async fn exec(&mut self, step: OcamlStep) -> anyhow::Result<bool> {

--- a/node/testing/src/scenarios/multi_node/basic_connectivity_initial_joining.rs
+++ b/node/testing/src/scenarios/multi_node/basic_connectivity_initial_joining.rs
@@ -157,7 +157,7 @@ impl MultiNodeBasicConnectivityInitialJoining {
                         .map_or(0, |discovery_state| {
                             discovery_state
                                 .routing_table
-                                .closest_peers(&my_id.into())
+                                .closest_peers(&my_id.try_into().unwrap())
                                 .count()
                         });
                     let state_machine_peers = if cfg!(feature = "p2p-webrtc") {

--- a/node/testing/src/scenarios/multi_node/connection_discovery.rs
+++ b/node/testing/src/scenarios/multi_node/connection_discovery.rs
@@ -382,7 +382,7 @@ where
 
     Ok(peer_ids.into_iter().all(|peer_id| {
         table
-            .look_up(&peer_id.into())
+            .look_up(&peer_id.try_into().unwrap())
             .map(|entry| entry.peer_id == peer_id)
             .unwrap_or_default()
     }))

--- a/node/testing/src/scenarios/solo_node/basic_connectivity_accept_incoming.rs
+++ b/node/testing/src/scenarios/solo_node/basic_connectivity_accept_incoming.rs
@@ -99,7 +99,7 @@ impl SoloNodeBasicConnectivityAcceptIncoming {
                 .map_or(0, |discovery_state| {
                     discovery_state
                         .routing_table
-                        .closest_peers(&my_id.into())
+                        .closest_peers(&my_id.try_into().unwrap())
                         .count()
                 });
 

--- a/node/testing/src/scenarios/solo_node/basic_connectivity_initial_joining.rs
+++ b/node/testing/src/scenarios/solo_node/basic_connectivity_initial_joining.rs
@@ -50,14 +50,15 @@ impl SoloNodeBasicConnectivityInitialJoining {
             .initial_peers(initial_peers);
 
         let node_id = runner.add_rust_node(config);
-        let peer_id = libp2p::PeerId::from(
+        let peer_id = libp2p::PeerId::try_from(
             runner
                 .node(node_id)
                 .expect("must exist")
                 .state()
                 .p2p
                 .my_id(),
-        );
+        )
+        .unwrap();
         eprintln!("launch Openmina node, id: {node_id}, peer_id: {peer_id}");
 
         for step in 0..STEPS {
@@ -102,7 +103,7 @@ impl SoloNodeBasicConnectivityInitialJoining {
                 .map_or(0, |discovery_state| {
                     discovery_state
                         .routing_table
-                        .closest_peers(&my_id.into())
+                        .closest_peers(&my_id.try_into().unwrap())
                         .count()
                 });
 

--- a/p2p/src/network/identify/stream/p2p_network_identify_stream_reducer.rs
+++ b/p2p/src/network/identify/stream/p2p_network_identify_stream_reducer.rs
@@ -5,6 +5,7 @@ use crate::{
     network::identify::{pb::Identify, P2pNetworkIdentify},
     P2pLimits, P2pNetworkStreamProtobufError,
 };
+use openmina_core::bug_condition;
 use prost::Message;
 use quick_protobuf::BytesReader;
 use redux::ActionWithMeta;
@@ -15,48 +16,53 @@ impl P2pNetworkIdentifyStreamState {
         action: ActionWithMeta<&P2pNetworkIdentifyStreamAction>,
         limits: &P2pLimits,
     ) -> Result<(), String> {
-        use super::P2pNetworkIdentifyStreamAction as A;
-        use super::P2pNetworkIdentifyStreamState as S;
         let (action, _meta) = action.split();
         match &self {
-            S::Default => {
-                if let A::New { incoming, .. } = action {
-                    let kind = P2pNetworkIdentifyStreamKind::from(*incoming);
-
-                    *self = match kind {
-                        // For incoming streams we prepare to send the Identify message
-                        P2pNetworkIdentifyStreamKind::Incoming => S::SendIdentify,
-                        // For outgoing streams we expect to get the Identify message from the remote peer
-                        P2pNetworkIdentifyStreamKind::Outgoing => S::RecvIdentify,
-                    };
-                    Ok(())
-                } else {
+            P2pNetworkIdentifyStreamState::Default => {
+                let P2pNetworkIdentifyStreamAction::New { incoming, .. } = action else {
                     // enabling conditions should prevent receiving other actions in Default state
-                    unreachable!()
-                }
+                    bug_condition!("Received action {:?} in Default state", action);
+                    return Ok(());
+                };
+
+                let kind = P2pNetworkIdentifyStreamKind::from(*incoming);
+
+                *self = match kind {
+                    // For incoming streams we prepare to send the Identify message
+                    P2pNetworkIdentifyStreamKind::Incoming => {
+                        P2pNetworkIdentifyStreamState::SendIdentify
+                    }
+                    // For outgoing streams we expect to get the Identify message from the remote peer
+                    P2pNetworkIdentifyStreamKind::Outgoing => {
+                        P2pNetworkIdentifyStreamState::RecvIdentify
+                    }
+                };
+
+                Ok(())
             }
-            S::RecvIdentify => match action {
-                A::IncomingData { data, .. } => {
+            P2pNetworkIdentifyStreamState::RecvIdentify => match action {
+                P2pNetworkIdentifyStreamAction::IncomingData { data, .. } => {
                     let data = &data.0;
                     let mut reader = BytesReader::from_bytes(data);
                     let Ok(len) = reader.read_varint32(data).map(|v| v as usize) else {
-                        *self = S::Error(P2pNetworkStreamProtobufError::MessageLength);
+                        *self = P2pNetworkIdentifyStreamState::Error(
+                            P2pNetworkStreamProtobufError::MessageLength,
+                        );
                         return Ok(());
                     };
 
                     // TODO: implement as configuration option
                     if len > limits.identify_message() {
-                        *self = S::Error(P2pNetworkStreamProtobufError::Limit(
-                            len,
-                            limits.identify_message(),
-                        ));
+                        *self = P2pNetworkIdentifyStreamState::Error(
+                            P2pNetworkStreamProtobufError::Limit(len, limits.identify_message()),
+                        );
                         return Ok(());
                     }
 
                     let data = &data[(data.len() - reader.len())..];
 
                     if len > reader.len() {
-                        *self = S::IncomingPartialData {
+                        *self = P2pNetworkIdentifyStreamState::IncomingPartialData {
                             len,
                             data: data.to_vec(),
                         };
@@ -65,35 +71,44 @@ impl P2pNetworkIdentifyStreamState {
                         self.handle_incoming_identify_message(len, data)
                     }
                 }
-                A::RemoteClose { .. } => Ok(()),
-                A::Close { .. } => todo!(),
-                _ => unreachable!(),
+                P2pNetworkIdentifyStreamAction::RemoteClose { .. } => Ok(()),
+                _ => {
+                    // State and connection cleanup should be handled by timeout
+                    bug_condition!("Received action {:?} in RecvIdentify state", action);
+                    Ok(())
+                }
             },
-            S::IncomingPartialData { len, data } => match action {
-                A::IncomingData { data: new_data, .. } => {
+            P2pNetworkIdentifyStreamState::IncomingPartialData { len, data } => match action {
+                P2pNetworkIdentifyStreamAction::IncomingData { data: new_data, .. } => {
                     let mut data = data.clone();
                     data.extend_from_slice(&new_data.0);
 
                     if *len > data.len() {
-                        *self = S::IncomingPartialData { len: *len, data };
+                        *self =
+                            P2pNetworkIdentifyStreamState::IncomingPartialData { len: *len, data };
                         Ok(())
                     } else {
                         self.handle_incoming_identify_message(*len, &data)
                     }
                 }
-                A::RemoteClose { .. } => Ok(()),
-                A::Close { .. } => todo!(),
+                P2pNetworkIdentifyStreamAction::RemoteClose { .. } => Ok(()),
                 _ => {
-                    unreachable!();
+                    // State and connection cleanup should be handled by timeout
+                    bug_condition!("Received action {:?} in IncomingPartialData state", action);
+                    Ok(())
                 }
             },
-            S::SendIdentify => match action {
-                A::RemoteClose { .. } => Ok(()),
-                A::Close { .. } => Ok(()),
-                _ => unreachable!(),
+            P2pNetworkIdentifyStreamState::SendIdentify => match action {
+                P2pNetworkIdentifyStreamAction::RemoteClose { .. } => Ok(()),
+                P2pNetworkIdentifyStreamAction::Close { .. } => Ok(()),
+                _ => {
+                    // State and connection cleanup should be handled by timeout
+                    bug_condition!("Received action {:?} in SendIdentify state", action);
+                    Ok(())
+                }
             },
-            S::IdentifyReceived { .. } => Ok(()),
-            S::Error(_) => {
+            P2pNetworkIdentifyStreamState::IdentifyReceived { .. } => Ok(()),
+            P2pNetworkIdentifyStreamState::Error(_) => {
                 // TODO
                 Ok(())
             }

--- a/p2p/src/network/kad/bootstrap/p2p_network_kad_bootstrap_state.rs
+++ b/p2p/src/network/kad/bootstrap/p2p_network_kad_bootstrap_state.rs
@@ -33,7 +33,7 @@ impl P2pNetworkKadBootstrapState {
     pub fn new(key: PeerId) -> Self {
         P2pNetworkKadBootstrapState {
             key,
-            kademlia_key: key.into(),
+            kademlia_key: key.try_into().expect("valid key"), // TODO: propagate error
             processed_peers: BTreeSet::new(),
             requests: BTreeMap::new(),
             successful_requests: 0,

--- a/p2p/src/network/kad/p2p_network_kad_reducer.rs
+++ b/p2p/src/network/kad/p2p_network_kad_reducer.rs
@@ -100,9 +100,9 @@ impl super::P2pNetworkKadState {
                 Ok(())
             }
             (_, UpdateRoutingTable { peer_id, addrs }) => {
-                let _ = self
-                    .routing_table
-                    .insert(P2pNetworkKadEntry::new(*peer_id, addrs.clone()));
+                let _ = self.routing_table.insert(
+                    P2pNetworkKadEntry::new(*peer_id, addrs.clone()).map_err(|e| e.to_string())?,
+                );
                 Ok(())
             }
             (state, action) => Err(format!("invalid action {action:?} for state {state:?}")),

--- a/p2p/src/network/kad/request/p2p_network_kad_request_effects.rs
+++ b/p2p/src/network/kad/request/p2p_network_kad_request_effects.rs
@@ -1,5 +1,6 @@
 use std::net::SocketAddr;
 
+use openmina_core::bug_condition;
 use redux::ActionMeta;
 
 use crate::{
@@ -137,7 +138,12 @@ impl P2pNetworkKadRequestAction {
                 stream_id,
                 addr,
             } => {
-                let data = crate::P2pNetworkKademliaRpcRequest::find_node(request_state.key);
+                let Ok(data) = crate::P2pNetworkKademliaRpcRequest::find_node(request_state.key)
+                else {
+                    bug_condition!("P2pNetworkKadRequestAction::StreamReady invalid request key");
+                    return Ok(());
+                };
+
                 store.dispatch(P2pNetworkKademliaStreamAction::SendRequest {
                     addr,
                     peer_id,

--- a/p2p/src/network/kad/request/p2p_network_kad_request_reducer.rs
+++ b/p2p/src/network/kad/request/p2p_network_kad_request_reducer.rs
@@ -21,7 +21,8 @@ impl P2pNetworkKadRequestState {
                 self.status = super::P2pNetworkKadRequestStatus::WaitingForKadStream(*stream_id)
             }
             P2pNetworkKadRequestAction::StreamReady { .. } => {
-                let find_node = P2pNetworkKademliaRpcRequest::find_node(self.key);
+                let find_node =
+                    P2pNetworkKademliaRpcRequest::find_node(self.key).map_err(|e| e.to_string())?;
                 let message = super::super::Message::from(&find_node);
                 self.status = quick_protobuf::serialize_into_vec(&message).map_or_else(
                     |e| {

--- a/p2p/src/network/kad/stream/p2p_network_kad_stream_reducer.rs
+++ b/p2p/src/network/kad/stream/p2p_network_kad_stream_reducer.rs
@@ -100,7 +100,7 @@ impl P2pNetworkKadIncomingStreamState {
                 P2pNetworkKadIncomingStreamState::WaitingForReply,
                 P2pNetworkKademliaStreamAction::SendResponse { data, .. },
             ) => {
-                let message = Message::from(data);
+                let message = Message::try_from(data).map_err(|e| e.to_string())?;
                 let bytes = serialize_into_vec(&message).map_err(|e| format!("{e}"))?;
                 *self = P2pNetworkKadIncomingStreamState::ResponseBytesAreReady { bytes };
                 Ok(())

--- a/p2p/src/network/p2p_network_state.rs
+++ b/p2p/src/network/p2p_network_state.rs
@@ -22,13 +22,12 @@ impl P2pNetworkState {
         let peer_id = identity.peer_id();
         let pnet_key = chain_id.preshared_key();
         let discovery_state = discovery.then(|| {
-            let mut routing_table =
-                P2pNetworkKadRoutingTable::new(P2pNetworkKadEntry::new(peer_id, addrs));
-            routing_table.extend(
-                known_peers
-                    .into_iter()
-                    .map(|(peer_id, maddr)| P2pNetworkKadEntry::new(peer_id, vec![maddr])),
+            let mut routing_table = P2pNetworkKadRoutingTable::new(
+                P2pNetworkKadEntry::new(peer_id, addrs).expect("valid peer_id"),
             );
+            routing_table.extend(known_peers.into_iter().map(|(peer_id, maddr)| {
+                P2pNetworkKadEntry::new(peer_id, vec![maddr]).expect("valid known peer")
+            }));
             P2pNetworkKadState {
                 routing_table,
                 ..Default::default()

--- a/p2p/src/network/pubsub/p2p_network_pubsub_reducer.rs
+++ b/p2p/src/network/pubsub/p2p_network_pubsub_reducer.rs
@@ -267,7 +267,8 @@ impl P2pNetworkPubsubState {
             } => {
                 self.seq += 1;
 
-                let libp2p_peer_id = libp2p_identity::PeerId::from(*author);
+                let libp2p_peer_id =
+                    libp2p_identity::PeerId::try_from(*author).expect("valid peer_id"); // This can't happen unless something is broken in the configuration
                 self.to_sign.push_back(pb::Message {
                     from: Some(libp2p_peer_id.to_bytes()),
                     data: Some(data.0.clone().into_vec()),

--- a/p2p/testing/src/cluster.rs
+++ b/p2p/testing/src/cluster.rs
@@ -438,14 +438,20 @@ impl Cluster {
             Listener::Rust(id) => Ok(self.rust_node(id).libp2p_dial_opts(self.ip)),
             Listener::Libp2p(id) => Ok(self.libp2p_node(id).libp2p_dial_opts(self.ip)),
             Listener::Multiaddr(maddr) => Ok(maddr),
-            Listener::SocketPeerId(socket, peer_id) => match socket {
-                SocketAddr::V4(ipv4) => {
-                    Ok(multiaddr!(Ip4(*ipv4.ip()), Tcp(ipv4.port()), P2p(peer_id)))
+            Listener::SocketPeerId(socket, peer_id) => {
+                let peer_id: libp2p::PeerId = peer_id
+                    .try_into()
+                    .map_err(|_| Error::Other("Listener: invalid peer_id".to_string()))?;
+
+                match socket {
+                    SocketAddr::V4(ipv4) => {
+                        Ok(multiaddr!(Ip4(*ipv4.ip()), Tcp(ipv4.port()), P2p(peer_id)))
+                    }
+                    SocketAddr::V6(ipv6) => {
+                        Ok(multiaddr!(Ip6(*ipv6.ip()), Tcp(ipv6.port()), P2p(peer_id)))
+                    }
                 }
-                SocketAddr::V6(ipv6) => {
-                    Ok(multiaddr!(Ip6(*ipv6.ip()), Tcp(ipv6.port()), P2p(peer_id)))
-                }
-            },
+            }
         }
     }
 

--- a/p2p/testing/src/libp2p_node.rs
+++ b/p2p/testing/src/libp2p_node.rs
@@ -46,7 +46,7 @@ impl Libp2pNode {
 
 impl TestNode for Libp2pNode {
     fn peer_id(&self) -> PeerId {
-        (*self.swarm.local_peer_id()).into()
+        (*self.swarm.local_peer_id()).try_into().unwrap()
     }
 
     fn libp2p_port(&self) -> u16 {

--- a/p2p/testing/src/predicates.rs
+++ b/p2p/testing/src/predicates.rs
@@ -121,7 +121,10 @@ where
             ClusterEvent::Libp2p {
                 id,
                 event: Libp2pEvent::ConnectionEstablished { peer_id, .. },
-            } => nodes_peers.remove(&(id.into(), peer_id.into())) && nodes_peers.is_empty(),
+            } => {
+                nodes_peers.remove(&(id.into(), peer_id.try_into().unwrap()))
+                    && nodes_peers.is_empty()
+            }
             _ => false,
         })
     }

--- a/p2p/testing/src/test_node.rs
+++ b/p2p/testing/src/test_node.rs
@@ -21,12 +21,14 @@ pub trait TestNode {
     }
 
     fn libp2p_dial_opts(&self, host: IpAddr) -> Multiaddr {
+        let peer_id: libp2p::PeerId = self.peer_id().try_into().unwrap();
+
         match host {
             IpAddr::V4(ip) => {
-                multiaddr!(Ip4(ip), Tcp(self.libp2p_port()), P2p(self.peer_id()))
+                multiaddr!(Ip4(ip), Tcp(self.libp2p_port()), P2p(peer_id))
             }
             IpAddr::V6(ip) => {
-                multiaddr!(Ip6(ip), Tcp(self.libp2p_port()), P2p(self.peer_id()))
+                multiaddr!(Ip6(ip), Tcp(self.libp2p_port()), P2p(peer_id))
             }
         }
     }

--- a/p2p/tests/identify.rs
+++ b/p2p/tests/identify.rs
@@ -81,7 +81,9 @@ async fn rust_node_to_rust_node() -> anyhow::Result<()> {
             cluster
                 .connect(
                     node,
-                    addr.clone().with_p2p(peer_id.into()).expect("no error"),
+                    addr.clone()
+                        .with_p2p(peer_id.try_into().unwrap())
+                        .expect("no error"),
                 )
                 .expect("no error");
             let connected = cluster
@@ -137,7 +139,7 @@ async fn test_bad_node() -> anyhow::Result<()> {
         .routing_table;
 
     let bad_peer_entry = routing_table
-        .look_up(&bad_node_peer_id.into())
+        .look_up(&bad_node_peer_id.try_into().unwrap())
         .expect("Node not found");
 
     let bad_peer_addresses = bad_peer_entry


### PR DESCRIPTION
This is a WIP with the purpose of removing code that can panic/crash the node.

This PR:
- Adds `bug_condition!()`: we can use it to log errors that should never happen in runtime. We can still set `PANIC_ON_BUG=true` to force a panic.
- Replaces `From` implementations that were fallible (they shouldn't) by a `TryForm` version. Most P2P code is affected by this change because of conversions between our `PeerID` type and the one used by libp2p. This propagates upwards to most conversions.
