### PR TITLE
Implement compatible with OCaml Mina way to configure keypair

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,6 +1028,7 @@ dependencies = [
  "node",
  "num_cpus",
  "openmina-core",
+ "openmina-node-account",
  "openmina-node-native",
  "rand 0.8.5",
  "rayon",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -31,6 +31,7 @@ reqwest = { version = "0.11.24", features = ["blocking", "json"] }
 openmina-core = { path = "../core" }
 node = { path = "../node", features = ["replay"] }
 openmina-node-native = { path = "../node/native" }
+openmina-node-account = { path = "../node/account" }
 bytes = "1.4.0"
 tracing = "0.1.37"
 nix = { version = "0.26.2", features = ["signal"] }


### PR DESCRIPTION
Now can use `--libp2p-keypair=<path to json>` to specify encrypted sk and provide pasphrase in `MINA_LIBP2P_PASS` environment variable.