### PR TITLE
fix: Put circuit blobs in the right place when building docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ RUN cargo build --release --package=cli --bin=openmina
 RUN cargo build --release --features scenario-generators --bin openmina-node-testing
 
 # necessary for proof generation when running a block producer.
-RUN git clone --depth 1 https://github.com/openmina/circuit-blobs.git
-RUN mv node/web/circuit-blobs/* ledger
+RUN git clone --depth 1 https://github.com/openmina/circuit-blobs.git \
+    && rm -rf circuit-blobs/berkeley_rc1 circuit-blobs/*/tests
 
 FROM openmina/mina-snark-worker-prover:${MINA_SNARK_WORKER_TAG} AS prover
 
@@ -19,5 +19,7 @@ RUN apt-get update && apt-get install -y libjemalloc2 libssl1.1 libpq5 curl jq p
 COPY --from=build /openmina/cli/bin/snark-worker /usr/local/bin/
 COPY --from=build /openmina/target/release/openmina /usr/local/bin/
 COPY --from=build /openmina/target/release/openmina-node-testing /usr/local/bin/
+RUN mkdir -p /usr/local/lib/openmina/circuit-blobs
+COPY --from=build /openmina/circuit-blobs/ /usr/local/lib/openmina/circuit-blobs/
 COPY --from=prover /usr/local/bin/mina /usr/local/bin
 ENTRYPOINT [ "openmina" ]

--- a/ledger/src/proofs/gates.rs
+++ b/ledger/src/proofs/gates.rs
@@ -88,7 +88,14 @@ fn read_gates() -> Gates {
         Vec<CircuitGate<F>>,
     ) {
         let circuits_config = openmina_core::NetworkConfig::global().circuits_config;
-        let base_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let base_dir = std::env::var("OPENMINA_CIRCUIT_BLOBS_BASE_DIR")
+            .unwrap_or_else(|_| env!("CARGO_MANIFEST_DIR").to_string());
+        let base_dir = Path::new(&base_dir);
+        let base_dir = if base_dir.exists() {
+            base_dir
+        } else {
+            Path::new("/usr/local/lib/openmina/circuit-blobs")
+        };
         let base_dir = base_dir.join(circuits_config.directory_name);
 
         let internal_vars_path = base_dir.join(format!("{}_internal_vars.bin", filename));


### PR DESCRIPTION
Also added `OPENMINA_CIRCUIT_BLOBS_BASE_DIR` and a default search path `/usr/local/lib/openmina/circuit-blobs`