### PR TITLE
fix(block-producer): Fix delegator table construction 

### DIFF
--- a/node/src/ledger/ledger_manager.rs
+++ b/node/src/ledger/ledger_manager.rs
@@ -173,15 +173,10 @@ impl LedgerRequest {
                                 AccountPublicKey::from(pub_key.clone()) == producer
                             })
                             .and_then(|list| list.into_iter().next())
-                            // FIXME(tizoc): somehow the table data is being transposed somewhere, so we end
-                            // with the delegator pubkey as the key in the map, with the elements all containing
-                            // the block producer key.
-                            .map(|(delegator_key, table)| {
+                            .map(|(_, table)| {
                                 table
                                     .into_iter()
-                                    .map(|(index, _pub_key, balance)| {
-                                        (index, (delegator_key.clone(), balance))
-                                    })
+                                    .map(|(index, pub_key, balance)| (index, (pub_key, balance)))
                                     .collect()
                             });
 

--- a/node/src/ledger/ledger_service.rs
+++ b/node/src/ledger/ledger_service.rs
@@ -425,7 +425,7 @@ impl LedgerCtx {
         let mut accounts = Vec::new();
 
         mask.iter(|account| {
-            if filter(&account.public_key) || account.delegate.as_ref().map_or(false, &mut filter) {
+            if filter(account.delegate.as_ref().unwrap_or(&account.public_key)) {
                 accounts.push((
                     account.id(),
                     account.delegate.clone(),


### PR DESCRIPTION
Should only include the producer if it delegates to itself.