### PR TITLE
Handle multiple `StagedLedger` having the same merkle root hash

### DIFF
--- a/core/src/block/block_with_hash.rs
+++ b/core/src/block/block_with_hash.rs
@@ -106,8 +106,8 @@ impl<T: AsRef<Block>> BlockWithHash<T> {
         next_epoch_ledger_hash(self.header())
     }
 
-    pub fn staged_ledger_hash(&self) -> &LedgerHash {
-        staged_ledger_hash(self.header())
+    pub fn merkle_root_hash(&self) -> &LedgerHash {
+        merkle_root_hash(self.header())
     }
 
     pub fn staged_ledger_hashes(&self) -> &MinaBaseStagedLedgerHashStableV1 {
@@ -221,8 +221,8 @@ impl<T: AsRef<BlockHeader>> BlockHeaderWithHash<T> {
         next_epoch_ledger_hash(self.header())
     }
 
-    pub fn staged_ledger_hash(&self) -> &LedgerHash {
-        staged_ledger_hash(self.header())
+    pub fn merkle_root_hash(&self) -> &LedgerHash {
+        merkle_root_hash(self.header())
     }
 
     pub fn staged_ledger_hashes(&self) -> &MinaBaseStagedLedgerHashStableV1 {
@@ -302,7 +302,7 @@ fn next_epoch_ledger_hash(header: &BlockHeader) -> &LedgerHash {
     &consensus_state(header).next_epoch_data.ledger.hash
 }
 
-fn staged_ledger_hash(header: &BlockHeader) -> &LedgerHash {
+fn merkle_root_hash(header: &BlockHeader) -> &LedgerHash {
     &staged_ledger_hashes(header).non_snark.ledger_hash
 }
 

--- a/mina-p2p-messages/src/v2/generated.rs
+++ b/mina-p2p-messages/src/v2/generated.rs
@@ -2220,7 +2220,19 @@ pub struct MinaBasePendingCoinbaseStateStackStableV1 {
 ///
 /// Gid: `863`
 /// Location: [src/lib/mina_base/pending_coinbase.ml:373:8](https://github.com/MinaProtocol/mina/blob/1551e2faaa/src/lib/mina_base/pending_coinbase.ml#L373)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite, Deref)]
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    BinProtRead,
+    BinProtWrite,
+    Deref,
+    PartialOrd,
+    Ord,
+    Eq,
+)]
 pub struct MinaBasePendingCoinbaseHashBuilderStableV1(pub crate::bigint::BigInt);
 
 /// **OCaml name**: `Mina_base__Pending_coinbase.Make_str.Update.Action.Stable.V1`
@@ -2269,7 +2281,19 @@ pub struct MinaBasePendingCoinbaseStackVersionedStableV1 {
 ///
 /// Gid: `871`
 /// Location: [src/lib/mina_base/pending_coinbase.ml:535:8](https://github.com/MinaProtocol/mina/blob/1551e2faaa/src/lib/mina_base/pending_coinbase.ml#L535)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite, Deref)]
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    BinProtRead,
+    BinProtWrite,
+    Deref,
+    PartialOrd,
+    Ord,
+    Eq,
+)]
 pub struct MinaBasePendingCoinbaseHashVersionedStableV1(
     pub MinaBasePendingCoinbaseHashBuilderStableV1,
 );
@@ -2297,21 +2321,47 @@ pub struct MinaBasePendingCoinbaseMerkleTreeVersionedStableV2 {
 ///
 /// Gid: `875`
 /// Location: [src/lib/mina_base/staged_ledger_hash.ml:27:8](https://github.com/MinaProtocol/mina/blob/1551e2faaa/src/lib/mina_base/staged_ledger_hash.ml#L27)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite, Deref)]
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    BinProtRead,
+    BinProtWrite,
+    Deref,
+    PartialOrd,
+    Ord,
+    Eq,
+)]
 pub struct MinaBaseStagedLedgerHashAuxHashStableV1(pub crate::string::ByteString);
 
 /// **OCaml name**: `Mina_base__Staged_ledger_hash.Make_str.Pending_coinbase_aux.Stable.V1`
 ///
 /// Gid: `876`
 /// Location: [src/lib/mina_base/staged_ledger_hash.ml:111:8](https://github.com/MinaProtocol/mina/blob/1551e2faaa/src/lib/mina_base/staged_ledger_hash.ml#L111)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite, Deref)]
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    BinProtRead,
+    BinProtWrite,
+    Deref,
+    PartialOrd,
+    Ord,
+    Eq,
+)]
 pub struct MinaBaseStagedLedgerHashPendingCoinbaseAuxStableV1(pub crate::string::ByteString);
 
 /// **OCaml name**: `Mina_base__Staged_ledger_hash.Make_str.Non_snark.Stable.V1`
 ///
 /// Gid: `877`
 /// Location: [src/lib/mina_base/staged_ledger_hash.ml:154:8](https://github.com/MinaProtocol/mina/blob/1551e2faaa/src/lib/mina_base/staged_ledger_hash.ml#L154)
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(
+    Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite, PartialOrd, Ord, Eq,
+)]
 pub struct MinaBaseStagedLedgerHashNonSnarkStableV1 {
     pub ledger_hash: LedgerHash,
     pub aux_hash: StagedLedgerHashAuxHash,
@@ -2327,7 +2377,9 @@ pub struct MinaBaseStagedLedgerHashNonSnarkStableV1 {
 /// Gid: `878`
 /// Location: [src/lib/mina_base/staged_ledger_hash.ml:243:8](https://github.com/MinaProtocol/mina/blob/1551e2faaa/src/lib/mina_base/staged_ledger_hash.ml#L243)
 /// Args: MinaBaseStagedLedgerHashNonSnarkStableV1 , PendingCoinbaseHash
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite)]
+#[derive(
+    Clone, Debug, PartialEq, Serialize, Deserialize, BinProtRead, BinProtWrite, PartialOrd, Ord, Eq,
+)]
 pub struct MinaBaseStagedLedgerHashStableV1 {
     pub non_snark: MinaBaseStagedLedgerHashNonSnarkStableV1,
     pub pending_coinbase_hash: PendingCoinbaseHash,

--- a/node/src/ledger/ledger_effects.rs
+++ b/node/src/ledger/ledger_effects.rs
@@ -272,7 +272,7 @@ fn build_staged_ledger_parts_request(
         .best_chain
         .iter()
         .find(|b| &b.hash == block_hash)
-        .map(|b| b.staged_ledger_hash().clone())?;
+        .map(|b| b.staged_ledger_hashes().clone())?;
     let protocol_states = tf
         .needed_protocol_states
         .iter()
@@ -336,8 +336,7 @@ fn find_peers_with_ledger_rpc(
                         .transition_frontier
                         .get_state_body(block_hash)
                         .map_or(false, |b| {
-                            b.blockchain_state.staged_ledger_hash.non_snark.ledger_hash
-                                == data.ledger_hash
+                            b.blockchain_state.staged_ledger_hash == data.ledger_hash
                         }),
                     _ => false,
                 })
@@ -355,8 +354,7 @@ fn find_peers_with_ledger_rpc(
                         .transition_frontier
                         .get_state_body(block_hash)
                         .map_or(false, |b| {
-                            b.blockchain_state.staged_ledger_hash.non_snark.ledger_hash
-                                == data.ledger_hash
+                            b.blockchain_state.staged_ledger_hash == data.ledger_hash
                         }),
                     _ => false,
                 })

--- a/node/src/ledger/ledger_manager.rs
+++ b/node/src/ledger/ledger_manager.rs
@@ -196,13 +196,13 @@ impl LedgerRequest {
                     }
                     LedgerReadRequest::GetStagedLedgerAuxAndPendingCoinbases(data) => {
                         let res = ledger_ctx.staged_ledger_aux_and_pending_coinbase(
-                            data.ledger_hash,
+                            &data.ledger_hash,
                             data.protocol_states,
                         );
                         LedgerReadResponse::GetStagedLedgerAuxAndPendingCoinbases(res)
                     }
                     LedgerReadRequest::ScanStateSummary(ledger_hash) => {
-                        let res = ledger_ctx.scan_state_summary(ledger_hash);
+                        let res = ledger_ctx.scan_state_summary(&ledger_hash);
                         LedgerReadResponse::ScanStateSummary(res)
                     }
                     LedgerReadRequest::GetAccounts(ledger_hash, account_ids) => {

--- a/node/src/ledger/ledger_service.rs
+++ b/node/src/ledger/ledger_service.rs
@@ -624,15 +624,15 @@ impl LedgerCtx {
         openmina_core::info!(openmina_core::log::system_time();
             kind = "LedgerService::block_apply",
             summary = format!("{}, {} <- {}", block.height(), block.hash(), block.pred_hash()),
-            pred_staged_ledger_hash = pred_block.staged_ledger_hash().to_string(),
-            staged_ledger_hash = block.staged_ledger_hash().to_string(),
+            pred_staged_ledger_hash = pred_block.merkle_root_hash().to_string(),
+            staged_ledger_hash = block.merkle_root_hash().to_string(),
         );
         let mut staged_ledger = self
             .staged_ledger_mut(pred_block.staged_ledger_hashes())
             .ok_or_else(|| {
                 format!(
-                    "parent staged ledger missing: {}",
-                    pred_block.staged_ledger_hash()
+                    "parent staged ledger missing: {:#?}",
+                    pred_block.staged_ledger_hashes()
                 )
             })?
             .clone();
@@ -753,7 +753,7 @@ impl LedgerCtx {
         for ledger_hash in [
             new_best_tip.staking_epoch_ledger_hash(),
             new_root.snarked_ledger_hash(),
-            new_root.staged_ledger_hash(),
+            new_root.merkle_root_hash(),
         ] {
             if let Some((mut mask, is_synced)) = self.mask(ledger_hash) {
                 if !is_synced {
@@ -940,7 +940,7 @@ impl LedgerCtx {
             .ok_or_else(|| {
                 format!(
                     "parent staged ledger missing: {}",
-                    pred_block.staged_ledger_hash()
+                    pred_block.merkle_root_hash()
                 )
             })?
             .clone();

--- a/node/src/ledger/ledger_service.rs
+++ b/node/src/ledger/ledger_service.rs
@@ -72,12 +72,98 @@ fn merkle_root(mask: &mut Mask) -> LedgerHash {
     MinaBaseLedgerHash0StableV1(mask.merkle_root().into()).into()
 }
 
+/// Indexing `StagedLedger` both by their "merkle root hash" and their "staged ledger hash"
+#[derive(Default)]
+struct StagedLedgersStorage {
+    /// 1 merkle root hash can refer to 1 or more `StagedLedger`
+    by_merkle_root_hash: BTreeMap<LedgerHash, Vec<Arc<MinaBaseStagedLedgerHashStableV1>>>,
+    staged_ledgers: BTreeMap<Arc<MinaBaseStagedLedgerHashStableV1>, StagedLedger>,
+}
+
+impl StagedLedgersStorage {
+    /// Slow, it will recompute the full staged ledger hash
+    /// Prefer `Self::insert` when you have the "staged ledger hash" around
+    fn insert_by_recomputing_hash(&mut self, mut staged_ledger: StagedLedger) {
+        let staged_ledger_hash: MinaBaseStagedLedgerHashStableV1 = (&staged_ledger.hash()).into();
+        self.insert(Arc::new(staged_ledger_hash), staged_ledger);
+    }
+
+    fn insert(
+        &mut self,
+        staged_ledger_hash: Arc<MinaBaseStagedLedgerHashStableV1>,
+        staged_ledger: StagedLedger,
+    ) {
+        let merkle_root_hash: LedgerHash = merkle_root(&mut staged_ledger.ledger());
+        self.by_merkle_root_hash
+            .entry(merkle_root_hash.clone())
+            .or_insert_with(|| Vec::with_capacity(1))
+            .extend([staged_ledger_hash.clone()]);
+        self.staged_ledgers
+            .insert(staged_ledger_hash, staged_ledger);
+    }
+
+    fn get_mask(&self, root_hash: &LedgerHash) -> Option<Mask> {
+        let staged_ledger_hashes: &Vec<_> = self.by_merkle_root_hash.get(root_hash)?;
+        // Note: there can be multiple `staged_ledger_hashes`, but they all have the same
+        // mask, so we just take the 1st one
+        self.staged_ledgers
+            .get(staged_ledger_hashes.first()?)
+            .map(|staged_ledger| staged_ledger.ledger())
+    }
+
+    fn get(&self, staged_ledger_hash: &MinaBaseStagedLedgerHashStableV1) -> Option<&StagedLedger> {
+        self.staged_ledgers.get(staged_ledger_hash)
+    }
+
+    fn get_mut(
+        &mut self,
+        staged_ledger_hash: &MinaBaseStagedLedgerHashStableV1,
+    ) -> Option<&mut StagedLedger> {
+        self.staged_ledgers.get_mut(staged_ledger_hash)
+    }
+
+    fn retain<F>(&mut self, fun: F)
+    where
+        F: Fn(&LedgerHash, &[Arc<MinaBaseStagedLedgerHashStableV1>]) -> bool,
+    {
+        self.by_merkle_root_hash
+            .retain(|merkle_root_hash, staged_ledger_hashes| {
+                let retain = fun(merkle_root_hash, staged_ledger_hashes.as_slice());
+                if !retain {
+                    for staged_ledger_hash in staged_ledger_hashes {
+                        self.staged_ledgers.remove(staged_ledger_hash);
+                    }
+                }
+                retain
+            });
+    }
+
+    fn extend<I>(&mut self, iterator: I)
+    where
+        I: IntoIterator<Item = (Arc<MinaBaseStagedLedgerHashStableV1>, StagedLedger)>,
+    {
+        for (hash, staged_ledger) in iterator.into_iter() {
+            self.insert(hash, staged_ledger);
+        }
+    }
+
+    fn take(&mut self) -> BTreeMap<Arc<MinaBaseStagedLedgerHashStableV1>, StagedLedger> {
+        let Self {
+            by_merkle_root_hash,
+            staged_ledgers,
+        } = self;
+
+        let _ = std::mem::take(by_merkle_root_hash);
+        std::mem::take(staged_ledgers)
+    }
+}
+
 #[derive(Default)]
 pub struct LedgerCtx {
     snarked_ledgers: BTreeMap<LedgerHash, Mask>,
     /// Additional snarked ledgers specified at startup (loaded from disk)
     additional_snarked_ledgers: BTreeMap<LedgerHash, Mask>,
-    staged_ledgers: BTreeMap<LedgerHash, StagedLedger>,
+    staged_ledgers: StagedLedgersStorage,
     sync: LedgerSyncState,
     event_sender:
         Option<openmina_core::channels::mpsc::UnboundedSender<crate::event_source::Event>>,
@@ -86,7 +172,7 @@ pub struct LedgerCtx {
 #[derive(Default)]
 struct LedgerSyncState {
     snarked_ledgers: BTreeMap<LedgerHash, Mask>,
-    staged_ledgers: BTreeMap<LedgerHash, StagedLedger>,
+    staged_ledgers: StagedLedgersStorage,
 }
 
 impl LedgerCtx {
@@ -151,13 +237,13 @@ impl LedgerCtx {
         let hash = merkle_root(&mut mask);
         let staged_ledger =
             StagedLedger::create_exn(constraint_constants().clone(), mask.copy()).unwrap();
-        self.snarked_ledgers.insert(hash.clone(), mask);
-        self.staged_ledgers.insert(hash.clone(), staged_ledger);
+        self.snarked_ledgers.insert(hash, mask);
+        self.staged_ledgers
+            .insert_by_recomputing_hash(staged_ledger);
     }
 
     pub fn staged_ledger_reconstruct_result_store(&mut self, ledger: StagedLedger) {
-        let hash = merkle_root(&mut ledger.ledger().clone());
-        self.staged_ledgers.insert(hash, ledger);
+        self.staged_ledgers.insert_by_recomputing_hash(ledger);
     }
 
     // TODO(adonagy): Uh-oh, clean this up
@@ -196,7 +282,7 @@ impl LedgerCtx {
             .get(hash)
             .cloned()
             .map(|mask| (mask, true))
-            .or_else(|| Some((self.staged_ledgers.get(hash)?.ledger(), true)))
+            .or_else(|| Some((self.staged_ledgers.get_mask(hash)?, true)))
             .or_else(|| self.sync.mask(hash))
             .or_else(|| {
                 self.additional_snarked_ledgers
@@ -273,7 +359,10 @@ impl LedgerCtx {
     }
 
     /// Returns a mutable reference to the [StagedLedger] with the specified `hash` if it exists or `None` otherwise.
-    fn staged_ledger_mut(&mut self, hash: &LedgerHash) -> Option<&mut StagedLedger> {
+    fn staged_ledger_mut(
+        &mut self,
+        hash: &MinaBaseStagedLedgerHashStableV1,
+    ) -> Option<&mut StagedLedger> {
         match self.staged_ledgers.get_mut(hash) {
             Some(v) => Some(v),
             None => self.sync.staged_ledger_mut(hash),
@@ -308,7 +397,7 @@ impl LedgerCtx {
         protocol_states: &BTreeMap<StateHash, MinaStateProtocolStateValueStableV2>,
         old_root_snarked_ledger_hash: &LedgerHash,
         new_root_snarked_ledger_hash: &LedgerHash,
-        new_root_staged_ledger_hash: &LedgerHash,
+        new_root_staged_ledger_hash: &MinaBaseStagedLedgerHashStableV1,
     ) -> Result<(), String> {
         openmina_core::debug!(openmina_core::log::system_time();
             kind = "LedgerService::push_snarked_ledger",
@@ -381,7 +470,7 @@ impl LedgerCtx {
             .staged_ledger_mut(new_root_staged_ledger_hash)
             .ok_or_else(|| {
                 format!(
-                    "Failed to find staged ledger with hash: {}",
+                    "Failed to find staged ledger with hash: {:#?}",
                     new_root_staged_ledger_hash
                 )
             })?
@@ -539,7 +628,7 @@ impl LedgerCtx {
             staged_ledger_hash = block.staged_ledger_hash().to_string(),
         );
         let mut staged_ledger = self
-            .staged_ledger_mut(pred_block.staged_ledger_hash())
+            .staged_ledger_mut(pred_block.staged_ledger_hashes())
             .ok_or_else(|| {
                 format!(
                     "parent staged ledger missing: {}",
@@ -579,7 +668,7 @@ impl LedgerCtx {
         let expected_ledger_hashes = block.staged_ledger_hashes();
         if &ledger_hashes != expected_ledger_hashes {
             let staged_ledger = self
-                .staged_ledger_mut(pred_block.staged_ledger_hash())
+                .staged_ledger_mut(pred_block.staged_ledger_hashes())
                 .unwrap(); // We already know the ledger exists, see the same call a few lines above
 
             match dump_application_to_file(staged_ledger, block.clone(), pred_block) {
@@ -598,10 +687,9 @@ impl LedgerCtx {
             panic!("staged ledger hash mismatch. found: {ledger_hashes:#?}, expected: {expected_ledger_hashes:#?}");
         }
 
-        let ledger_hash = block.staged_ledger_hash();
         self.sync
             .staged_ledgers
-            .insert(ledger_hash.clone(), staged_ledger);
+            .insert(Arc::new(ledger_hashes), staged_ledger);
 
         Ok(())
     }
@@ -655,9 +743,11 @@ impl LedgerCtx {
         self.staged_ledgers
             .retain(|hash, _| ledgers_to_keep.contains(hash));
         self.staged_ledgers.extend(
-            std::mem::take(&mut self.sync.staged_ledgers)
+            self.sync
+                .staged_ledgers
+                .take()
                 .into_iter()
-                .filter(|(hash, _)| ledgers_to_keep.contains(hash)),
+                .filter(|(hash, _)| ledgers_to_keep.contains(&hash.non_snark.ledger_hash)),
         );
 
         for ledger_hash in [
@@ -692,7 +782,7 @@ impl LedgerCtx {
         }
 
         // TODO(tizoc): should this fail silently?
-        let Some(new_root_ledger) = self.staged_ledgers.get_mut(new_root.staged_ledger_hash())
+        let Some(new_root_ledger) = self.staged_ledgers.get_mut(new_root.staged_ledger_hashes())
         else {
             return Default::default();
         };
@@ -701,7 +791,7 @@ impl LedgerCtx {
         new_root_ledger.commit_and_reparent_to_root();
 
         let needed_protocol_states = self
-            .staged_ledger_mut(new_root.staged_ledger_hash())
+            .staged_ledger_mut(new_root.staged_ledger_hashes())
             .map(|l| {
                 l.scan_state()
                     .required_state_hashes()
@@ -712,7 +802,7 @@ impl LedgerCtx {
             .unwrap_or_default();
 
         let available_jobs = self
-            .staged_ledger_mut(new_best_tip.staged_ledger_hash())
+            .staged_ledger_mut(new_best_tip.staged_ledger_hashes())
             .map(|l| {
                 l.scan_state()
                     .all_job_pairs_iter()
@@ -810,10 +900,10 @@ impl LedgerCtx {
 
     pub fn staged_ledger_aux_and_pending_coinbase(
         &mut self,
-        ledger_hash: LedgerHash,
+        ledger_hash: &MinaBaseStagedLedgerHashStableV1,
         protocol_states: BTreeMap<StateHash, MinaStateProtocolStateValueStableV2>,
     ) -> Option<Arc<StagedLedgerAuxAndPendingCoinbases>> {
-        let ledger = self.staged_ledger_mut(&ledger_hash)?;
+        let ledger = self.staged_ledger_mut(ledger_hash)?;
         let needed_blocks = ledger
             .scan_state()
             .required_state_hashes()
@@ -825,7 +915,7 @@ impl LedgerCtx {
         Some(
             StagedLedgerAuxAndPendingCoinbases {
                 scan_state: (ledger.scan_state()).into(),
-                staged_ledger_hash: ledger_hash,
+                staged_ledger_hash: ledger_hash.non_snark.ledger_hash.clone(),
                 pending_coinbase: (ledger.pending_coinbase_collection()).into(),
                 needed_blocks,
             }
@@ -846,7 +936,7 @@ impl LedgerCtx {
         transactions_by_fee: Vec<valid::UserCommand>,
     ) -> Result<StagedLedgerDiffCreateOutput, String> {
         let mut staged_ledger = self
-            .staged_ledger_mut(pred_block.staged_ledger_hash())
+            .staged_ledger_mut(pred_block.staged_ledger_hashes())
             .ok_or_else(|| {
                 format!(
                     "parent staged ledger missing: {}",
@@ -940,11 +1030,11 @@ impl LedgerCtx {
 
     pub fn scan_state_summary(
         &self,
-        staged_ledger_hash: LedgerHash,
+        staged_ledger_hash: &MinaBaseStagedLedgerHashStableV1,
     ) -> Result<Vec<Vec<RpcScanStateSummaryScanStateJob>>, String> {
         use ledger::scan_state::scan_state::JobValue;
 
-        let ledger = self.staged_ledgers.get(&staged_ledger_hash);
+        let ledger = self.staged_ledgers.get(staged_ledger_hash);
         let Some(ledger) = ledger else {
             return Ok(Vec::new());
         };
@@ -1077,7 +1167,7 @@ impl LedgerSyncState {
             .get(hash)
             .cloned()
             .map(|mask| (mask, false))
-            .or_else(|| Some((self.staged_ledgers.get(hash)?.ledger(), true)))
+            .or_else(|| Some((self.staged_ledgers.get_mask(hash)?, true)))
     }
 
     fn pending_sync_snarked_ledger_mask(&self, hash: &LedgerHash) -> Result<Mask, String> {
@@ -1097,7 +1187,10 @@ impl LedgerSyncState {
         })
     }
 
-    fn staged_ledger_mut(&mut self, hash: &LedgerHash) -> Option<&mut StagedLedger> {
+    fn staged_ledger_mut(
+        &mut self,
+        hash: &MinaBaseStagedLedgerHashStableV1,
+    ) -> Option<&mut StagedLedger> {
         self.staged_ledgers.get_mut(hash)
     }
 }

--- a/node/src/ledger/read/mod.rs
+++ b/node/src/ledger/read/mod.rs
@@ -43,7 +43,7 @@ pub enum LedgerReadRequest {
     GetChildAccountsAtAddr(v2::LedgerHash, LedgerAddress),
     GetStagedLedgerAuxAndPendingCoinbases(LedgerReadStagedLedgerAuxAndPendingCoinbases),
     // rpcs
-    ScanStateSummary(v2::LedgerHash),
+    ScanStateSummary(v2::MinaBaseStagedLedgerHashStableV1),
     AccountsForRpc(RpcId, v2::LedgerHash, Option<AccountPublicKey>),
 }
 
@@ -64,7 +64,7 @@ pub enum LedgerReadResponse {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct LedgerReadStagedLedgerAuxAndPendingCoinbases {
-    pub ledger_hash: v2::LedgerHash,
+    pub ledger_hash: v2::MinaBaseStagedLedgerHashStableV1,
     pub protocol_states: BTreeMap<v2::StateHash, v2::MinaStateProtocolStateValueStableV2>,
 }
 

--- a/node/src/rpc/rpc_effects.rs
+++ b/node/src/rpc/rpc_effects.rs
@@ -670,7 +670,7 @@ pub fn rpc_effects<S: Service>(store: &mut Store<S>, action: RpcActionWithMeta) 
         }
         RpcAction::LedgerAccountsGetInit { rpc_id, public_key } => {
             let ledger_hash = if let Some(best_tip) = store.state().transition_frontier.best_tip() {
-                best_tip.staged_ledger_hash()
+                best_tip.merkle_root_hash()
             } else {
                 return;
             };

--- a/node/src/rpc/rpc_effects.rs
+++ b/node/src/rpc/rpc_effects.rs
@@ -346,7 +346,7 @@ pub fn rpc_effects<S: Service>(store: &mut Store<S>, action: RpcActionWithMeta) 
                 }
             };
             if store.dispatch(LedgerReadAction::Init {
-                request: LedgerReadRequest::ScanStateSummary(block.staged_ledger_hash().clone()),
+                request: LedgerReadRequest::ScanStateSummary(block.staged_ledger_hashes().clone()),
             }) {
                 store.dispatch(RpcAction::ScanStateSummaryGetPending {
                     rpc_id,

--- a/node/src/rpc/rpc_state.rs
+++ b/node/src/rpc/rpc_state.rs
@@ -64,7 +64,13 @@ impl RpcState {
 
     pub fn scan_state_summary_rpc_ids(
         &self,
-    ) -> impl Iterator<Item = (RpcId, &v2::LedgerHash, &RpcRequestStatus)> {
+    ) -> impl Iterator<
+        Item = (
+            RpcId,
+            &v2::MinaBaseStagedLedgerHashStableV1,
+            &RpcRequestStatus,
+        ),
+    > {
         self.requests
             .iter()
             .filter(|(_, req)| matches!(req.req, RpcRequest::ScanStateSummaryGet(_)))
@@ -73,7 +79,7 @@ impl RpcState {
                     RpcRequestExtraData::FullBlockOpt(block) => block.as_ref()?,
                     _ => return None,
                 };
-                Some((*id, block.staged_ledger_hash(), &req.status))
+                Some((*id, block.staged_ledger_hashes(), &req.status))
             })
     }
 

--- a/node/src/transition_frontier/genesis/mod.rs
+++ b/node/src/transition_frontier/genesis/mod.rs
@@ -29,7 +29,7 @@ pub(super) fn empty_pending_coinbase() -> PendingCoinbase {
     v
 }
 
-pub(super) fn empty_pending_coinbase_hash() -> v2::PendingCoinbaseHash {
+pub fn empty_pending_coinbase_hash() -> v2::PendingCoinbaseHash {
     v2::MinaBasePendingCoinbaseHashVersionedStableV1(
         v2::MinaBasePendingCoinbaseHashBuilderStableV1(
             empty_pending_coinbase().merkle_root().into(),

--- a/node/src/transition_frontier/sync/transition_frontier_sync_actions.rs
+++ b/node/src/transition_frontier/sync/transition_frontier_sync_actions.rs
@@ -37,7 +37,7 @@ pub enum TransitionFrontierSyncAction {
         new_best_tip_height = best_tip.height(),
         new_root_block_hash = display(&root_block.hash),
         new_root_snarked_ledger_hash = display(root_block.snarked_ledger_hash()),
-        new_root_staged_ledger_hash = display(root_block.staged_ledger_hash()),
+        new_root_staged_ledger_hash = display(root_block.merkle_root_hash()),
     ))]
     BestTipUpdate {
         // Required to be able to reuse partially synced root ledgers

--- a/node/src/transition_frontier/sync/transition_frontier_sync_effects.rs
+++ b/node/src/transition_frontier/sync/transition_frontier_sync_effects.rs
@@ -319,7 +319,7 @@ impl TransitionFrontierSyncAction {
                     .flat_map(|b| {
                         [
                             b.snarked_ledger_hash(),
-                            b.staged_ledger_hash(),
+                            b.merkle_root_hash(),
                             b.staking_epoch_ledger_hash(),
                             b.next_epoch_ledger_hash(),
                         ]

--- a/node/src/transition_frontier/sync/transition_frontier_sync_state.rs
+++ b/node/src/transition_frontier/sync/transition_frontier_sync_state.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use mina_p2p_messages::v2::{LedgerHash, MinaStateProtocolStateValueStableV2, StateHash};
+use mina_p2p_messages::v2::{self, LedgerHash, MinaStateProtocolStateValueStableV2, StateHash};
 use openmina_core::block::ArcBlockWithHash;
 use redux::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -104,7 +104,7 @@ pub struct TransitionFrontierRootSnarkedLedgerUpdate {
     /// ledger as the target. From that staged ledger we can fetch
     /// transactions that we need to apply on top of `parent` in order
     /// to construct target snarked ledger.
-    pub staged_ledger_hash: LedgerHash,
+    pub staged_ledger_hash: v2::MinaBaseStagedLedgerHashStableV1,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -560,7 +560,7 @@ impl TransitionFrontierRootSnarkedLedgerUpdates {
                     let last_block = std::mem::replace(last_block, b);
                     let update = TransitionFrontierRootSnarkedLedgerUpdate {
                         parent: b.snarked_ledger_hash().clone(),
-                        staged_ledger_hash: last_block.staged_ledger_hash().clone(),
+                        staged_ledger_hash: last_block.staged_ledger_hashes().clone(),
                     };
                     let snarked_ledger_hash = last_block.snarked_ledger_hash().clone();
 

--- a/node/src/transition_frontier/transition_frontier_effects.rs
+++ b/node/src/transition_frontier/transition_frontier_effects.rs
@@ -294,7 +294,7 @@ fn synced_effects<S: crate::Service>(
         });
     }
 
-    let best_tip_hash = best_tip.staged_ledger_hash().clone();
+    let best_tip_hash = best_tip.merkle_root_hash().clone();
     store.dispatch(ConsensusAction::Prune);
     store.dispatch(BlockProducerAction::BestTipUpdate { best_tip });
     store.dispatch(TransactionPoolAction::BestTipChanged {

--- a/node/testing/src/cluster/runner/mod.rs
+++ b/node/testing/src/cluster/runner/mod.rs
@@ -284,7 +284,7 @@ impl<'a> ClusterRunner<'a> {
     ) -> Box<dyn 'b + Iterator<Item = (AccountSecretKey, Box<ledger::Account>)>> {
         let Some(mask) = self.node(node_id).and_then(|node| {
             let best_tip = node.state().transition_frontier.best_tip()?;
-            let ledger_hash = best_tip.staged_ledger_hash();
+            let ledger_hash = best_tip.merkle_root_hash();
             let (mask, _) = LedgerService::ledger_manager(node.service()).get_mask(ledger_hash)?;
             Some(mask)
         }) else {


### PR DESCRIPTION
This removes fetching a `StagedLedger` by its merkle root hash: multiple `StagedLedger` can have the same merkle root hash

Alternative to #705 