### PR TITLE
fix(block-producer): Use the correct staking ledger after epoch boundaries

### DIFF
--- a/node/src/block_producer/block_producer_effects.rs
+++ b/node/src/block_producer/block_producer_effects.rs
@@ -151,6 +151,16 @@ pub fn block_producer_effects<S: crate::Service>(
                 .collect();
             // TODO(binier)
             let supercharge_coinbase = true;
+            // We want to know if this is a new epoch to decide which staking ledger to use
+            // (staking epoch ledger or next epoch ledger).
+            let is_new_epoch = won_slot.epoch()
+                > pred_block
+                    .header()
+                    .protocol_state
+                    .body
+                    .consensus_state
+                    .epoch_count
+                    .as_u32();
 
             let transactions_by_fee = state.block_producer.pending_transactions();
 
@@ -159,6 +169,7 @@ pub fn block_producer_effects<S: crate::Service>(
                     pred_block: pred_block.clone(),
                     global_slot_since_genesis: won_slot
                         .global_slot_since_genesis(pred_block.global_slot_diff()),
+                    is_new_epoch,
                     producer: producer.clone(),
                     delegator: won_slot.delegator.0.clone(),
                     coinbase_receiver: coinbase_receiver.clone(),

--- a/node/src/ledger/ledger_manager.rs
+++ b/node/src/ledger/ledger_manager.rs
@@ -126,6 +126,7 @@ impl LedgerRequest {
                 LedgerWriteRequest::StagedLedgerDiffCreate {
                     pred_block,
                     global_slot_since_genesis: global_slot,
+                    is_new_epoch,
                     producer,
                     delegator,
                     coinbase_receiver,
@@ -138,6 +139,7 @@ impl LedgerRequest {
                     let result = ledger_ctx.staged_ledger_diff_create(
                         pred_block,
                         global_slot,
+                        is_new_epoch,
                         producer,
                         delegator,
                         coinbase_receiver,

--- a/node/src/ledger/ledger_service.rs
+++ b/node/src/ledger/ledger_service.rs
@@ -950,6 +950,7 @@ impl LedgerCtx {
         &mut self,
         pred_block: ArcBlockWithHash,
         global_slot_since_genesis: v2::MinaNumbersGlobalSlotSinceGenesisMStableV1,
+        is_new_epoch: bool,
         producer: NonZeroCurvePoint,
         delegator: NonZeroCurvePoint,
         coinbase_receiver: NonZeroCurvePoint,
@@ -1024,6 +1025,11 @@ impl LedgerCtx {
             .map_err(|err| format!("{err:?}"))?;
 
         let diff_hash = block_body_hash(&diff).map_err(|err| format!("{err:?}"))?;
+        let staking_ledger_hash = if is_new_epoch {
+            pred_block.next_epoch_ledger_hash()
+        } else {
+            pred_block.staking_epoch_ledger_hash()
+        };
 
         Ok(StagedLedgerDiffCreateOutput {
             diff,
@@ -1039,11 +1045,7 @@ impl LedgerCtx {
                 is_new_stack: res.pending_coinbase_update.0,
             },
             stake_proof_sparse_ledger: self
-                .stake_proof_sparse_ledger(
-                    pred_block.staking_epoch_ledger_hash(),
-                    &producer,
-                    &delegator,
-                )
+                .stake_proof_sparse_ledger(staking_ledger_hash, &producer, &delegator)
                 .map_err(error_to_string)?,
         })
     }

--- a/node/src/ledger/write/mod.rs
+++ b/node/src/ledger/write/mod.rs
@@ -38,6 +38,7 @@ pub enum LedgerWriteRequest {
     StagedLedgerDiffCreate {
         pred_block: ArcBlockWithHash,
         global_slot_since_genesis: v2::MinaNumbersGlobalSlotSinceGenesisMStableV1,
+        is_new_epoch: bool,
         producer: v2::NonZeroCurvePoint,
         delegator: v2::NonZeroCurvePoint,
         coinbase_receiver: v2::NonZeroCurvePoint,


### PR DESCRIPTION
If the epoch of the block being producer is greater than the epoch of the parent block, then the next epoch ledger must be used.