### PR TITLE
Fix zkapp verification with feature flags

### DIFF
--- a/ledger/src/proofs/step.rs
+++ b/ledger/src/proofs/step.rs
@@ -8,7 +8,7 @@ use crate::{
             prepared_statement::{DeferredValues, PreparedStatement, ProofState},
         },
         unfinalized::dummy_ipa_step_challenges_computed,
-        util::proof_evaluation_to_list,
+        util::proof_evaluation_to_absorption_sequence,
         verifiers::wrap_domains,
         wrap::{
             create_oracle_with_public_input, dummy_ipa_wrap_sg, wrap_verifier, Domain,
@@ -2002,7 +2002,7 @@ pub fn expand_deferred(params: ExpandDeferredParams) -> Result<DeferredValues<Fp
         }
     };
 
-    let xs = proof_evaluation_to_list(&evals.evals.evals);
+    let xs = proof_evaluation_to_absorption_sequence(&evals.evals.evals);
     let (x1, x2) = &evals.evals.public_input;
 
     let old_bulletproof_challenges: Vec<_> = old_bulletproof_challenges

--- a/ledger/src/proofs/transaction.rs
+++ b/ledger/src/proofs/transaction.rs
@@ -4181,7 +4181,7 @@ mod tests_with_wasm {
 }
 
 #[cfg(test)]
-mod tests {
+pub(super) mod tests {
     use std::path::Path;
 
     use mina_p2p_messages::binprot::{
@@ -4215,7 +4215,7 @@ mod tests {
         PerformJob(mina_p2p_messages::v2::SnarkWorkerWorkerRpcsVersionedGetWorkV2TResponse),
     }
 
-    fn panic_in_ci() {
+    pub fn panic_in_ci() {
         fn is_ci() -> bool {
             std::env::var("CI").is_ok()
         }

--- a/ledger/src/proofs/util.rs
+++ b/ledger/src/proofs/util.rs
@@ -287,6 +287,7 @@ pub fn proof_evaluation_to_absorption_sequence<F: FieldWitness>(
         .filter_map(|v| v.as_ref()),
     );
 
+    #[allow(clippy::iter_cloned_collect)]
     list.iter().cloned().collect()
 }
 

--- a/ledger/src/proofs/util.rs
+++ b/ledger/src/proofs/util.rs
@@ -134,7 +134,7 @@ pub fn challenge_polynomial_checked<F: FieldWitness>(
 }
 
 /// Note: Outdated URL
-/// Note: Same as `to_absorption_sequence`
+/// Note: Different than `to_absorption_sequence`
 /// https://github.com/MinaProtocol/mina/blob/4af0c229548bc96d76678f11b6842999de5d3b0b/src/lib/pickles_types/plonk_types.ml#L611
 pub fn proof_evaluation_to_list<F: FieldWitness>(
     e: &ProofEvaluations<PointEvaluations<Vec<F>>>,
@@ -209,6 +209,85 @@ pub fn proof_evaluation_to_list<F: FieldWitness>(
     );
 
     list
+}
+
+pub fn proof_evaluation_to_absorption_sequence<F: FieldWitness>(
+    e: &ProofEvaluations<PointEvaluations<Vec<F>>>,
+) -> Vec<&PointEvaluations<Vec<F>>> {
+    let ProofEvaluations {
+        public: _,
+        w,
+        coefficients,
+        z,
+        s,
+        generic_selector,
+        poseidon_selector,
+        complete_add_selector,
+        mul_selector,
+        emul_selector,
+        endomul_scalar_selector,
+        range_check0_selector,
+        range_check1_selector,
+        foreign_field_add_selector,
+        foreign_field_mul_selector,
+        xor_selector,
+        rot_selector,
+        lookup_aggregation,
+        lookup_table,
+        lookup_sorted,
+        runtime_lookup_table,
+        runtime_lookup_table_selector,
+        xor_lookup_selector,
+        lookup_gate_lookup_selector,
+        range_check_lookup_selector,
+        foreign_field_mul_lookup_selector,
+    } = e;
+
+    let mut list = vec![
+        z,
+        generic_selector,
+        poseidon_selector,
+        complete_add_selector,
+        mul_selector,
+        emul_selector,
+        endomul_scalar_selector,
+    ];
+
+    list.extend(w.iter());
+    list.extend(coefficients.iter());
+    list.extend(s.iter());
+
+    list.extend(
+        [
+            range_check0_selector,
+            range_check1_selector,
+            foreign_field_add_selector,
+            foreign_field_mul_selector,
+            xor_selector,
+            rot_selector,
+            lookup_aggregation,
+            lookup_table,
+        ]
+        .into_iter()
+        .filter_map(|v| v.as_ref()),
+    );
+
+    list.extend(lookup_sorted.iter().filter_map(|v| v.as_ref()));
+
+    list.extend(
+        [
+            runtime_lookup_table,
+            runtime_lookup_table_selector,
+            xor_lookup_selector,
+            lookup_gate_lookup_selector,
+            range_check_lookup_selector,
+            foreign_field_mul_lookup_selector,
+        ]
+        .into_iter()
+        .filter_map(|v| v.as_ref()),
+    );
+
+    list.iter().cloned().collect()
 }
 
 /// https://github.com/MinaProtocol/mina/blob/4af0c229548bc96d76678f11b6842999de5d3b0b/src/lib/pickles_types/plonk_types.ml#L611
@@ -312,7 +391,98 @@ pub fn to_absorption_sequence_opt<F: FieldWitness>(
     evals: &ProofEvaluations<PointEvaluations<Vec<F>>>,
     hack_feature_flags: OptFlag,
 ) -> Vec<Opt<PointEvaluations<Vec<F>>>> {
-    proof_evaluation_to_list_opt(evals, hack_feature_flags)
+    let ProofEvaluations {
+        public: _,
+        w,
+        coefficients,
+        z,
+        s,
+        generic_selector,
+        poseidon_selector,
+        complete_add_selector,
+        mul_selector,
+        emul_selector,
+        endomul_scalar_selector,
+        range_check0_selector,
+        range_check1_selector,
+        foreign_field_add_selector,
+        foreign_field_mul_selector,
+        xor_selector,
+        rot_selector,
+        lookup_aggregation,
+        lookup_table,
+        lookup_sorted,
+        runtime_lookup_table,
+        runtime_lookup_table_selector,
+        xor_lookup_selector,
+        lookup_gate_lookup_selector,
+        range_check_lookup_selector,
+        foreign_field_mul_lookup_selector,
+    } = evals;
+
+    let mut list = vec![
+        Opt::Some(z.clone()),
+        Opt::Some(generic_selector.clone()),
+        Opt::Some(poseidon_selector.clone()),
+        Opt::Some(complete_add_selector.clone()),
+        Opt::Some(mul_selector.clone()),
+        Opt::Some(emul_selector.clone()),
+        Opt::Some(endomul_scalar_selector.clone()),
+    ];
+
+    list.extend(w.iter().cloned().map(Opt::Some));
+    list.extend(coefficients.iter().cloned().map(Opt::Some));
+    list.extend(s.iter().cloned().map(Opt::Some));
+
+    let zero = || PointEvaluations {
+        zeta: vec![F::zero()],
+        zeta_omega: vec![F::zero()],
+    };
+    let to_opt = |v: &Option<PointEvaluations<Vec<F>>>| {
+        if let OptFlag::Maybe = hack_feature_flags {
+            match v {
+                Some(v) => Opt::Maybe(Boolean::True, v.clone()),
+                None => Opt::Maybe(Boolean::False, zero()),
+            }
+        } else {
+            match v {
+                Some(v) => Opt::Some(v.clone()),
+                None => Opt::No,
+            }
+        }
+    };
+
+    list.extend(
+        [
+            range_check0_selector,
+            range_check1_selector,
+            foreign_field_add_selector,
+            foreign_field_mul_selector,
+            xor_selector,
+            rot_selector,
+            lookup_aggregation,
+            lookup_table,
+        ]
+        .iter()
+        .map(|e| to_opt(e)),
+    );
+
+    list.extend(lookup_sorted.iter().map(to_opt));
+
+    list.extend(
+        [
+            runtime_lookup_table,
+            runtime_lookup_table_selector,
+            xor_lookup_selector,
+            lookup_gate_lookup_selector,
+            range_check_lookup_selector,
+            foreign_field_mul_lookup_selector,
+        ]
+        .into_iter()
+        .map(to_opt),
+    );
+
+    list
 }
 
 pub fn sha256_sum(s: &[u8]) -> String {

--- a/ledger/src/proofs/verification.rs
+++ b/ledger/src/proofs/verification.rs
@@ -866,110 +866,127 @@ fn generate_new_filename(name: &str, extension: &str, data: &[u8]) -> std::io::R
     Err(std::io::Error::other("no filename available"))
 }
 
-// #[cfg(test)]
-// mod tests {
-//     use std::{
-//         collections::hash_map::DefaultHasher,
-//         hash::{Hash, Hasher},
-//     };
+#[cfg(test)]
+mod tests {
+    use mina_hasher::Fp;
+    use mina_p2p_messages::{binprot::BinProtRead, v2};
 
-//     // use binprot::BinProtRead;
-//     use mina_curves::pasta::{Vesta, Fq};
-//     use mina_hasher::Fp;
-//     use mina_p2p_messages::v2::MinaBlockHeaderStableV2;
-//     use poly_commitment::srs::SRS;
+    use super::*;
 
-//     use crate::{
-//         proofs::{caching::{
-//             srs_from_bytes, srs_to_bytes, verifier_index_from_bytes, verifier_index_to_bytes,
-//         }, verifier_index::{get_verifier_index, VerifierKind}}, verifier::get_srs,
-//         // get_srs, get_verifier_index,
-//     };
+    #[cfg(target_family = "wasm")]
+    use wasm_bindgen_test::wasm_bindgen_test as test;
 
-//     #[cfg(target_family = "wasm")]
-//     use wasm_bindgen_test::wasm_bindgen_test as test;
+    #[test]
+    fn test_verify_zkapp() {
+        use mina_p2p_messages::binprot;
+        use mina_p2p_messages::binprot::macros::{BinProtRead, BinProtWrite};
 
-//     #[test]
-//     fn test_verification() {
-//         let now = redux::Instant::now();
-//         let verifier_index = get_verifier_index(VerifierKind::Blockchain);
-//         println!("get_verifier_index={:?}", now.elapsed());
+        #[derive(Clone, Debug, PartialEq, BinProtRead, BinProtWrite)]
+        struct VerifyZkapp {
+            vk: v2::MinaBaseVerificationKeyWireStableV1,
+            zkapp_statement: v2::MinaBaseZkappStatementStableV2,
+            proof: v2::PicklesProofProofsVerified2ReprStableV2,
+        }
 
-//         let now = redux::Instant::now();
-//         let srs = get_srs::<Fp>();
-//         let srs = srs.lock().unwrap();
-//         println!("get_srs={:?}\n", now.elapsed());
+        let Ok(file) = std::fs::read("/tmp/verify_zapp_4af39d1e141859c964fe32b4e80537d3bd8c32d75e2754c0b869738006d25251_0.binprot") else {
+            eprintln!("not found");
+            return;
+        };
 
-//         // let now = redux::Instant::now();
-//         // let bytes = verifier_index_to_bytes(&verifier_index);
-//         // println!("verifier_elapsed={:?}", now.elapsed());
-//         // println!("verifier_length={:?}", bytes.len());
-//         // assert_eq!(bytes.len(), 5622520);
+        let VerifyZkapp {
+            vk,
+            zkapp_statement,
+            proof,
+        } = VerifyZkapp::binprot_read(&mut file.as_slice()).unwrap();
 
-//         // let now = redux::Instant::now();
-//         // let verifier_index = verifier_index_from_bytes(&bytes);
-//         // println!("verifier_deserialize_elapsed={:?}\n", now.elapsed());
+        let vk = (&vk).try_into().unwrap();
+        let zkapp_statement = (&zkapp_statement).try_into().unwrap();
+        let srs = crate::verifier::get_srs::<Fp>();
 
-//         // let now = redux::Instant::now();
-//         // let bytes = srs_to_bytes(&srs);
-//         // println!("srs_elapsed={:?}", now.elapsed());
-//         // println!("srs_length={:?}", bytes.len());
-//         // assert_eq!(bytes.len(), 5308513);
+        verify_zkapp(&vk, &zkapp_statement, &proof, &*srs);
+    }
 
-//         // let now = redux::Instant::now();
-//         // let srs: SRS<Vesta> = srs_from_bytes(&bytes);
-//         // println!("deserialize_elapsed={:?}\n", now.elapsed());
+    // #[test]
+    // fn test_verification() {
+    //     let now = redux::Instant::now();
+    //     let verifier_index = get_verifier_index(VerifierKind::Blockchain);
+    //     println!("get_verifier_index={:?}", now.elapsed());
 
-//         // Few blocks headers from berkeleynet
-//         let files = [
-//             include_bytes!("/tmp/block-rampup4.binprot"),
-//             // include_bytes!("../data/5573.binprot"),
-//             // include_bytes!("../data/5574.binprot"),
-//             // include_bytes!("../data/5575.binprot"),
-//             // include_bytes!("../data/5576.binprot"),
-//             // include_bytes!("../data/5577.binprot"),
-//             // include_bytes!("../data/5578.binprot"),
-//             // include_bytes!("../data/5579.binprot"),
-//             // include_bytes!("../data/5580.binprot"),
-//         ];
+    //     let now = redux::Instant::now();
+    //     let srs = get_srs::<Fp>();
+    //     let srs = srs.lock().unwrap();
+    //     println!("get_srs={:?}\n", now.elapsed());
 
-//         use mina_p2p_messages::binprot::BinProtRead;
-//         use crate::proofs::accumulator_check::accumulator_check;
+    //     // let now = redux::Instant::now();
+    //     // let bytes = verifier_index_to_bytes(&verifier_index);
+    //     // println!("verifier_elapsed={:?}", now.elapsed());
+    //     // println!("verifier_length={:?}", bytes.len());
+    //     // assert_eq!(bytes.len(), 5622520);
 
-//         for file in files {
-//             let header = MinaBlockHeaderStableV2::binprot_read(&mut file.as_slice()).unwrap();
+    //     // let now = redux::Instant::now();
+    //     // let verifier_index = verifier_index_from_bytes(&bytes);
+    //     // println!("verifier_deserialize_elapsed={:?}\n", now.elapsed());
 
-//             let now = redux::Instant::now();
-//             let accum_check = accumulator_check(&*srs, &header.protocol_state_proof.0);
-//             println!("accumulator_check={:?}", now.elapsed());
+    //     // let now = redux::Instant::now();
+    //     // let bytes = srs_to_bytes(&srs);
+    //     // println!("srs_elapsed={:?}", now.elapsed());
+    //     // println!("srs_length={:?}", bytes.len());
+    //     // assert_eq!(bytes.len(), 5308513);
 
-//             let now = redux::Instant::now();
-//             let verified = super::verify_block(&header, &verifier_index, &*srs);
+    //     // let now = redux::Instant::now();
+    //     // let srs: SRS<Vesta> = srs_from_bytes(&bytes);
+    //     // println!("deserialize_elapsed={:?}\n", now.elapsed());
 
-//             // let verified = crate::verify(&header, &verifier_index);
-//             println!("snark::verify={:?}", now.elapsed());
+    //     // Few blocks headers from berkeleynet
+    //     let files = [
+    //         include_bytes!("/tmp/block-rampup4.binprot"),
+    //         // include_bytes!("../data/5573.binprot"),
+    //         // include_bytes!("../data/5574.binprot"),
+    //         // include_bytes!("../data/5575.binprot"),
+    //         // include_bytes!("../data/5576.binprot"),
+    //         // include_bytes!("../data/5577.binprot"),
+    //         // include_bytes!("../data/5578.binprot"),
+    //         // include_bytes!("../data/5579.binprot"),
+    //         // include_bytes!("../data/5580.binprot"),
+    //     ];
 
-//             assert!(accum_check);
-//             assert!(verified);
-//         }
-//     }
+    //     use mina_p2p_messages::binprot::BinProtRead;
+    //     use crate::proofs::accumulator_check::accumulator_check;
 
-//     #[test]
-//     fn test_verifier_index_deterministic() {
-//         let mut nruns = 0;
-//         let nruns = &mut nruns;
+    //     for file in files {
+    //         let header = MinaBlockHeaderStableV2::binprot_read(&mut file.as_slice()).unwrap();
 
-//         let mut hash_verifier_index = || {
-//             *nruns += 1;
-//             let verifier_index = get_verifier_index();
-//             let bytes = verifier_index_to_bytes(&verifier_index);
+    //         let now = redux::Instant::now();
+    //         let accum_check = accumulator_check(&*srs, &header.protocol_state_proof.0);
+    //         println!("accumulator_check={:?}", now.elapsed());
 
-//             let mut hasher = DefaultHasher::new();
-//             bytes.hash(&mut hasher);
-//             hasher.finish()
-//         };
+    //         let now = redux::Instant::now();
+    //         let verified = super::verify_block(&header, &verifier_index, &*srs);
 
-//         assert_eq!(hash_verifier_index(), hash_verifier_index());
-//         assert_eq!(*nruns, 2);
-//     }
-// }
+    //         // let verified = crate::verify(&header, &verifier_index);
+    //         println!("snark::verify={:?}", now.elapsed());
+
+    //         assert!(accum_check);
+    //         assert!(verified);
+    //     }
+    // }
+
+    // #[test]
+    // fn test_verifier_index_deterministic() {
+    //     let mut nruns = 0;
+    //     let nruns = &mut nruns;
+
+    //     let mut hash_verifier_index = || {
+    //         *nruns += 1;
+    //         let verifier_index = get_verifier_index();
+    //         let bytes = verifier_index_to_bytes(&verifier_index);
+
+    //         let mut hasher = DefaultHasher::new();
+    //         bytes.hash(&mut hasher);
+    //         hasher.finish()
+    //     };
+
+    //     assert_eq!(hash_verifier_index(), hash_verifier_index());
+    //     assert_eq!(*nruns, 2);
+    // }
+}


### PR DESCRIPTION
The bug was introduced in #721
Restore `proof_evaluation_to_absorption_sequence`, because it's actually different than `proof_evaluation_to_list`