### PR TITLE
feat(proofs): Batch verification of completed works in blocks

### DIFF
--- a/ledger/src/proofs/accumulator_check.rs
+++ b/ledger/src/proofs/accumulator_check.rs
@@ -9,38 +9,52 @@ use super::urs_utils;
 
 pub fn accumulator_check(
     urs: &SRS<Vesta>,
-    proof: &PicklesProofProofsVerified2ReprStableV2,
+    proofs: &[&PicklesProofProofsVerified2ReprStableV2],
 ) -> Result<bool, InvalidBigInt> {
     // accumulator check
+    // https://github.com/MinaProtocol/mina/blob/fb1c3c0a408c344810140bdbcedacc532a11be91/src/lib/pickles/common.ml#L191-L204
     // Note:
     // comms: statement.proof_state.messages_for_next_wrap_proof.challenge_polynomial_commitment
+    //        Array.of_list_map comm_chals ~f:(fun (comm, _) -> Or_infinity.Finite comm )
     // chals: statement.proof_state.deferred_values.bulletproof_challenges
+    //        Array.concat @@ List.map comm_chals ~f:(fun (_, chals) -> Vector.to_array chals)
 
-    let deferred_values = &proof.statement.proof_state.deferred_values;
-    let bulletproof_challenges = &deferred_values.bulletproof_challenges;
-    let bulletproof_challenges: Vec<Fp> = bulletproof_challenges
-        .iter()
-        .map(|chal| {
-            let prechallenge = &chal.prechallenge.inner;
-            let prechallenge: [u64; 2] = prechallenge.each_ref().map(|c| c.as_u64());
+    let mut comms = Vec::with_capacity(proofs.len());
+    let mut bulletproof_challenges = vec![];
 
-            ScalarChallenge::limbs_to_field(&prechallenge)
-        })
-        .collect();
+    for proof in proofs {
+        let chals = &proof
+            .statement
+            .proof_state
+            .deferred_values
+            .bulletproof_challenges;
+        let mut chals: Vec<Fp> = chals
+            .iter()
+            .map(|chal| {
+                let prechallenge = &chal.prechallenge.inner;
+                let prechallenge: [u64; 2] = prechallenge.each_ref().map(|c| c.as_u64());
 
-    let of_coord =
-        |(x, y): &(BigInt, BigInt)| Ok(Vesta::of_coordinates(x.to_field()?, y.to_field()?));
+                ScalarChallenge::limbs_to_field(&prechallenge)
+            })
+            .collect();
 
-    // statement.proof_state.messages_for_next_wrap_proof.challenge_polynomial_commitment
-    let acc_comm = &proof
-        .statement
-        .proof_state
-        .messages_for_next_wrap_proof
-        .challenge_polynomial_commitment;
-    let acc_comm: Vesta = of_coord(acc_comm)?;
+        bulletproof_challenges.append(&mut chals);
 
-    let acc_check =
-        urs_utils::batch_dlog_accumulator_check(urs, &[acc_comm], &bulletproof_challenges);
+        let of_coord =
+            |(x, y): &(BigInt, BigInt)| Ok(Vesta::of_coordinates(x.to_field()?, y.to_field()?));
+
+        // statement.proof_state.messages_for_next_wrap_proof.challenge_polynomial_commitment
+        let acc_comm = &proof
+            .statement
+            .proof_state
+            .messages_for_next_wrap_proof
+            .challenge_polynomial_commitment;
+        let acc_comm: Vesta = of_coord(acc_comm)?;
+
+        comms.push(acc_comm);
+    }
+
+    let acc_check = urs_utils::batch_dlog_accumulator_check(urs, &comms, &bulletproof_challenges);
 
     if !acc_check {
         println!("accumulator_check failed");

--- a/ledger/src/staged_ledger/staged_ledger.rs
+++ b/ledger/src/staged_ledger/staged_ledger.rs
@@ -1247,12 +1247,16 @@ impl StagedLedger {
         supercharge_coinbase: bool,
     ) -> Result<DiffResult, StagedLedgerError> {
         let work = witness.completed_works();
+        let works_count = work.len();
 
         let now = redux::Instant::now();
         if skip_verification.is_none() {
             Self::check_completed_works(logger, verifier, &self.scan_state, work)?;
         }
-        eprintln!("verification time={:?}", now.elapsed());
+        eprintln!(
+            "verification time={:?} ({works_count} completed works)",
+            now.elapsed()
+        );
 
         let prediff = witness.get(
             |cmd| Self::check_commands(self.ledger.clone(), verifier, cmd, skip_verification),


### PR DESCRIPTION
Doesn't enable verifications during block application yet (that will come with the changes to the catchup process, so that blocks are queued for verification before applying).