### PR TITLE
fix(ci): Install a specific version of wasm-bindgen-cli

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,7 +116,7 @@ jobs:
          rustup default nightly
          rustup component add rustfmt rust-src
          rustup target add wasm32-unknown-unknown
-         cargo install -f wasm-bindgen-cli
+         cargo install -f wasm-bindgen-cli --version 0.2.93
 
      - name: Setup Rust Cache
        uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
To avoid this issue (which I assume is caused by us caching results from run to run):

```
it looks like the Rust project used to create this Wasm file was linked against
version of wasm-bindgen that uses a different bindgen format than this binary:

  rust Wasm file schema version: 0.2.93
     this binary schema version: 0.2.94
```