### PR TITLE
Updated reducer to accept action instead of & action

### DIFF
--- a/node/src/reducer.rs
+++ b/node/src/reducer.rs
@@ -36,7 +36,7 @@ pub fn reducer(
                     let time = meta.time();
                     let result = p2p::P2pState::reducer(
                         Substate::new(state, dispatcher),
-                        meta.with_action(action),
+                        meta.with_action(action.clone()),
                     );
 
                     if let Err(error) = result {

--- a/node/src/rpc/mod.rs
+++ b/node/src/rpc/mod.rs
@@ -587,7 +587,7 @@ pub mod discovery {
             }
 
             Ok(RpcDiscoveryRoutingTable {
-                this_key: value.this_key.clone(),
+                this_key: value.this_key,
                 buckets,
             })
         }
@@ -643,8 +643,8 @@ pub mod discovery {
             Ok(RpcEntry {
                 peer_id: value.peer_id,
                 libp2p: value.peer_id.try_into()?,
-                key: value.key.clone(),
-                dist: this_key - &value.key,
+                key: value.key,
+                dist: this_key - value.key,
                 addrs: value.addresses().clone(),
                 connection: value.connection,
             })

--- a/p2p/src/channels/best_tip/p2p_channels_best_tip_reducer.rs
+++ b/p2p/src/channels/best_tip/p2p_channels_best_tip_reducer.rs
@@ -12,7 +12,7 @@ impl P2pChannelsBestTipState {
     /// Substate is accessed
     pub fn reducer<Action, State>(
         mut state_context: Substate<Action, State, P2pState>,
-        action: ActionWithMeta<&P2pChannelsBestTipAction>,
+        action: ActionWithMeta<P2pChannelsBestTipAction>,
     ) -> Result<(), String>
     where
         State: crate::P2pStateTrait,
@@ -90,10 +90,7 @@ impl P2pChannelsBestTipState {
                 *last_received = Some(best_tip.clone());
 
                 let dispatcher = state_context.into_dispatcher();
-                dispatcher.push(P2pPeerAction::BestTipUpdate {
-                    peer_id,
-                    best_tip: best_tip.clone(),
-                });
+                dispatcher.push(P2pPeerAction::BestTipUpdate { peer_id, best_tip });
                 dispatcher.push(P2pChannelsBestTipAction::RequestSend { peer_id });
                 Ok(())
             }
@@ -115,7 +112,7 @@ impl P2pChannelsBestTipState {
                     .callbacks
                     .on_p2p_channels_best_tip_request_received
                 {
-                    dispatcher.push_callback(callback.clone(), *peer_id);
+                    dispatcher.push_callback(callback.clone(), peer_id);
                 }
                 Ok(())
             }
@@ -141,7 +138,7 @@ impl P2pChannelsBestTipState {
                 if !is_libp2p {
                     dispatcher.push(P2pChannelsBestTipEffectfulAction::ResponseSend {
                         peer_id,
-                        best_tip: best_tip.clone(),
+                        best_tip,
                     });
                     return Ok(());
                 }

--- a/p2p/src/channels/p2p_channels_reducer.rs
+++ b/p2p/src/channels/p2p_channels_reducer.rs
@@ -34,7 +34,7 @@ use redux::{ActionWithMeta, Dispatcher};
 impl P2pChannelsState {
     pub fn reducer<Action, State>(
         state_context: Substate<Action, State, P2pState>,
-        action: ActionWithMeta<&P2pChannelsAction>,
+        action: ActionWithMeta<P2pChannelsAction>,
     ) -> Result<(), String>
     where
         State: crate::P2pStateTrait,
@@ -75,7 +75,7 @@ impl P2pChannelsState {
     }
 
     fn dispatch_message<Action, State>(
-        action: ActionWithMeta<&P2pChannelsMessageReceivedAction>,
+        action: ActionWithMeta<P2pChannelsMessageReceivedAction>,
         dispatcher: &mut Dispatcher<Action, State>,
         state: &State,
     ) -> Result<(), String>
@@ -91,7 +91,7 @@ impl P2pChannelsState {
 
         let mut is_enabled = |action: Action| dispatcher.push_if_enabled(action, state, time);
 
-        let was_expected = match *action.message.clone() {
+        let was_expected = match *action.message {
             ChannelMsg::SignalingDiscovery(msg) => match msg {
                 SignalingDiscoveryChannelMsg::GetNext => is_enabled(
                     P2pChannelsSignalingDiscoveryAction::RequestReceived { peer_id }.into(),

--- a/p2p/src/channels/signaling/discovery/p2p_channels_signaling_discovery_reducer.rs
+++ b/p2p/src/channels/signaling/discovery/p2p_channels_signaling_discovery_reducer.rs
@@ -23,7 +23,7 @@ impl P2pChannelsSignalingDiscoveryState {
     /// Substate is accessed
     pub fn reducer<Action, State>(
         mut state_context: Substate<Action, State, P2pState>,
-        action: ActionWithMeta<&P2pChannelsSignalingDiscoveryAction>,
+        action: ActionWithMeta<P2pChannelsSignalingDiscoveryAction>,
     ) -> Result<(), String>
     where
         State: crate::P2pStateTrait,
@@ -405,7 +405,7 @@ impl P2pChannelsSignalingDiscoveryState {
                     P2pConnectionResponse::Rejected(reason) => {
                         dispatcher.push(P2pConnectionOutgoingAction::AnswerRecvError {
                             peer_id: target_public_key.peer_id(),
-                            error: P2pConnectionErrorResponse::Rejected(*reason),
+                            error: P2pConnectionErrorResponse::Rejected(reason),
                         })
                     }
                     P2pConnectionResponse::SignalDecryptionFailed => {

--- a/p2p/src/channels/signaling/exchange/p2p_channels_signaling_exchange_reducer.rs
+++ b/p2p/src/channels/signaling/exchange/p2p_channels_signaling_exchange_reducer.rs
@@ -24,7 +24,7 @@ impl P2pChannelsSignalingExchangeState {
     /// Substate is accessed
     pub fn reducer<Action, State>(
         mut state_context: Substate<Action, State, P2pState>,
-        action: ActionWithMeta<&P2pChannelsSignalingExchangeAction>,
+        action: ActionWithMeta<P2pChannelsSignalingExchangeAction>,
     ) -> Result<(), String>
     where
         State: crate::P2pStateTrait,

--- a/p2p/src/channels/snark_job_commitment/p2p_channels_snark_job_commitment_reducer.rs
+++ b/p2p/src/channels/snark_job_commitment/p2p_channels_snark_job_commitment_reducer.rs
@@ -17,7 +17,7 @@ impl P2pChannelsSnarkJobCommitmentState {
     /// Substate is accessed
     pub fn reducer<Action, State>(
         mut state_context: Substate<Action, State, P2pState>,
-        action: ActionWithMeta<&P2pChannelsSnarkJobCommitmentAction>,
+        action: ActionWithMeta<P2pChannelsSnarkJobCommitmentAction>,
     ) -> Result<(), String>
     where
         State: crate::P2pStateTrait,
@@ -73,14 +73,12 @@ impl P2pChannelsSnarkJobCommitmentState {
                 };
                 *local = SnarkJobCommitmentPropagationState::Requested {
                     time: meta.time(),
-                    requested_limit: *limit,
+                    requested_limit: limit,
                 };
 
                 let dispatcher = state_context.into_dispatcher();
-                dispatcher.push(P2pChannelsSnarkJobCommitmentAction::RequestSend {
-                    peer_id,
-                    limit: *limit,
-                });
+                dispatcher
+                    .push(P2pChannelsSnarkJobCommitmentAction::RequestSend { peer_id, limit });
                 Ok(())
             }
             P2pChannelsSnarkJobCommitmentAction::PromiseReceived { promised_count, .. } => {
@@ -105,7 +103,7 @@ impl P2pChannelsSnarkJobCommitmentState {
                 *local = SnarkJobCommitmentPropagationState::Responding {
                     time: meta.time(),
                     requested_limit: *requested_limit,
-                    promised_count: *promised_count,
+                    promised_count,
                     current_count: 0,
                 };
                 Ok(())
@@ -151,7 +149,7 @@ impl P2pChannelsSnarkJobCommitmentState {
                     .callbacks
                     .on_p2p_channels_snark_job_commitment_received
                 {
-                    dispatcher.push_callback(callback.clone(), (peer_id, commitment.clone()));
+                    dispatcher.push_callback(callback.clone(), (peer_id, commitment));
                 }
                 Ok(())
             }
@@ -165,7 +163,7 @@ impl P2pChannelsSnarkJobCommitmentState {
                 };
                 *remote = SnarkJobCommitmentPropagationState::Requested {
                     time: meta.time(),
-                    requested_limit: *limit,
+                    requested_limit: limit,
                 };
                 Ok(())
             }
@@ -201,7 +199,7 @@ impl P2pChannelsSnarkJobCommitmentState {
                 let dispatcher = state_context.into_dispatcher();
                 dispatcher.push(P2pChannelsSnarkJobCommitmentEffectfulAction::ResponseSend {
                     peer_id,
-                    commitments: commitments.clone(),
+                    commitments,
                 });
                 Ok(())
             }

--- a/p2p/src/channels/streaming_rpc/rpcs/mod.rs
+++ b/p2p/src/channels/streaming_rpc/rpcs/mod.rs
@@ -144,7 +144,7 @@ impl P2pStreamingRpcReceiveProgress {
         }
     }
 
-    pub fn update(&mut self, time: redux::Timestamp, resp: &P2pStreamingRpcResponse) -> bool {
+    pub fn update(&mut self, time: redux::Timestamp, resp: P2pStreamingRpcResponse) -> bool {
         match (self, resp) {
             (
                 Self::StagedLedgerParts(progress),

--- a/p2p/src/channels/streaming_rpc/rpcs/staged_ledger_parts.rs
+++ b/p2p/src/channels/streaming_rpc/rpcs/staged_ledger_parts.rs
@@ -192,13 +192,10 @@ impl Default for StagedLedgerPartsSendProgress {
 }
 
 impl StagedLedgerPartsReceiveProgress {
-    pub fn update(&mut self, time: redux::Timestamp, resp: &StagedLedgerPartsResponse) -> bool {
+    pub fn update(&mut self, time: redux::Timestamp, resp: StagedLedgerPartsResponse) -> bool {
         match (std::mem::take(self), resp) {
             (Self::BasePending { .. }, StagedLedgerPartsResponse::Base(base)) => {
-                *self = Self::BaseSuccess {
-                    time,
-                    base: base.clone(),
-                };
+                *self = Self::BaseSuccess { time, base };
                 true
             }
             (
@@ -208,7 +205,7 @@ impl StagedLedgerPartsReceiveProgress {
                 *self = Self::ScanStateBaseSuccess {
                     time,
                     base,
-                    scan_state_base: data.clone(),
+                    scan_state_base: data,
                 };
                 true
             }
@@ -224,7 +221,7 @@ impl StagedLedgerPartsReceiveProgress {
                     time,
                     base,
                     scan_state_base,
-                    previous_incomplete_zkapp_updates: data.clone(),
+                    previous_incomplete_zkapp_updates: data,
                 };
                 true
             }
@@ -238,7 +235,7 @@ impl StagedLedgerPartsReceiveProgress {
                 },
                 StagedLedgerPartsResponse::ScanStateTree(tree),
             ) => {
-                trees.extend(std::iter::once(tree.clone()));
+                trees.extend(std::iter::once(tree));
 
                 *self = if trees.len() >= scan_state_base.trees.as_u32() as usize {
                     // base, scan_state_base, previous_incomplete_zkapp_updates, trees

--- a/p2p/src/connection/incoming/mod.rs
+++ b/p2p/src/connection/incoming/mod.rs
@@ -19,7 +19,7 @@ pub struct P2pConnectionIncomingInitOpts {
 }
 
 // TODO(binier): maybe move to `crate::webrtc`?
-#[derive(Serialize, Deserialize, Eq, PartialEq, Debug, Clone)]
+#[derive(Serialize, Deserialize, Eq, PartialEq, Debug, Clone, Copy)]
 pub enum IncomingSignalingMethod {
     /// Http rpc is used for sending offer and getting answer as a response.
     Http,

--- a/p2p/src/connection/incoming/p2p_connection_incoming_reducer.rs
+++ b/p2p/src/connection/incoming/p2p_connection_incoming_reducer.rs
@@ -160,10 +160,10 @@ impl P2pConnectionIncomingState {
                     );
                     return Ok(());
                 };
-                let signaling = signaling.clone();
+                let signaling = *signaling;
                 *state = Self::AnswerReady {
                     time: meta.time(),
-                    signaling: signaling.clone(),
+                    signaling,
                     offer: offer.clone(),
                     answer: answer.clone(),
                     rpc_id: rpc_id.take(),

--- a/p2p/src/connection/outgoing/p2p_connection_outgoing_actions.rs
+++ b/p2p/src/connection/outgoing/p2p_connection_outgoing_actions.rs
@@ -8,9 +8,6 @@ use crate::{webrtc, P2pState, PeerId};
 
 use super::{P2pConnectionOutgoingError, P2pConnectionOutgoingInitOpts};
 
-pub type P2pConnectionOutgoingActionWithMetaRef<'a> =
-    redux::ActionWithMeta<&'a P2pConnectionOutgoingAction>;
-
 #[derive(Serialize, Deserialize, Debug, Clone, ActionEvent)]
 #[action_event(fields(display(opts), display(peer_id), display(error)))]
 pub enum P2pConnectionOutgoingAction {

--- a/p2p/src/connection/p2p_connection_reducer.rs
+++ b/p2p/src/connection/p2p_connection_reducer.rs
@@ -10,7 +10,7 @@ use crate::P2pState;
 impl P2pConnectionState {
     pub fn reducer<Action, State>(
         state_context: Substate<Action, State, P2pState>,
-        action: ActionWithMeta<&P2pConnectionAction>,
+        action: ActionWithMeta<P2pConnectionAction>,
     ) -> Result<(), String>
     where
         State: crate::P2pStateTrait,

--- a/p2p/src/connection/p2p_connection_state.rs
+++ b/p2p/src/connection/p2p_connection_state.rs
@@ -26,7 +26,7 @@ impl P2pConnectionState {
     pub fn incoming_init(opts: &P2pConnectionIncomingInitOpts) -> Self {
         Self::Incoming(P2pConnectionIncomingState::Init {
             time: Timestamp::ZERO,
-            signaling: opts.signaling.clone(),
+            signaling: opts.signaling,
             offer: opts.offer.clone(),
             rpc_id: None,
         })

--- a/p2p/src/disconnection/p2p_disconnection_reducer.rs
+++ b/p2p/src/disconnection/p2p_disconnection_reducer.rs
@@ -11,7 +11,7 @@ use super::{P2pDisconnectedState, P2pDisconnectionAction};
 impl P2pDisconnectedState {
     pub fn reducer<Action, State>(
         mut state_context: Substate<Action, State, P2pState>,
-        action: ActionWithMeta<&P2pDisconnectionAction>,
+        action: ActionWithMeta<P2pDisconnectionAction>,
     ) -> Result<(), String>
     where
         State: crate::P2pStateTrait,
@@ -23,37 +23,34 @@ impl P2pDisconnectedState {
         match action {
             P2pDisconnectionAction::Init { peer_id, reason } => {
                 #[cfg(feature = "p2p-libp2p")]
-                if p2p_state.is_libp2p_peer(peer_id) {
+                if p2p_state.is_libp2p_peer(&peer_id) {
                     if let Some((&addr, _)) = p2p_state
                         .network
                         .scheduler
                         .connections
                         .iter()
-                        .find(|(_, conn_state)| conn_state.peer_id() == Some(peer_id))
+                        .find(|(_, conn_state)| conn_state.peer_id() == Some(&peer_id))
                     {
-                        let Some(peer) = p2p_state.peers.get_mut(peer_id) else {
+                        let Some(peer) = p2p_state.peers.get_mut(&peer_id) else {
                             bug_condition!("Invalid state for: `P2pDisconnectionAction::Finish`");
                             return Ok(());
                         };
                         peer.status = P2pPeerStatus::Disconnecting { time: meta.time() };
 
                         let dispatcher = state_context.into_dispatcher();
-                        dispatcher.push(P2pNetworkSchedulerAction::Disconnect {
-                            addr,
-                            reason: reason.clone(),
-                        });
-                        dispatcher.push(P2pDisconnectionAction::Finish { peer_id: *peer_id });
+                        dispatcher.push(P2pNetworkSchedulerAction::Disconnect { addr, reason });
+                        dispatcher.push(P2pDisconnectionAction::Finish { peer_id });
                     }
                     return Ok(());
                 }
 
                 let dispatcher = state_context.into_dispatcher();
-                dispatcher.push(P2pDisconnectionEffectfulAction::Init { peer_id: *peer_id });
+                dispatcher.push(P2pDisconnectionEffectfulAction::Init { peer_id });
                 Ok(())
             }
             #[cfg(not(feature = "p2p-libp2p"))]
             P2pDisconnectionAction::Finish { peer_id } => {
-                let Some(peer) = p2p_state.peers.get_mut(peer_id) else {
+                let Some(peer) = p2p_state.peers.get_mut(&peer_id) else {
                     bug_condition!("Invalid state for: `P2pDisconnectionAction::Finish`");
                     return Ok(());
                 };
@@ -61,10 +58,10 @@ impl P2pDisconnectedState {
 
                 let (dispatcher, state) = state_context.into_dispatcher_and_state();
                 let p2p_state: &P2pState = state.substate()?;
-                dispatcher.push(P2pPeerAction::Remove { peer_id: *peer_id });
+                dispatcher.push(P2pPeerAction::Remove { peer_id });
 
                 if let Some(callback) = &p2p_state.callbacks.on_p2p_disconnection_finish {
-                    dispatcher.push_callback(callback.clone(), *peer_id);
+                    dispatcher.push_callback(callback.clone(), peer_id);
                 }
                 Ok(())
             }
@@ -76,13 +73,13 @@ impl P2pDisconnectedState {
                     .connections
                     .iter()
                     .any(|(_addr, conn_state)| {
-                        conn_state.peer_id() == Some(peer_id) && conn_state.closed.is_none()
+                        conn_state.peer_id() == Some(&peer_id) && conn_state.closed.is_none()
                     })
                 {
                     return Ok(());
                 }
 
-                let Some(peer) = p2p_state.peers.get_mut(peer_id) else {
+                let Some(peer) = p2p_state.peers.get_mut(&peer_id) else {
                     bug_condition!("Invalid state for: `P2pDisconnectionAction::Finish`");
                     return Ok(());
                 };
@@ -90,10 +87,10 @@ impl P2pDisconnectedState {
 
                 let (dispatcher, state) = state_context.into_dispatcher_and_state();
                 let p2p_state: &P2pState = state.substate()?;
-                dispatcher.push(P2pPeerAction::Remove { peer_id: *peer_id });
+                dispatcher.push(P2pPeerAction::Remove { peer_id });
 
                 if let Some(callback) = &p2p_state.callbacks.on_p2p_disconnection_finish {
-                    dispatcher.push_callback(callback.clone(), *peer_id);
+                    dispatcher.push_callback(callback.clone(), peer_id);
                 }
 
                 Ok(())

--- a/p2p/src/network/identify/p2p_network_identify_reducer.rs
+++ b/p2p/src/network/identify/p2p_network_identify_reducer.rs
@@ -6,7 +6,7 @@ use redux::ActionWithMeta;
 impl super::P2pNetworkIdentifyState {
     pub fn reducer<Action, State>(
         state_context: Substate<Action, State, Self>,
-        action: ActionWithMeta<&P2pNetworkIdentifyAction>,
+        action: ActionWithMeta<P2pNetworkIdentifyAction>,
         limits: &P2pLimits,
     ) -> Result<(), String>
     where

--- a/p2p/src/network/kad/request/p2p_network_kad_request_reducer.rs
+++ b/p2p/src/network/kad/request/p2p_network_kad_request_reducer.rs
@@ -13,7 +13,7 @@ use super::{P2pNetworkKadRequestAction, P2pNetworkKadRequestState, P2pNetworkKad
 impl P2pNetworkKadRequestState {
     pub fn reducer<State, Action>(
         mut state_context: Substate<Action, State, P2pNetworkKadState>,
-        action: ActionWithMeta<&P2pNetworkKadRequestAction>,
+        action: ActionWithMeta<P2pNetworkKadRequestAction>,
     ) -> Result<(), String>
     where
         State: SubstateAccess<P2pNetworkKadState> + SubstateAccess<P2pState>,
@@ -25,12 +25,12 @@ impl P2pNetworkKadRequestState {
 
         let request_state = match action {
             P2pNetworkKadRequestAction::New { peer_id, addr, key } => state
-                .create_request(*addr, *peer_id, *key)
+                .create_request(addr, peer_id, key)
                 .map_err(|_request| format!("kademlia request to {addr} is already in progress"))?,
             P2pNetworkKadRequestAction::Prune { peer_id } => {
                 return state
                     .requests
-                    .remove(peer_id)
+                    .remove(&peer_id)
                     .map(|_| ())
                     .ok_or_else(|| "kademlia request for {peer_id} is not found".to_owned());
             }
@@ -44,10 +44,7 @@ impl P2pNetworkKadRequestState {
             P2pNetworkKadRequestAction::New { peer_id, addr, .. } => {
                 let (dispatcher, state) = state_context.into_dispatcher_and_state();
                 let p2p_state: &P2pState = state.substate()?;
-                let peer_state = p2p_state.peers.get(peer_id);
-
-                let peer_id = *peer_id;
-                let addr = *addr;
+                let peer_state = p2p_state.peers.get(&peer_id);
 
                 let on_initialize_connection = |dispatcher: &mut Dispatcher<Action, State>| {
                     // initialize connection to the peer.
@@ -140,7 +137,7 @@ impl P2pNetworkKadRequestState {
                     .network
                     .scheduler
                     .connections
-                    .get(addr)
+                    .get(&addr)
                     .ok_or_else(|| format!("connection with {addr} not found"))
                     .and_then(|conn| {
                         conn.mux
@@ -156,20 +153,18 @@ impl P2pNetworkKadRequestState {
 
                 // TODO: add callbacks
                 dispatcher.push(P2pNetworkYamuxAction::OpenStream {
-                    addr: *addr,
+                    addr,
                     stream_id,
                     stream_kind: crate::token::StreamKind::Discovery(
                         crate::token::DiscoveryAlgorithm::Kademlia1_0_0,
                     ),
                 });
-                dispatcher.push(P2pNetworkKadRequestAction::StreamIsCreating {
-                    peer_id: *peer_id,
-                    stream_id,
-                });
+                dispatcher
+                    .push(P2pNetworkKadRequestAction::StreamIsCreating { peer_id, stream_id });
                 Ok(())
             }
             P2pNetworkKadRequestAction::StreamIsCreating { stream_id, .. } => {
-                request_state.status = P2pNetworkKadRequestStatus::WaitingForKadStream(*stream_id);
+                request_state.status = P2pNetworkKadRequestStatus::WaitingForKadStream(stream_id);
 
                 Ok(())
             }
@@ -197,9 +192,7 @@ impl P2pNetworkKadRequestState {
                     },
                     super::P2pNetworkKadRequestStatus::Request,
                 );
-                let peer_id = *peer_id;
-                let stream_id = *stream_id;
-                let addr = *addr;
+
                 let key = request_state.key;
 
                 let dispatcher = state_context.into_dispatcher();
@@ -230,7 +223,7 @@ impl P2pNetworkKadRequestState {
 
                 let bootstrap_request = state
                     .bootstrap_state()
-                    .and_then(|bootstrap_state| bootstrap_state.request(peer_id))
+                    .and_then(|bootstrap_state| bootstrap_state.request(&peer_id))
                     .is_some();
 
                 let closest_peers = bootstrap_request
@@ -241,7 +234,7 @@ impl P2pNetworkKadRequestState {
 
                 if bootstrap_request {
                     dispatcher.push(P2pNetworkKadBootstrapAction::RequestDone {
-                        peer_id: *peer_id,
+                        peer_id,
                         closest_peers,
                     });
                 }
@@ -263,10 +256,10 @@ impl P2pNetworkKadRequestState {
                         sock_addr: addr,
                         incoming: false,
                     },
-                    peer_id: *peer_id,
-                    stream_id: *stream_id,
+                    peer_id,
+                    stream_id,
                 });
-                dispatcher.push(P2pNetworkKadRequestAction::Prune { peer_id: *peer_id });
+                dispatcher.push(P2pNetworkKadRequestAction::Prune { peer_id });
                 Ok(())
             }
             P2pNetworkKadRequestAction::Prune { .. } => {
@@ -277,19 +270,16 @@ impl P2pNetworkKadRequestState {
                 request_state.status = P2pNetworkKadRequestStatus::Error(error.clone());
                 let bootstrap_request = state
                     .bootstrap_state()
-                    .and_then(|bootstrap_state| bootstrap_state.request(peer_id))
+                    .and_then(|bootstrap_state| bootstrap_state.request(&peer_id))
                     .is_some();
 
                 let dispatcher = state_context.into_dispatcher();
 
                 if bootstrap_request {
-                    dispatcher.push(P2pNetworkKadBootstrapAction::RequestError {
-                        peer_id: *peer_id,
-                        error: error.clone(),
-                    });
+                    dispatcher.push(P2pNetworkKadBootstrapAction::RequestError { peer_id, error });
                 }
 
-                dispatcher.push(P2pNetworkKadRequestAction::Prune { peer_id: *peer_id });
+                dispatcher.push(P2pNetworkKadRequestAction::Prune { peer_id });
                 Ok(())
             }
         }

--- a/p2p/src/network/p2p_network_reducer.rs
+++ b/p2p/src/network/p2p_network_reducer.rs
@@ -7,7 +7,7 @@ use super::*;
 impl P2pNetworkState {
     pub fn reducer<State, Action>(
         state_context: Substate<Action, State, Self>,
-        action: redux::ActionWithMeta<&P2pNetworkAction>,
+        action: redux::ActionWithMeta<P2pNetworkAction>,
         limits: &P2pLimits,
     ) -> Result<(), String>
     where

--- a/p2p/src/network/rpc/p2p_network_rpc_state.rs
+++ b/p2p/src/network/rpc/p2p_network_rpc_state.rs
@@ -85,7 +85,7 @@ impl RpcMessage {
                     .unwrap_or_default();
             }
             Self::Query { header, bytes } => {
-                MessageHeader::Query(header.clone())
+                MessageHeader::Query(header)
                     .binprot_write(&mut v)
                     .unwrap_or_default();
                 v.extend_from_slice(&bytes);

--- a/p2p/src/p2p_reducer.rs
+++ b/p2p/src/p2p_reducer.rs
@@ -17,7 +17,7 @@ use redux::{ActionMeta, ActionWithMeta, Dispatcher, Timestamp};
 impl P2pState {
     pub fn reducer<State, Action>(
         mut state_context: Substate<Action, State, Self>,
-        action: ActionWithMeta<&P2pAction>,
+        action: ActionWithMeta<P2pAction>,
     ) -> Result<(), String>
     where
         State: crate::P2pStateTrait,

--- a/p2p/src/p2p_state.rs
+++ b/p2p/src/p2p_state.rs
@@ -296,7 +296,7 @@ impl P2pState {
     pub fn peer_with_connection(
         &self,
         conn_id: crate::ConnectionAddr,
-    ) -> Option<(PeerId, P2pPeerState)> {
+    ) -> Option<(PeerId, &P2pPeerState)> {
         let result = if let crate::ConnectionAddr {
             sock_addr,
             incoming: false,
@@ -326,7 +326,7 @@ impl P2pState {
                             .and_then(|peer_id| self.peers.iter().find(|(id, _)| *id == peer_id))
                     })
             })
-            .map(|(peer_id, peer_state)| (*peer_id, peer_state.clone()))
+            .map(|(peer_id, peer_state)| (*peer_id, peer_state))
     }
 
     pub fn incoming_peer_connection_mut(

--- a/p2p/src/peer/p2p_peer_reducer.rs
+++ b/p2p/src/peer/p2p_peer_reducer.rs
@@ -9,7 +9,7 @@ impl P2pPeerState {
     /// Substate is accessed
     pub fn reducer<Action, State>(
         mut state_context: Substate<Action, State, P2pState>,
-        action: ActionWithMeta<&P2pPeerAction>,
+        action: ActionWithMeta<P2pPeerAction>,
     ) -> Result<(), String>
     where
         State: crate::P2pStateTrait,
@@ -23,10 +23,10 @@ impl P2pPeerState {
                 // TODO: add bound to peers
                 let peer_state = p2p_state
                     .peers
-                    .entry(*peer_id)
+                    .entry(peer_id)
                     .or_insert_with(|| P2pPeerState {
                         is_libp2p: true,
-                        dial_opts: dial_opts.clone(),
+                        dial_opts: None,
                         identify: None,
                         status: P2pPeerStatus::Disconnected {
                             time: Timestamp::ZERO,
@@ -34,16 +34,16 @@ impl P2pPeerState {
                     });
 
                 if let Some(dial_opts) = dial_opts {
-                    peer_state.dial_opts.get_or_insert(dial_opts.clone());
+                    let _ = peer_state.dial_opts.insert(dial_opts);
                 }
                 Ok(())
             }
             P2pPeerAction::Ready { peer_id, incoming } => {
-                let Some(peer) = p2p_state.peers.get_mut(peer_id) else {
+                let Some(peer) = p2p_state.peers.get_mut(&peer_id) else {
                     return Ok(());
                 };
                 peer.status = P2pPeerStatus::Ready(P2pPeerStatusReady::new(
-                    *incoming,
+                    incoming,
                     meta.time(),
                     &p2p_state.config.enabled_channels,
                 ));
@@ -51,13 +51,13 @@ impl P2pPeerState {
                 if !peer.is_libp2p {
                     let (dispatcher, state) = state_context.into_dispatcher_and_state();
                     let state: &P2pState = state.substate()?;
-                    state.channels_init(dispatcher, *peer_id);
+                    state.channels_init(dispatcher, peer_id);
                 }
 
                 Ok(())
             }
             P2pPeerAction::BestTipUpdate { peer_id, best_tip } => {
-                let Some(peer) = p2p_state.get_ready_peer_mut(peer_id) else {
+                let Some(peer) = p2p_state.get_ready_peer_mut(&peer_id) else {
                     bug_condition!("Peer state not found for `P2pPeerAction::BestTipUpdate`");
                     return Ok(());
                 };
@@ -67,12 +67,12 @@ impl P2pPeerState {
                 let p2p_state: &P2pState = state.substate()?;
 
                 if let Some(callback) = &p2p_state.callbacks.on_p2p_peer_best_tip_update {
-                    dispatcher.push_callback(callback.clone(), best_tip.clone());
+                    dispatcher.push_callback(callback.clone(), best_tip);
                 }
                 Ok(())
             }
             P2pPeerAction::Remove { peer_id } => {
-                if p2p_state.peers.remove(peer_id).is_none() {
+                if p2p_state.peers.remove(&peer_id).is_none() {
                     bug_condition!(
                         "Missing state for peer {peer_id} action: `P2pPeerAction::Remove`"
                     );

--- a/p2p/src/peer/p2p_peer_reducer.rs
+++ b/p2p/src/peer/p2p_peer_reducer.rs
@@ -34,7 +34,7 @@ impl P2pPeerState {
                     });
 
                 if let Some(dial_opts) = dial_opts {
-                    let _ = peer_state.dial_opts.insert(dial_opts);
+                    peer_state.dial_opts.get_or_insert(dial_opts);
                 }
                 Ok(())
             }

--- a/p2p/testing/src/cluster.rs
+++ b/p2p/testing/src/cluster.rs
@@ -391,7 +391,7 @@ impl Cluster {
                 let state_context = Substate::new(state, dispatcher);
                 let result = match action {
                     Action::P2p(action) => {
-                        P2pState::reducer(state_context, meta.with_action(action))
+                        P2pState::reducer(state_context, meta.with_action(action.clone()))
                     }
                     Action::Idle(_) => P2pState::p2p_timeout_dispatch(state_context, &meta),
                     Action::P2pEffectful(_) => Ok(()),

--- a/p2p/testing/src/cluster.rs
+++ b/p2p/testing/src/cluster.rs
@@ -367,6 +367,7 @@ impl Cluster {
 
     pub fn add_rust_node(&mut self, config: RustNodeConfig) -> Result<RustNodeId> {
         let override_fn = config.override_fn;
+        let reducer_override_fn = config.override_reducer;
         let node_idx = self.rust_nodes.len();
         let (event_sender, event_receiver) = mpsc::unbounded_channel();
         let (config, secret_key) = self.rust_node_config(config)?;
@@ -381,7 +382,7 @@ impl Cluster {
         );
 
         let store = crate::redux::Store::new(
-            |state, action, dispatcher| {
+            reducer_override_fn.unwrap_or(|state, action, dispatcher| {
                 let meta = action.meta().clone();
                 let action = action.action();
 
@@ -400,7 +401,7 @@ impl Cluster {
                 if let Err(error) = result {
                     openmina_core::warn!(time; "error = {error}");
                 }
-            },
+            }),
             override_fn.unwrap_or(|store, action| {
                 let (action, meta) = action.split();
                 match action {

--- a/p2p/testing/src/redux.rs
+++ b/p2p/testing/src/redux.rs
@@ -60,6 +60,9 @@ impl State {
     pub fn state(&self) -> &P2pState {
         &self.0
     }
+    pub fn state_mut(&mut self) -> &mut P2pState {
+        &mut self.0
+    }
 }
 
 impl EnablingCondition<State> for Action {

--- a/p2p/testing/src/rust_node.rs
+++ b/p2p/testing/src/rust_node.rs
@@ -6,7 +6,7 @@ use std::{
 
 use futures::Stream;
 use p2p::{P2pAction, P2pEvent, P2pLimits, P2pState, P2pTimeouts, PeerId};
-use redux::{Effects, EnablingCondition, SubStore};
+use redux::{Effects, EnablingCondition, Reducer, SubStore};
 use tokio::sync::mpsc;
 
 use crate::{
@@ -28,6 +28,7 @@ pub struct RustNodeConfig {
     pub limits: P2pLimits,
     pub discovery: bool,
     pub override_fn: Option<Effects<State, ClusterService, Action>>,
+    pub override_reducer: Option<Reducer<State, Action>>,
 }
 
 impl RustNodeConfig {
@@ -61,6 +62,11 @@ impl RustNodeConfig {
 
     pub fn with_override(mut self, override_fn: Effects<State, ClusterService, Action>) -> Self {
         self.override_fn = Some(override_fn);
+        self
+    }
+
+    pub fn with_override_reducer(mut self, override_fn: Reducer<State, Action>) -> Self {
+        self.override_reducer = Some(override_fn);
         self
     }
 }

--- a/p2p/tests/identify.rs
+++ b/p2p/tests/identify.rs
@@ -7,15 +7,15 @@ use multiaddr::{multiaddr, Multiaddr};
 use p2p::{
     identity::SecretKey,
     network::identify::{
-        stream::P2pNetworkIdentifyStreamState, P2pNetworkIdentify, P2pNetworkIdentifyAction,
-        P2pNetworkIdentifyStreamAction,
+        stream_effectful::P2pNetworkIdentifyStreamEffectfulAction, P2pNetworkIdentify,
+        P2pNetworkIdentifyEffectfulAction, P2pNetworkIdentifyStreamAction,
     },
     token::{self, DiscoveryAlgorithm},
-    Data, P2pAction, P2pNetworkAction, P2pNetworkYamuxAction, PeerId,
+    Data, P2pEffectfulAction, P2pNetworkEffectfulAction, P2pNetworkYamuxAction, PeerId,
 };
 use p2p_testing::{
     cluster::{Cluster, ClusterBuilder, ClusterEvent, Listener},
-    event::{event_mapper_effect, RustNodeEvent},
+    event::{allow_disconnections, event_mapper_effect, RustNodeEvent},
     futures::TryStreamExt,
     predicates::{async_fn, listener_is_ready, peer_is_connected},
     redux::{Action, State},
@@ -103,12 +103,12 @@ async fn rust_node_to_rust_node() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-#[ignore = "TODO: Add override for reducer"]
 /// Test that even if bad node spams many different listen_addrs we don't end up with duplicates
 async fn test_bad_node() -> anyhow::Result<()> {
     let mut cluster = ClusterBuilder::new()
         .ports_with_len(100)
         .idle_duration(Duration::from_millis(100))
+        .is_error(allow_disconnections)
         .start()
         .await?;
 
@@ -154,6 +154,9 @@ async fn test_bad_node() -> anyhow::Result<()> {
 
     let expected_addrs = [
         multiaddr!(Ip4([127, 0, 0, 1]), Tcp(bad_node_port)),
+        multiaddr!(Unix("domain.com")),
+        multiaddr!(Dns("domain.com"), Tcp(10530u16)),
+        multiaddr!(Https),
         multiaddr!(Ip4([127, 0, 0, 1]), Tcp(10500u16)),
         multiaddr!(Ip6([0; 16]), Tcp(10500u16)),
         multiaddr!(Ip6([1; 16]), Tcp(10500u16)),
@@ -171,103 +174,81 @@ fn bad_node_effects(
     action: ActionWithMeta<Action>,
 ) {
     {
-        let (action, _meta) = action.split();
+        let (action, meta) = action.split();
         match action {
             Action::P2p(a) => {
-                match a.clone() {
-                    P2pAction::Network(P2pNetworkAction::Identify(
-                        P2pNetworkIdentifyAction::Stream(P2pNetworkIdentifyStreamAction::New {
-                            addr,
-                            peer_id,
-                            stream_id,
-                            ..
-                        }),
-                    )) => {
-                        let state = store
-                            .state()
-                            .state()
-                            .network
-                            .scheduler
-                            .identify_state
-                            .find_identify_stream_state(&peer_id, &stream_id)
-                            .expect("Unable to find identify stream");
-
-                        if let P2pNetworkIdentifyStreamState::SendIdentify = state {
-                            let listen_addrs = vec![
-                                multiaddr!(Ip4([127, 0, 0, 1]), Tcp(10500u16)),
-                                multiaddr!(Ip4([127, 0, 0, 1]), Tcp(10500u16)),
-                                multiaddr!(Ip6([0; 16]), Tcp(10500u16)),
-                                multiaddr!(Ip6([0; 16]), Tcp(10500u16)),
-                                multiaddr!(Ip6([1; 16]), Tcp(10500u16)),
-                                multiaddr!(Ip6([1; 16]), Tcp(10500u16)),
-                                multiaddr!(Dns("domain.com"), Tcp(10530u16)),
-                                multiaddr!(Dns("domain.com"), Tcp(10530u16)),
-                                multiaddr!(Dns("domain.com"), Tcp(10530u16)),
-                                multiaddr!(Dns("domain.com"), Tcp(10530u16)),
-                                multiaddr!(Unix("domain.com")),
-                                multiaddr!(Https),
-                            ];
-
-                            let public_key = Some(SecretKey::rand().public_key());
-
-                            let protocols = vec![
-                                token::StreamKind::Identify(
-                                    token::IdentifyAlgorithm::Identify1_0_0,
-                                ),
-                                token::StreamKind::Broadcast(
-                                    p2p::token::BroadcastAlgorithm::Meshsub1_1_0,
-                                ),
-                                p2p::token::StreamKind::Rpc(token::RpcAlgorithm::Rpc0_0_1),
-                                p2p::token::StreamKind::Discovery(
-                                    DiscoveryAlgorithm::Kademlia1_0_0,
-                                ),
-                            ];
-
-                            let identify_msg = P2pNetworkIdentify {
-                                protocol_version: Some("ipfs/0.1.0".to_string()),
-                                agent_version: Some("openmina".to_owned()),
-                                public_key,
-                                listen_addrs,
-                                observed_addr: None,
-                                protocols,
-                            };
-
-                            let mut out = Vec::new();
-                            let identify_msg_proto =
-                                identify_msg.to_proto_message().expect("serialized message");
-
-                            prost::Message::encode_length_delimited(&identify_msg_proto, &mut out)
-                                .expect("Error converting message");
-
-                            store.dispatch(Action::P2p(
-                                P2pNetworkYamuxAction::OutgoingData {
-                                    addr,
-                                    stream_id,
-                                    data: Data(out.into_boxed_slice()),
-                                    flags: Default::default(),
-                                }
-                                .into(),
-                            ));
-
-                            store.dispatch(Action::P2p(
-                                P2pNetworkIdentifyStreamAction::Close {
-                                    addr,
-                                    peer_id,
-                                    stream_id,
-                                }
-                                .into(),
-                            ));
-                        }
-                    }
-                    _ => {
-                        // p2p_effects(store, meta.with_action(a.clone()));
-                    }
-                }
                 event_mapper_effect(store, a);
             }
-            Action::Idle(_) | Action::P2pEffectful(_) => {
-                // p2p_timeout_effects(store, &meta);
+            Action::P2pEffectful(P2pEffectfulAction::Network(
+                P2pNetworkEffectfulAction::Identify(P2pNetworkIdentifyEffectfulAction::Stream(
+                    P2pNetworkIdentifyStreamEffectfulAction::SendIdentify {
+                        addr,
+                        peer_id,
+                        stream_id,
+                    },
+                )),
+            )) => {
+                let listen_addrs = vec![
+                    multiaddr!(Ip4([127, 0, 0, 1]), Tcp(10500u16)),
+                    multiaddr!(Ip4([127, 0, 0, 1]), Tcp(10500u16)),
+                    multiaddr!(Ip6([0; 16]), Tcp(10500u16)),
+                    multiaddr!(Ip6([0; 16]), Tcp(10500u16)),
+                    multiaddr!(Ip6([1; 16]), Tcp(10500u16)),
+                    multiaddr!(Ip6([1; 16]), Tcp(10500u16)),
+                    multiaddr!(Dns("domain.com"), Tcp(10530u16)),
+                    multiaddr!(Dns("domain.com"), Tcp(10530u16)),
+                    multiaddr!(Dns("domain.com"), Tcp(10530u16)),
+                    multiaddr!(Dns("domain.com"), Tcp(10530u16)),
+                    multiaddr!(Unix("domain.com")),
+                    multiaddr!(Https),
+                ];
+
+                let public_key = Some(SecretKey::rand().public_key());
+
+                let protocols = vec![
+                    token::StreamKind::Identify(token::IdentifyAlgorithm::Identify1_0_0),
+                    token::StreamKind::Broadcast(p2p::token::BroadcastAlgorithm::Meshsub1_1_0),
+                    p2p::token::StreamKind::Rpc(token::RpcAlgorithm::Rpc0_0_1),
+                    p2p::token::StreamKind::Discovery(DiscoveryAlgorithm::Kademlia1_0_0),
+                ];
+
+                let identify_msg = P2pNetworkIdentify {
+                    protocol_version: Some("ipfs/0.1.0".to_string()),
+                    agent_version: Some("openmina".to_owned()),
+                    public_key,
+                    listen_addrs,
+                    observed_addr: None,
+                    protocols,
+                };
+
+                let mut out = Vec::new();
+                let identify_msg_proto =
+                    identify_msg.to_proto_message().expect("serialized message");
+
+                prost::Message::encode_length_delimited(&identify_msg_proto, &mut out)
+                    .expect("Error converting message");
+
+                store.dispatch(Action::P2p(
+                    P2pNetworkYamuxAction::OutgoingData {
+                        addr,
+                        stream_id,
+                        data: Data(out.into_boxed_slice()),
+                        flags: Default::default(),
+                    }
+                    .into(),
+                ));
+
+                store.dispatch(Action::P2p(
+                    P2pNetworkIdentifyStreamAction::Close {
+                        addr,
+                        peer_id,
+                        stream_id,
+                    }
+                    .into(),
+                ));
             }
+            Action::P2pEffectful(action) => action.effects(meta, store),
+            _ => {}
         };
     }
 }

--- a/p2p/tests/kademlia.rs
+++ b/p2p/tests/kademlia.rs
@@ -1,15 +1,16 @@
+use openmina_core::Substate;
 use p2p::{
     identity::SecretKey, P2pAction, P2pNetworkAction, P2pNetworkKadAction, P2pNetworkKadBucket,
-    P2pNetworkKademliaAction, P2pNetworkKademliaRpcReply, P2pNetworkKademliaStreamAction, PeerId,
+    P2pNetworkKademliaAction, P2pNetworkKademliaRpcReply, P2pNetworkKademliaStreamAction, P2pState,
+    PeerId,
 };
 use p2p_testing::{
     cluster::{Cluster, ClusterBuilder, ClusterEvent, Listener},
-    event::{allow_disconnections, event_mapper_effect, RustNodeEvent},
+    event::{allow_disconnections, RustNodeEvent},
     futures::{StreamExt, TryStreamExt},
     predicates::kad_finished_bootstrap,
     redux::{Action, State},
     rust_node::{RustNodeConfig, RustNodeId},
-    service::ClusterService,
     stream::ClusterStreamExt,
     test_node::TestNode,
     utils::{
@@ -17,7 +18,7 @@ use p2p_testing::{
         try_wait_for_nodes_to_listen,
     },
 };
-use redux::{ActionWithMeta, Store};
+use redux::{ActionWithMeta, Dispatcher};
 use std::{future::ready, net::Ipv4Addr, time::Duration};
 
 #[tokio::test]
@@ -311,7 +312,6 @@ async fn discovery_seed_multiple_peers() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-#[ignore = "TODO: Add override for reducer"]
 async fn test_bad_node() -> anyhow::Result<()> {
     std::env::set_var("OPENMINA_DISCOVERY_FILTER_ADDR", "false");
 
@@ -324,7 +324,7 @@ async fn test_bad_node() -> anyhow::Result<()> {
     let bad_node = cluster.add_rust_node(
         RustNodeConfig::default()
             .with_discovery(true)
-            .with_override(bad_node_effects),
+            .with_override_reducer(bad_node_reducer),
     )?;
 
     let node = cluster.add_rust_node(
@@ -352,57 +352,56 @@ async fn test_bad_node() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn bad_node_effects(
-    store: &mut Store<State, ClusterService, Action>,
-    action: ActionWithMeta<Action>,
+fn bad_node_reducer(
+    state: &mut State,
+    action: &ActionWithMeta<Action>,
+    dispatcher: &mut Dispatcher<Action, State>,
 ) {
     {
-        let (action, _meta) = action.split();
+        let meta = action.meta().clone();
+        let action = action.action();
+        let time = meta.time();
         match action {
-            Action::P2p(a) => {
-                match a.clone() {
-                    P2pAction::Network(P2pNetworkAction::Kad(P2pNetworkKadAction::System(
-                        P2pNetworkKademliaAction::AnswerFindNodeRequest {
-                            addr,
-                            peer_id,
-                            stream_id,
-                            ..
-                        },
-                    ))) => {
-                        let closer_peers = store
-                            .state
-                            .get()
-                            .state()
-                            .network
-                            .scheduler
-                            .discovery_state()
-                            .expect("Error getting discovery state")
-                            .routing_table
-                            .buckets
-                            .iter()
-                            .flat_map(|bucket| bucket.clone().into_iter())
-                            .collect();
+            Action::P2p(P2pAction::Network(P2pNetworkAction::Kad(
+                P2pNetworkKadAction::System(P2pNetworkKademliaAction::AnswerFindNodeRequest {
+                    addr,
+                    peer_id,
+                    stream_id,
+                    ..
+                }),
+            ))) => {
+                let closer_peers = state
+                    .state()
+                    .network
+                    .scheduler
+                    .discovery_state()
+                    .expect("Error getting discovery state")
+                    .routing_table
+                    .buckets
+                    .iter()
+                    .flat_map(|bucket| bucket.clone().into_iter())
+                    .collect();
 
-                        let message = P2pNetworkKademliaRpcReply::FindNode { closer_peers };
-                        store.dispatch(Action::P2p(
-                            P2pNetworkKademliaStreamAction::SendResponse {
-                                addr,
-                                peer_id,
-                                stream_id,
-                                data: message,
-                            }
-                            .into(),
-                        ));
+                let message = P2pNetworkKademliaRpcReply::FindNode { closer_peers };
+                dispatcher.push(Action::P2p(
+                    P2pNetworkKademliaStreamAction::SendResponse {
+                        addr: *addr,
+                        peer_id: *peer_id,
+                        stream_id: *stream_id,
+                        data: message,
                     }
-                    _ => {
-                        // p2p_effects(store, meta.with_action(a.clone()));
-                    }
+                    .into(),
+                ));
+            }
+            Action::P2p(action) => {
+                if let Err(error) = P2pState::reducer(
+                    Substate::new(state, dispatcher),
+                    meta.with_action(action.clone()),
+                ) {
+                    openmina_core::warn!(time; "error = {error}");
                 }
-                event_mapper_effect(store, a);
             }
-            Action::Idle(_) | Action::P2pEffectful(_) => {
-                // p2p_timeout_effects(store, &meta);
-            }
+            Action::Idle(_) | Action::P2pEffectful(_) => {}
         };
     }
 }


### PR DESCRIPTION
Update reducer to accept action instead of reference to action, this is to make p2p layer ready for full stateful vs effetcful split between actions.

The cloning of an action shouldn't impact the stack size, since the size of `P2pAction` is only 184 bytes. In most cases, it needs to be either fully or partially cloned to update the state and/or pass data to new actions.