### PR TITLE
Fix WebNode: initial_time + Instant::now() != current time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5577,7 +5577,7 @@ dependencies = [
 [[package]]
 name = "redux"
 version = "0.1.0"
-source = "git+https://github.com/openmina/redux-rs.git?rev=588dd76c#588dd76cb45bd8cc1a9ac5a67cfc22585b3fefae"
+source = "git+https://github.com/openmina/redux-rs.git?rev=75d4d1d9#75d4d1d927f9031f0656b7f56c4a3ec398da138f"
 dependencies = [
  "enum_dispatch",
  "linkme",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ poly-commitment = {git = "https://github.com/openmina/proof-systems", rev = "2fd
 libp2p = { git = "https://github.com/openmina/rust-libp2p", rev = "5c44c7d9", default-features = false }
 vrf = { path = "vrf" }
 openmina-node-account = { path = "node/account" }
-redux = { git = "https://github.com/openmina/redux-rs.git", rev = "588dd76c", features = ["serde"] }
+redux = { git = "https://github.com/openmina/redux-rs.git", rev = "75d4d1d9", features = ["serde"] }
 serde = "1.0.190"
 serde_json = "1.0.107"
 serde_with = { version = "3.7.0", features = ["hex"] }


### PR DESCRIPTION
When browser tab sleeps, performance::now() doesn't tick, causing this issue.
https://developer.mozilla.org/en-US/docs/Web/API/Performance/now#ticking_during_sleep
![image](https://github.com/user-attachments/assets/2cb5a84a-3016-4e4b-9a9e-b6c7fdb93f04)
