### PR TITLE
Correcting epoch progress

### DIFF
--- a/frontend/src/app/features/block-production/won-slots/cards/block-production-won-slots-cards.component.ts
+++ b/frontend/src/app/features/block-production/won-slots/cards/block-production-won-slots-cards.component.ts
@@ -40,7 +40,7 @@ export class BlockProductionWonSlotsCardsComponent extends StoreDispatcher imple
 
       const epochEndTime = this.addMinutesToTimestamp(epoch.currentTime / ONE_BILLION, (epoch.end - epoch.currentGlobalSlot) * 3);
       this.card5.endIn = getTimeDiff(epochEndTime * ONE_THOUSAND).diff;
-      this.card5.epochProgress = Math.floor(epoch.currentGlobalSlot / epoch.end * 100) + '%';
+      this.card5.epochProgress = Math.floor((epoch.currentGlobalSlot - epoch.start) / (epoch.end - epoch.start) * 100) + '%';
 
       this.detect();
     }, filter(Boolean));


### PR DESCRIPTION
![CleanShot 2024-10-24 at 09 10 19@2x](https://github.com/user-attachments/assets/b0cf4f65-0787-4cc8-b9cc-7d349b940f3c)

Currently, this stat doesn't show the progress of the current epoch. This fix displays the percentage of the current epoch completed.
