### PR TITLE
fix: Expose p2p port in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,8 @@ COPY --from=build /openmina/target/release/openmina /usr/local/bin/
 COPY --from=build /openmina/target/release/openmina-node-testing /usr/local/bin/
 RUN mkdir -p /usr/local/lib/openmina/circuit-blobs
 COPY --from=build /openmina/circuit-blobs/ /usr/local/lib/openmina/circuit-blobs/
+
+EXPOSE 3000
+EXPOSE 8302
+
 ENTRYPOINT [ "openmina" ]

--- a/docker-compose.block-producer.yml
+++ b/docker-compose.block-producer.yml
@@ -5,6 +5,7 @@ services:
       sh -c "openmina node --producer-key /root/.openmina/producer-key $${COINBASE_RECEIVER:+--coinbase-receiver $$COINBASE_RECEIVER}"
     ports:
       - "3000:3000"
+      - "8302:8302"
     volumes:
       - ./openmina-workdir:/root/.openmina:rw
     environment:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,6 +6,7 @@ services:
     command: [ "node" ]
     ports:
       - "3000:3000"
+      - "8302:8302"
     networks:
       - app-network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     command: [ "node" ]
     ports:
       - "3000:3000"
+      - "8302:8302"
 
   frontend:
     image: openmina/frontend:${OPENMINA_FRONTEND_TAG:-latest}


### PR DESCRIPTION
Exposing the p2p ports in the compose files so that they are visible from the outside.