### PR TITLE
Block Producer: start production earlier

### DIFF
--- a/node/src/block_producer/block_producer_actions.rs
+++ b/node/src/block_producer/block_producer_actions.rs
@@ -61,7 +61,6 @@ pub enum BlockProducerAction {
         proof: Box<MinaBaseProofStableV2>,
     },
     BlockProduced,
-    #[action_event(level = trace)]
     BlockInject,
     BlockInjected,
 }

--- a/node/src/consensus/consensus_actions.rs
+++ b/node/src/consensus/consensus_actions.rs
@@ -161,7 +161,7 @@ impl redux::EnablingCondition<crate::State> for ConsensusAction {
                     state.transition_frontier.sync.best_tip(),
                 ])
                 .flatten()
-                .all(|b| b.hash() == best_tip.hash()
+                .any(|b| b.hash() == best_tip.hash()
                     || !consensus_take(b.consensus_state(), best_tip.consensus_state(), b.hash(), best_tip.hash())) {
                     return false;
                 }

--- a/node/src/snark_pool/candidate/snark_pool_candidate_actions.rs
+++ b/node/src/snark_pool/candidate/snark_pool_candidate_actions.rs
@@ -20,6 +20,7 @@ pub enum SnarkPoolCandidateAction {
         peer_id: PeerId,
         info: SnarkInfo,
     },
+    #[action_event(level = trace)]
     WorkFetchAll,
     WorkFetchInit {
         peer_id: PeerId,
@@ -34,6 +35,7 @@ pub enum SnarkPoolCandidateAction {
         peer_id: PeerId,
         work: Snark,
     },
+    #[action_event(level = trace)]
     WorkVerifyNext,
     WorkVerifyPending {
         peer_id: PeerId,

--- a/node/src/snark_pool/snark_pool_actions.rs
+++ b/node/src/snark_pool/snark_pool_actions.rs
@@ -36,6 +36,7 @@ pub enum SnarkPoolAction {
         snark: Snark,
         sender: PeerId,
     },
+    #[action_event(level = trace)]
     P2pSendAll,
     P2pSend {
         peer_id: PeerId,
@@ -78,6 +79,8 @@ impl redux::EnablingCondition<crate::State> for SnarkPoolAction {
             SnarkPoolAction::P2pSend { peer_id } => state
                 .p2p
                 .get_ready_peer(peer_id)
+                // can't propagate empty snarkpool
+                .filter(|_| !state.snark_pool.is_empty())
                 // Only send commitments/snarks if peer has the same best tip,
                 // or its best tip is extension of our best tip. In such case
                 // no commitment/snark will be dropped by peer, because it

--- a/node/src/snark_pool/snark_pool_state.rs
+++ b/node/src/snark_pool/snark_pool_state.rs
@@ -71,6 +71,10 @@ impl SnarkPoolState {
         }
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.list.is_empty()
+    }
+
     pub fn last_index(&self) -> u64 {
         self.list.last_key_value().map_or(0, |(k, _)| *k)
     }


### PR DESCRIPTION
Start producing block earlier, especially for the webnode where proof generation is slower for now.