### PR TITLE
fix(vrf-evaluator): Handle cases where the delegator table is empty

### DIFF
--- a/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_reducer.rs
+++ b/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_reducer.rs
@@ -304,6 +304,12 @@ impl BlockProducerVrfEvaluatorState {
                     return;
                 };
 
+                openmina_core::log::warn!(
+                    meta.time();
+                    kind = "BlockProducerVrfEvaluatorAction::FinalizeDelegatorTableConstruction",
+                    message = "Empty delegator table, account may not exist yet in the staking ledger"
+                );
+
                 let mut staking_epoch_data = staking_epoch_data.clone();
                 staking_epoch_data.delegator_table = delegator_table.clone();
 

--- a/node/src/ledger/ledger_effects.rs
+++ b/node/src/ledger/ledger_effects.rs
@@ -417,7 +417,16 @@ fn propagate_read_response<S: redux::Service>(
                 return;
             }
             match table {
-                None => todo!("delegator table construction error handling"),
+                None => {
+                    // TODO(tizoc): Revise this, may be better to dispatch a different action here
+                    // and avoid running the VRF evaluator altogether when we know that the
+                    // table is empty.
+                    store.dispatch(
+                        BlockProducerVrfEvaluatorAction::FinalizeDelegatorTableConstruction {
+                            delegator_table: Default::default(),
+                        },
+                    );
+                }
                 Some(table) => {
                     store.dispatch(
                         BlockProducerVrfEvaluatorAction::FinalizeDelegatorTableConstruction {


### PR DESCRIPTION
This happens with producer accounts that are too new and haven't made it to the staking ledger yet.