### PR TITLE
fix(rpc): Replace `next_won_slot` in `/status` with `current_block_production_attempt`

### DIFF
--- a/node/src/rpc/mod.rs
+++ b/node/src/rpc/mod.rs
@@ -453,7 +453,7 @@ pub struct RpcNodeStatus {
     pub peers: Vec<RpcPeerInfo>,
     pub snark_pool: RpcNodeStatusSnarkPool,
     pub transaction_pool: RpcNodeStatusTransactionPool,
-    pub next_won_slot: Option<BlockProductionAttemptWonSlot>,
+    pub current_block_production_attempt: Option<BlockProductionAttempt>,
 }
 
 #[derive(Serialize, Debug, Clone)]


### PR DESCRIPTION
Using the data from the stats instead.