### PR TITLE
fix(transition-frontier): Skip verification of completed works in locally produced blocks

### DIFF
--- a/node/src/stats/stats_block_producer.rs
+++ b/node/src/stats/stats_block_producer.rs
@@ -261,12 +261,7 @@ impl BlockProducerStats {
     }
 
     pub fn block_apply_start(&mut self, time: redux::Timestamp, hash: &BlockHash) {
-        let is_our_block = self
-            .attempts
-            .back()
-            .and_then(|v| v.block.as_ref())
-            .map_or(false, |b| &b.hash == hash);
-        if !is_our_block {
+        if !self.is_our_block(hash) {
             return;
         }
 
@@ -318,6 +313,13 @@ impl BlockProducerStats {
             attempt.times.discarded = Some(time);
             true
         });
+    }
+
+    pub fn is_our_block(&self, hash: &BlockHash) -> bool {
+        self.attempts
+            .back()
+            .and_then(|v| v.block.as_ref())
+            .map_or(false, |b| &b.hash == hash)
     }
 }
 

--- a/node/src/transition_frontier/sync/transition_frontier_sync_effects.rs
+++ b/node/src/transition_frontier/sync/transition_frontier_sync_effects.rs
@@ -249,6 +249,7 @@ impl TransitionFrontierSyncAction {
 
                 // During catchup, we skip the verificationf of completed work and zkApp txn proofs
                 // until get closer to the best tip, at which point full verification is enabled.
+                // TODO(tizoc): locally produced blocks shouldn't be verified either
                 let skip_verification = super::CATCHUP_BLOCK_VERIFY_TAIL_LENGTH
                     < store.state().transition_frontier.sync.pending_count();
 

--- a/node/src/transition_frontier/sync/transition_frontier_sync_effects.rs
+++ b/node/src/transition_frontier/sync/transition_frontier_sync_effects.rs
@@ -253,7 +253,7 @@ impl TransitionFrontierSyncAction {
                     stats.block_producer().block_apply_start(meta.time(), &hash);
                     // TODO(tizoc): try a better approach that doesn't need
                     // to make use of the collected stats.
-                    is_our_block = stats.block_producer().is_our_block(&hash);
+                    is_our_block = stats.block_producer().is_our_just_produced_block(&hash);
                 } else {
                     is_our_block = false;
                 }


### PR DESCRIPTION
Also add `bug_condition!` calls in the block producer.