### PR TITLE
Fix WebRTC: snark pool propagation

### DIFF
--- a/cli/replay_dynamic_effects/src/lib.rs
+++ b/cli/replay_dynamic_effects/src/lib.rs
@@ -1,5 +1,5 @@
 use ::node::{ActionWithMeta, Store};
-use openmina_node_invariants::{InvariantResult, Invariants};
+use openmina_node_invariants::{InvariantIgnoreReason, InvariantResult, Invariants};
 use openmina_node_native::NodeService;
 
 pub mod ret {
@@ -33,6 +33,8 @@ extern "C" fn replay_dynamic_effects(
 ) -> u8 {
     for (invariant, res) in Invariants::check_all(store, action) {
         match res {
+            InvariantResult::Ignored(InvariantIgnoreReason::GlobalInvariantNotInTestingCluster) => {
+            }
             InvariantResult::Violation(violation) => {
                 eprintln!(
                     "Invariant({}) violated! violation: {violation}",

--- a/core/src/invariants.rs
+++ b/core/src/invariants.rs
@@ -1,7 +1,22 @@
 use std::any::Any;
 
 pub trait InvariantService: redux::Service {
+    type ClusterInvariantsState<'a>: 'a + std::ops::DerefMut<Target = InvariantsState>
+    where
+        Self: 'a;
+
+    fn node_id(&self) -> usize {
+        0
+    }
+
     fn invariants_state(&mut self) -> &mut InvariantsState;
+
+    fn cluster_invariants_state<'a>(&'a mut self) -> Option<Self::ClusterInvariantsState<'a>>
+    where
+        Self: 'a,
+    {
+        None
+    }
 }
 
 #[derive(Default)]

--- a/node/common/src/service/service.rs
+++ b/node/common/src/service/service.rs
@@ -181,7 +181,9 @@ impl node::service::TransitionFrontierGenesisService for NodeService {
 }
 
 impl node::core::invariants::InvariantService for NodeService {
-    fn invariants_state(&mut self) -> &mut node::core::invariants::InvariantsState {
+    type ClusterInvariantsState<'a> = std::cell::RefMut<'a, InvariantsState>;
+
+    fn invariants_state(&mut self) -> &mut InvariantsState {
         &mut self.invariants_state
     }
 }

--- a/node/invariants/src/invariant_result.rs
+++ b/node/invariants/src/invariant_result.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum InvariantResult {
+    Ignored(InvariantIgnoreReason),
     /// Invariant check was triggered but as a result we didn't do any
     /// checks, instead internal state of invariant might have been updated.
     Updated,
@@ -9,4 +10,9 @@ pub enum InvariantResult {
     Violation(String),
     /// Invariant check was done and it passed.
     Ok,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum InvariantIgnoreReason {
+    GlobalInvariantNotInTestingCluster,
 }

--- a/node/testing/src/cluster/mod.rs
+++ b/node/testing/src/cluster/mod.rs
@@ -11,6 +11,7 @@ pub mod runner;
 use std::collections::BTreeMap;
 use std::io::Read;
 use std::path::{Path, PathBuf};
+use std::sync::Mutex as StdMutex;
 use std::time::Duration;
 use std::{collections::VecDeque, sync::Arc};
 
@@ -21,6 +22,7 @@ use node::account::{AccountPublicKey, AccountSecretKey};
 use node::core::channels::mpsc;
 use node::core::consensus::ConsensusConstants;
 use node::core::constants::constraint_constants;
+use node::core::invariants::InvariantsState;
 use node::core::log::system_time;
 use node::core::requests::RpcId;
 use node::core::{thread, warn};
@@ -134,6 +136,7 @@ pub struct Cluster {
     work_verifier_index: TransactionVerifier,
 
     debugger: Option<Debugger>,
+    invariants_state: Arc<StdMutex<InvariantsState>>,
 }
 
 #[derive(Serialize)]
@@ -174,6 +177,7 @@ impl Cluster {
             work_verifier_index: TransactionVerifier::make(),
 
             debugger,
+            invariants_state: Arc::new(StdMutex::new(Default::default())),
         }
     }
 
@@ -342,7 +346,9 @@ impl Cluster {
             })
             .unwrap();
 
-        let mut service = NodeTestingService::new(real_service, node_id, shutdown_rx);
+        let invariants_state = self.invariants_state.clone();
+        let mut service =
+            NodeTestingService::new(real_service, node_id, invariants_state, shutdown_rx);
 
         service.set_proof_kind(self.config.proof_kind());
         if self.config.all_rust_to_rust_use_webrtc() {
@@ -365,6 +371,9 @@ impl Cluster {
             for (invariant, res) in Invariants::check_all(store, &action) {
                 // TODO(binier): record instead of panicing.
                 match res {
+                    InvariantResult::Ignored(reason) => {
+                        unreachable!("No invariant should be ignored! ignore reason: {reason:?}");
+                    }
                     InvariantResult::Violation(violation) => {
                         panic!(
                             "Invariant({}) violated! violation: {violation}",

--- a/node/testing/src/service/mod.rs
+++ b/node/testing/src/service/mod.rs
@@ -1,6 +1,7 @@
 mod rpc_service;
 
 use std::collections::VecDeque;
+use std::sync::Mutex as StdMutex;
 use std::time::Duration;
 use std::{collections::BTreeMap, sync::Arc};
 
@@ -20,6 +21,7 @@ use node::account::AccountPublicKey;
 use node::block_producer::vrf_evaluator::VrfEvaluatorInput;
 use node::block_producer::BlockProducerEvent;
 use node::core::channels::mpsc;
+use node::core::invariants::InvariantsState;
 use node::core::snark::{Snark, SnarkJobId};
 use node::external_snark_worker_effectful::ExternalSnarkWorkerEvent;
 use node::p2p::service_impl::webrtc_with_libp2p::P2pServiceWebrtcWithLibp2p;
@@ -134,12 +136,19 @@ pub struct NodeTestingService {
     dyn_effects: Option<DynEffects>,
 
     snarker_sok_digest: Option<ByteString>,
+
+    cluster_invariants_state: Arc<StdMutex<InvariantsState>>,
     /// Once dropped, it will cause all threads associated to shutdown.
     _shutdown: mpsc::Receiver<()>,
 }
 
 impl NodeTestingService {
-    pub fn new(real: NodeService, id: ClusterNodeId, _shutdown: mpsc::Receiver<()>) -> Self {
+    pub fn new(
+        real: NodeService,
+        id: ClusterNodeId,
+        cluster_invariants_state: Arc<StdMutex<InvariantsState>>,
+        _shutdown: mpsc::Receiver<()>,
+    ) -> Self {
         Self {
             real,
             id,
@@ -150,6 +159,7 @@ impl NodeTestingService {
             pending_events: PendingEvents::new(),
             dyn_effects: None,
             snarker_sok_digest: None,
+            cluster_invariants_state,
             _shutdown,
         }
     }
@@ -643,7 +653,24 @@ impl ExternalSnarkWorkerService for NodeTestingService {
 }
 
 impl node::core::invariants::InvariantService for NodeTestingService {
-    fn invariants_state(&mut self) -> &mut openmina_core::invariants::InvariantsState {
+    type ClusterInvariantsState<'a> = std::sync::MutexGuard<'a, InvariantsState>;
+
+    fn node_id(&self) -> usize {
+        self.node_id().index()
+    }
+
+    fn invariants_state(&mut self) -> &mut InvariantsState {
         node::core::invariants::InvariantService::invariants_state(&mut self.real)
+    }
+
+    fn cluster_invariants_state<'a>(&'a mut self) -> Option<Self::ClusterInvariantsState<'a>>
+    where
+        Self: 'a,
+    {
+        Some(
+            self.cluster_invariants_state.try_lock().expect(
+                "locking should never fail, since we are running all nodes in the same thread",
+            ),
+        )
     }
 }

--- a/p2p/src/channels/snark/p2p_channels_snark_actions.rs
+++ b/p2p/src/channels/snark/p2p_channels_snark_actions.rs
@@ -20,10 +20,12 @@ pub enum P2pChannelsSnarkAction {
     Ready {
         peer_id: PeerId,
     },
+    #[action_event(level = debug, fields(display(peer_id), limit))]
     RequestSend {
         peer_id: PeerId,
         limit: u8,
     },
+    #[action_event(level = debug, fields(display(peer_id), promised_count))]
     PromiseReceived {
         peer_id: PeerId,
         promised_count: u8,
@@ -32,10 +34,12 @@ pub enum P2pChannelsSnarkAction {
         peer_id: PeerId,
         snark: Box<SnarkInfo>,
     },
+    #[action_event(level = debug, fields(display(peer_id), limit))]
     RequestReceived {
         peer_id: PeerId,
         limit: u8,
     },
+    #[action_event(level = debug, fields(display(peer_id), snarks = snarks.len(), first_index, last_index))]
     ResponseSend {
         peer_id: PeerId,
         snarks: Vec<SnarkInfo>,
@@ -144,7 +148,7 @@ impl redux::EnablingCondition<P2pState> for P2pChannelsSnarkAction {
                 last_index,
             } => {
                 !snarks.is_empty()
-                    && first_index < last_index
+                    && first_index <= last_index
                     && state
                         .get_ready_peer(peer_id)
                         .map_or(false, |p| match &p.channels.snark {


### PR DESCRIPTION
With protocol built on top of WebRTC, nodes should be able to have their snark pools in sync with each other, but that wasn't a case because of the bug fixed by this pr.