### PR TITLE
Fix epoch number in BeginEpochEvaluation action

### DIFF
--- a/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_actions.rs
+++ b/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_actions.rs
@@ -86,11 +86,12 @@ pub enum BlockProducerVrfEvaluatorAction {
         next_epoch_first_slot: u32,
     },
     /// Starting epoch evaluation.
-    #[action_event(level = info, fields(best_tip_epoch, best_tip_slot, best_tip_global_slot))]
+    #[action_event(level = info, fields(evaluation_epoch, best_tip_epoch, best_tip_slot, best_tip_global_slot))]
     BeginEpochEvaluation {
         best_tip_slot: u32,
         best_tip_global_slot: u32,
         best_tip_epoch: u32,
+        evaluation_epoch: u32,
         staking_epoch_data: EpochData,
         latest_evaluated_global_slot: u32,
     },

--- a/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_reducer.rs
+++ b/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_reducer.rs
@@ -364,14 +364,15 @@ impl BlockProducerVrfEvaluatorState {
                 });
             }
             BlockProducerVrfEvaluatorAction::BeginEpochEvaluation {
-                best_tip_epoch,
+                best_tip_epoch: _,
+                evaluation_epoch,
                 latest_evaluated_global_slot,
                 staking_epoch_data,
                 best_tip_slot: _,
                 best_tip_global_slot: _,
             } => {
                 let latest_evaluated_global_slot = *latest_evaluated_global_slot;
-                let epoch_number = *best_tip_epoch;
+                let epoch_number = *evaluation_epoch;
 
                 state.set_pending_evaluation(PendingEvaluation {
                     epoch_number,
@@ -470,6 +471,7 @@ impl BlockProducerVrfEvaluatorState {
                         best_tip_epoch: *best_tip_epoch,
                         best_tip_global_slot: *current_best_tip_global_slot,
                         best_tip_slot: *current_best_tip_slot,
+                        evaluation_epoch: epoch_number,
                         staking_epoch_data: staking_epoch_data.clone(),
                         latest_evaluated_global_slot: initial_slot,
                     });


### PR DESCRIPTION
The best tip's epoch number was passed to the stats. This caused the wrong counter to increment resulting in more evaluated slots for the current_epoch than max_slots