### PR TITLE
Fix: get rid of dynamic threads

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -191,7 +191,7 @@ jobs:
          rustup default nightly
          rustup component add rustfmt rust-src
          rustup target add wasm32-unknown-unknown
-         cargo install -f wasm-bindgen-cli --version 0.2.95
+         cargo install -f wasm-bindgen-cli --version 0.2.99
 
      - name: Setup Rust Cache
        uses: Swatinem/rust-cache@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3087,10 +3087,11 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.72"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -8149,9 +8150,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -8160,13 +8161,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn 2.0.58",
@@ -8175,21 +8175,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.43"
+version = "0.4.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
 dependencies = [
  "cfg-if",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8197,9 +8198,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8210,9 +8211,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.95"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
 
 [[package]]
 name = "wasm-bindgen-test"
@@ -8266,9 +8267,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.72"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -38,8 +38,8 @@ ark-ff = { workspace = true }
 redux = { workspace = true, features=["serializable_callbacks"] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-wasm-bindgen = "0.2"
-wasm-bindgen-futures = "0.4"
+wasm-bindgen = "0.2.99"
+wasm-bindgen-futures = "0.4.49"
 wasm_thread = { version = "0.3", features = [ "es_modules" ] }
 js-sys = "0.3"
 web-sys = { version = "0.3", features = ["Window", "Response"] }

--- a/node/common/Cargo.toml
+++ b/node/common/Cargo.toml
@@ -26,7 +26,7 @@ openmina-core = { path = "../../core" }
 [target.'cfg(target_family = "wasm")'.dependencies]
 redux = { workspace = true }
 wasm-bindgen = "0.2"
-wasm-bindgen-futures = "0.4.42"
+wasm-bindgen-futures = "0.4"
 gloo-timers = { version = "0.3", features = ["futures"] }
 gloo-utils = "0.2"
 tracing-wasm = "0.2"

--- a/node/common/src/service/builder.rs
+++ b/node/common/src/service/builder.rs
@@ -125,8 +125,11 @@ impl NodeServiceCommonBuilder {
                 .chain(b"static")
                 .finalize_xof(),
             rng: self.rng,
-            event_sender: self.event_sender,
+            event_sender: self.event_sender.clone(),
             event_receiver: self.event_receiver,
+            snark_block_proof_verify: NodeService::snark_block_proof_verifier_spawn(
+                self.event_sender,
+            ),
             ledger_manager,
             block_producer: self.block_producer,
             p2p,

--- a/node/common/src/service/service.rs
+++ b/node/common/src/service/service.rs
@@ -22,6 +22,7 @@ use super::{
     p2p::webrtc_with_libp2p::P2pServiceCtx,
     replay::ReplayerState,
     rpc::{RpcSender, RpcService},
+    snarks::SnarkBlockVerifyArgs,
     EventReceiver, EventSender,
 };
 
@@ -35,6 +36,8 @@ pub struct NodeService {
     /// `event_source` state machine defined in the `openmina-node` crate.
     pub event_sender: EventSender,
     pub event_receiver: EventReceiver,
+
+    pub snark_block_proof_verify: mpsc::UnboundedSender<SnarkBlockVerifyArgs>,
 
     pub ledger_manager: LedgerManager,
     pub block_producer: Option<BlockProducerService>,
@@ -105,6 +108,7 @@ impl NodeService {
             rng: StdRng::from_seed(rng_seed),
             event_sender: mpsc::unbounded_channel().0,
             event_receiver: mpsc::unbounded_channel().1.into(),
+            snark_block_proof_verify: mpsc::unbounded_channel().0,
             ledger_manager: LedgerManager::spawn(Default::default()),
             block_producer: None,
             p2p: P2pServiceCtx::mocked(p2p_sec_key),

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -77,7 +77,7 @@ local-ip-address = "0.6.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"
-wasm-bindgen-futures = "0.4.42"
+wasm-bindgen-futures = "0.4"
 gloo-timers = { version = "0.3", features = ["futures"] }
 gloo-utils = "0.2"
 js-sys = "0.3.64"


### PR DESCRIPTION
By dynamic threads I mean threads that are spawned after the initial startup of the node. After this change, number of threads will stay constant for the node.

fixes: #991 