### PR TITLE
fix(vrf): Don't use parallelism when computing won slots

### DIFF
--- a/node/common/src/service/block_producer/vrf_evaluator.rs
+++ b/node/common/src/service/block_producer/vrf_evaluator.rs
@@ -8,7 +8,6 @@ use node::{
     core::channels::mpsc::{UnboundedReceiver, UnboundedSender},
     event_source::Event,
 };
-use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use vrf::{VrfEvaluationInput, VrfEvaluationOutput};
 
 use crate::NodeService;
@@ -32,8 +31,8 @@ pub fn vrf_evaluator(
         } = &vrf_evaluator_input;
 
         let vrf_result = delegator_table
-            .par_iter()
-            .find_map_any(|(index, (pub_key, stake))| {
+            .iter()
+            .find_map(|(index, (pub_key, stake))| {
                 let vrf_input = VrfEvaluationInput {
                     producer_key: keypair.clone(),
                     global_slot: *global_slot,
@@ -109,7 +108,7 @@ mod tests {
         let now = std::time::Instant::now();
 
         let vrf_result = delegator_table
-            .par_iter()
+            .iter()
             .map(|(index, (pub_key, stake))| {
                 let vrf_input = VrfEvaluationInput {
                     producer_key: keypair.clone(),


### PR DESCRIPTION
We may end up stealing resources from other parts of the system that are of higher priority. But even more important, the parallel version is non-deterministic and may return different delegators each time.