### PR TITLE
fix: typos in documentation files

### DIFF
--- a/core/src/log.rs
+++ b/core/src/log.rs
@@ -1,4 +1,4 @@
-/// Must only be used in logging and even there it's not prefferable.
+/// Must only be used in logging and even there it's not preferable.
 ///
 /// This **MUST** only be used in places which doesn't have access to any
 /// of the following: `redux::Store`, global state where time is stored,

--- a/ledger/src/proofs/zkapp.rs
+++ b/ledger/src/proofs/zkapp.rs
@@ -217,7 +217,7 @@ pub mod group {
                 new_list
             }
 
-            // I don't take responsability for this code, see OCaml comments
+            // I don't take responsibility for this code, see OCaml comments
             // https://github.com/MinaProtocol/mina/blob/78535ae3a73e0e90c5f66155365a934a15535779/src/lib/mina_base/zkapp_command.ml#L1590
             match (zkapp_commands, stmtss) {
                 ([] | [[]], [ _ ]) => {

--- a/ledger/src/zkapps/intefaces.rs
+++ b/ledger/src/zkapps/intefaces.rs
@@ -554,7 +554,7 @@ where
 /// - During witness generation (in-snark), we want to evaluate both branches
 ///   when there is a condition (`on_if`)
 /// - But during tx application (non-snark), we just want to evaluate 1 branch.
-///   Evaluating both branches in that case would be a waste of cpu/ressource
+///   Evaluating both branches in that case would be a waste of cpu/resource
 ///   and would result in a slower application
 ///
 /// Note that in `zkapp_logic::apply`, we don't always use that interface, we


### PR DESCRIPTION
Corrected `prefferable` to `preferable`
Corrected `responsability` to `responsibility`
Corrected `ressource` to `resource`