### PR TITLE
Refactor window size update to prevent underflow in stream

### DIFF
--- a/p2p/src/network/yamux/p2p_network_yamux_reducer.rs
+++ b/p2p/src/network/yamux/p2p_network_yamux_reducer.rs
@@ -216,7 +216,8 @@ impl P2pNetworkYamuxState {
                         if let Some(stream) = yamux_state.streams.get_mut(&frame.stream_id) {
                             // must not underflow
                             // TODO: check it and disconnect peer that violates flow rules
-                            stream.window_ours = stream.window_ours.wrapping_sub(data.len() as u32);
+                            stream.window_ours =
+                                stream.window_ours.saturating_sub(data.len() as u32);
                         }
                     }
                     YamuxFrameInner::WindowUpdate { difference } => {

--- a/p2p/src/service_impl/mio/mod.rs
+++ b/p2p/src/service_impl/mio/mod.rs
@@ -484,6 +484,11 @@ where
                     if limit > self.recv_buf.len() {
                         // TODO: upper bound? resize to `limit` or try to allocate some extra space too?
                         self.recv_buf.resize(limit, 0);
+
+                        openmina_core::warn!(
+                            openmina_core::log::system_time();
+                            summary = format!("Increasing buffer size to {}kb", limit / 1024)
+                        );
                     }
 
                     let mut keep = false;


### PR DESCRIPTION
Refactor window size update to use `saturating_sub` instead of `wrapping_sub`