### PR TITLE
Refactor: Transfer consensus state machine as transition frontier candidates state machine

### DIFF
--- a/node/common/src/service/rpc/mod.rs
+++ b/node/common/src/service/rpc/mod.rs
@@ -168,7 +168,6 @@ fn optimize_filtered_state(
         config
             | p2p
             | snark
-            | consensus
             | transition_frontier
             | snark_pool
             | external_snark_worker

--- a/node/src/action.rs
+++ b/node/src/action.rs
@@ -6,7 +6,6 @@ pub type ActionWithMetaRef<'a> = redux::ActionWithMeta<&'a Action>;
 
 pub use crate::block_producer::BlockProducerAction;
 pub use crate::block_producer_effectful::BlockProducerEffectfulAction;
-pub use crate::consensus::ConsensusAction;
 pub use crate::event_source::EventSourceAction;
 pub use crate::external_snark_worker::ExternalSnarkWorkerAction;
 use crate::external_snark_worker_effectful::ExternalSnarkWorkerEffectfulAction;
@@ -44,7 +43,6 @@ pub enum Action {
     Ledger(LedgerAction),
     LedgerEffects(LedgerEffectfulAction),
     Snark(SnarkAction),
-    Consensus(ConsensusAction),
     TransitionFrontier(TransitionFrontierAction),
     SnarkPool(SnarkPoolAction),
     SnarkPoolEffect(SnarkPoolEffectfulAction),
@@ -93,7 +91,6 @@ impl redux::EnablingCondition<crate::State> for Action {
             Action::Ledger(a) => a.is_enabled(state, time),
             Action::LedgerEffects(a) => a.is_enabled(state, time),
             Action::Snark(a) => a.is_enabled(&state.snark, time),
-            Action::Consensus(a) => a.is_enabled(state, time),
             Action::TransitionFrontier(a) => a.is_enabled(state, time),
             Action::SnarkPool(a) => a.is_enabled(state, time),
             Action::SnarkPoolEffect(a) => a.is_enabled(state, time),

--- a/node/src/consensus/mod.rs
+++ b/node/src/consensus/mod.rs
@@ -1,8 +1,0 @@
-mod consensus_state;
-pub use consensus_state::*;
-
-mod consensus_actions;
-pub use consensus_actions::*;
-
-mod consensus_reducer;
-pub use consensus_reducer::allow_block_too_late;

--- a/node/src/effects.rs
+++ b/node/src/effects.rs
@@ -100,7 +100,6 @@ pub fn effects<S: Service>(store: &mut Store<S>, action: ActionWithMeta) {
         | Action::SnarkPool(_)
         | Action::ExternalSnarkWorker(_)
         | Action::TransactionPool(_)
-        | Action::Consensus(_)
         | Action::Ledger(_)
         | Action::Rpc(_)
         | Action::WatchedAccounts(_)
@@ -114,14 +113,18 @@ pub fn effects<S: Service>(store: &mut Store<S>, action: ActionWithMeta) {
 fn p2p_request_best_tip_if_needed<S: Service>(store: &mut Store<S>) {
     // TODO(binier): refactor
     let state = store.state();
-    let consensus_best_tip_hash = state.consensus.best_tip.as_ref();
+    let consensus_best_tip_hash = state.transition_frontier.candidates.best_tip.as_ref();
     let best_tip_hash = state.transition_frontier.best_tip().map(|v| &v.hash);
     let syncing_best_tip_hash = state.transition_frontier.sync.best_tip().map(|v| &v.hash);
 
     if consensus_best_tip_hash.is_some()
         && consensus_best_tip_hash != best_tip_hash
         && consensus_best_tip_hash != syncing_best_tip_hash
-        && state.consensus.best_tip_chain_proof.is_none()
+        && state
+            .transition_frontier
+            .candidates
+            .best_tip_chain_proof
+            .is_none()
     {
         request_best_tip(store, consensus_best_tip_hash.cloned());
     }

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -34,7 +34,6 @@ pub mod stats;
 
 pub mod block_producer;
 pub mod block_producer_effectful;
-pub mod consensus;
 pub mod daemon_json;
 pub mod event_source;
 pub mod external_snark_worker;

--- a/node/src/logger/logger_effects.rs
+++ b/node/src/logger/logger_effects.rs
@@ -118,7 +118,6 @@ pub fn logger_effects<S: Service>(store: &Store<S>, action: ActionWithMetaRef<'_
         Action::SnarkPool(action) => action.action_event(&context),
         Action::Snark(SnarkAction::WorkVerify(a)) => a.action_event(&context),
         Action::Snark(SnarkAction::UserCommandVerify(a)) => a.action_event(&context),
-        Action::Consensus(a) => a.action_event(&context),
         Action::TransitionFrontier(a) => match a {
             TransitionFrontierAction::Synced { .. } => {
                 let tip = store.state().transition_frontier.best_tip().unwrap();

--- a/node/src/p2p/callbacks/p2p_callbacks_reducer.rs
+++ b/node/src/p2p/callbacks/p2p_callbacks_reducer.rs
@@ -16,11 +16,11 @@ use p2p::{
 use redux::{ActionMeta, ActionWithMeta, Dispatcher};
 
 use crate::{
-    consensus::allow_block_too_late,
     p2p_ready,
     snark_pool::candidate::SnarkPoolCandidateAction,
     state::BlockPrevalidationError,
     transaction_pool::candidate::TransactionPoolCandidateAction,
+    transition_frontier::candidate::{allow_block_too_late, TransitionFrontierCandidateAction},
     transition_frontier::sync::{
         ledger::{
             snarked::{
@@ -34,7 +34,7 @@ use crate::{
     watched_accounts::{
         WatchedAccountLedgerInitialState, WatchedAccountsLedgerInitialStateGetError,
     },
-    Action, ConsensusAction, State, WatchedAccountsAction,
+    Action, State, WatchedAccountsAction,
 };
 
 use super::P2pCallbacksAction;
@@ -571,7 +571,7 @@ impl crate::State {
                         return;
                     }
                 }
-                dispatcher.push(ConsensusAction::BlockChainProofUpdate {
+                dispatcher.push(TransitionFrontierCandidateAction::BlockChainProofUpdate {
                     hash: best_tip.hash,
                     chain_proof: (hashes, root_block),
                 });

--- a/node/src/reducer.rs
+++ b/node/src/reducer.rs
@@ -5,7 +5,8 @@ use crate::{
     external_snark_worker::ExternalSnarkWorkers,
     rpc::RpcState,
     state::{BlockProducerState, LedgerState},
-    Action, ActionWithMeta, ConsensusAction, EventSourceAction, P2p, State,
+    transition_frontier::candidate::TransitionFrontierCandidateAction,
+    Action, ActionWithMeta, EventSourceAction, P2p, State,
 };
 
 pub fn reducer(
@@ -23,7 +24,7 @@ pub fn reducer(
                     bug_condition!("{}", error);
                 };
             }
-            dispatcher.push(ConsensusAction::TransitionFrontierSyncTargetUpdate);
+            dispatcher.push(TransitionFrontierCandidateAction::TransitionFrontierSyncTargetUpdate);
         }
         Action::EventSource(EventSourceAction::NewEvent { .. }) => {}
         Action::EventSource(_) => {}
@@ -62,12 +63,6 @@ pub fn reducer(
         Action::LedgerEffects(_) => {}
         Action::Snark(a) => {
             snark::SnarkState::reducer(Substate::new(state, dispatcher), meta.with_action(a));
-        }
-        Action::Consensus(a) => {
-            crate::consensus::ConsensusState::reducer(
-                Substate::new(state, dispatcher),
-                meta.with_action(a),
-            );
         }
         Action::TransitionFrontier(a) => {
             crate::transition_frontier::TransitionFrontierState::reducer(

--- a/node/src/transition_frontier/candidate/mod.rs
+++ b/node/src/transition_frontier/candidate/mod.rs
@@ -1,0 +1,8 @@
+mod transition_frontier_candidate_state;
+pub use transition_frontier_candidate_state::*;
+
+mod transition_frontier_candidate_actions;
+pub use transition_frontier_candidate_actions::*;
+
+mod transition_frontier_candidate_reducer;
+pub use transition_frontier_candidate_reducer::allow_block_too_late;

--- a/node/src/transition_frontier/mod.rs
+++ b/node/src/transition_frontier/mod.rs
@@ -1,3 +1,4 @@
+pub mod candidate;
 pub mod genesis;
 pub mod genesis_effectful;
 pub mod sync;

--- a/node/src/transition_frontier/sync/transition_frontier_sync_actions.rs
+++ b/node/src/transition_frontier/sync/transition_frontier_sync_actions.rs
@@ -130,7 +130,8 @@ impl redux::EnablingCondition<crate::State> for TransitionFrontierSyncAction {
                         .best_tip()
                         .map_or(true, |tip| best_tip.hash != tip.hash)
                     && state
-                        .consensus
+                        .transition_frontier
+                        .candidates
                         .best_tip()
                         .is_some_and(|tip| &best_tip.hash == tip.hash)
             }

--- a/node/src/transition_frontier/transition_frontier_actions.rs
+++ b/node/src/transition_frontier/transition_frontier_actions.rs
@@ -6,6 +6,7 @@ use openmina_core::block::ArcBlockWithHash;
 use openmina_core::ActionEvent;
 use serde::{Deserialize, Serialize};
 
+use super::candidate::TransitionFrontierCandidateAction;
 use super::genesis::TransitionFrontierGenesisAction;
 use super::genesis_effectful::TransitionFrontierGenesisEffectfulAction;
 use super::sync::{SyncError, TransitionFrontierSyncAction, TransitionFrontierSyncState};
@@ -29,6 +30,7 @@ pub enum TransitionFrontierAction {
     #[action_event(level = info)]
     GenesisProvenInject,
 
+    Candidate(TransitionFrontierCandidateAction),
     Sync(TransitionFrontierSyncAction),
     /// Transition frontier synced.
     Synced {
@@ -62,6 +64,7 @@ impl redux::EnablingCondition<crate::State> for TransitionFrontierAction {
                     b.is_genesis() && !Arc::ptr_eq(&genesis.block, &b.block)
                 })
             }
+            TransitionFrontierAction::Candidate(a) => a.is_enabled(state, time),
             TransitionFrontierAction::Sync(a) => a.is_enabled(state, time),
             TransitionFrontierAction::Synced { .. } => matches!(
                 state.transition_frontier.sync,

--- a/node/src/transition_frontier/transition_frontier_effects.rs
+++ b/node/src/transition_frontier/transition_frontier_effects.rs
@@ -2,7 +2,6 @@ use mina_p2p_messages::gossip::GossipNetMessageV2;
 use redux::Timestamp;
 
 use crate::block_producer::BlockProducerAction;
-use crate::consensus::ConsensusAction;
 use crate::ledger::LEDGER_DEPTH;
 use crate::p2p::channels::best_tip::P2pChannelsBestTipAction;
 use crate::p2p::P2pNetworkPubsubAction;
@@ -10,6 +9,7 @@ use crate::snark_pool::{SnarkPoolAction, SnarkWork};
 use crate::stats::sync::SyncingLedger;
 use crate::{Store, TransactionPoolAction};
 
+use super::candidate::TransitionFrontierCandidateAction;
 use super::genesis::TransitionFrontierGenesisAction;
 use super::sync::ledger::snarked::{
     TransitionFrontierSyncLedgerSnarkedAction, ACCOUNT_SUBTREE_HEIGHT,
@@ -56,6 +56,7 @@ pub fn transition_frontier_effects<S: crate::Service>(
                 synced_effects(&meta, store);
             }
         }
+        TransitionFrontierAction::Candidate(_) => {}
         TransitionFrontierAction::Sync(a) => {
             match a {
                 TransitionFrontierSyncAction::Init {
@@ -321,7 +322,7 @@ fn synced_effects<S: crate::Service>(
     }
 
     let best_tip_hash = best_tip.merkle_root_hash().clone();
-    store.dispatch(ConsensusAction::Prune);
+    store.dispatch(TransitionFrontierCandidateAction::Prune);
     store.dispatch(BlockProducerAction::BestTipUpdate {
         best_tip: best_tip.block.clone(),
     });

--- a/node/src/transition_frontier/transition_frontier_reducer.rs
+++ b/node/src/transition_frontier/transition_frontier_reducer.rs
@@ -54,6 +54,12 @@ impl TransitionFrontierState {
                     state.sync = TransitionFrontierSyncState::Synced { time: meta.time() };
                 }
             }
+            TransitionFrontierAction::Candidate(a) => {
+                super::candidate::TransitionFrontierCandidatesState::reducer(
+                    openmina_core::Substate::from_compatible_substate(state_context),
+                    meta.with_action(a),
+                );
+            }
             TransitionFrontierAction::Sync(a) => {
                 let best_chain = state.best_chain.clone();
                 super::sync::TransitionFrontierSyncState::reducer(

--- a/node/src/transition_frontier/transition_frontier_state.rs
+++ b/node/src/transition_frontier/transition_frontier_state.rs
@@ -9,6 +9,7 @@ use openmina_core::block::{AppliedBlock, ArcBlockWithHash};
 use openmina_core::bug_condition;
 use serde::{Deserialize, Serialize};
 
+use super::candidate::TransitionFrontierCandidatesState;
 use super::genesis::TransitionFrontierGenesisState;
 use super::sync::TransitionFrontierSyncState;
 use super::TransitionFrontierConfig;
@@ -23,6 +24,7 @@ pub struct TransitionFrontierState {
     /// Needed protocol states for applying transactions in the root
     /// scan state that we don't have in the `best_chain` list.
     pub needed_protocol_states: BTreeMap<StateHash, MinaStateProtocolStateValueStableV2>,
+    pub candidates: TransitionFrontierCandidatesState,
     /// Transition frontier synchronization state
     pub sync: TransitionFrontierSyncState,
 
@@ -38,6 +40,7 @@ impl TransitionFrontierState {
         Self {
             config,
             genesis: TransitionFrontierGenesisState::Idle,
+            candidates: TransitionFrontierCandidatesState::new(),
             best_chain: Vec::with_capacity(290),
             needed_protocol_states: Default::default(),
             sync: TransitionFrontierSyncState::Idle,

--- a/node/src/watched_accounts/watched_accounts_actions.rs
+++ b/node/src/watched_accounts/watched_accounts_actions.rs
@@ -64,12 +64,12 @@ fn should_request_ledger_initial_state(state: &crate::State, pub_key: &NonZeroCu
     state
         .watched_accounts
         .get(pub_key)
-        .filter(|_| state.consensus.best_tip.is_some())
+        .filter(|_| state.transition_frontier.candidates.best_tip.is_some())
         .is_some_and(|a| match &a.initial_state {
             WatchedAccountLedgerInitialState::Idle { .. } => true,
             WatchedAccountLedgerInitialState::Error { .. } => true,
             WatchedAccountLedgerInitialState::Pending { block, .. } => {
-                let Some(best_tip) = state.consensus.best_tip() else {
+                let Some(best_tip) = state.transition_frontier.candidates.best_tip() else {
                     return false;
                 };
                 &block.hash != best_tip.hash


### PR DESCRIPTION
Since it no longer is just about consensus logic, making this change.

re: #998 