### PR TITLE
Heartbeat processor fixes and tweaks

### DIFF
--- a/tools/heartbeats-processor/.sqlx/query-45341663b6eb18a14a7106b3bf53a63c585f507ac1a957ee60a89b0de50fc9fc.json
+++ b/tools/heartbeats-processor/.sqlx/query-45341663b6eb18a14a7106b3bf53a63c585f507ac1a957ee60a89b0de50fc9fc.json
@@ -1,6 +1,6 @@
 {
   "db_name": "SQLite",
-  "query": "\n        SELECT id, start_time, end_time\n        FROM time_windows\n        WHERE start_time <= ?2 AND end_time >= ?1 AND disabled = FALSE\n        ORDER BY start_time ASC\n        ",
+  "query": "\n            SELECT id, start_time, end_time\n            FROM time_windows\n            WHERE start_time <= ?2 AND end_time >= ?1 AND disabled = FALSE\n            ORDER BY start_time ASC\n            ",
   "describe": {
     "columns": [
       {
@@ -28,5 +28,5 @@
       false
     ]
   },
-  "hash": "6a6910daae1887a4e1a8570c8fb06d1d585460f13b56a45d49fe2fc7447829a9"
+  "hash": "45341663b6eb18a14a7106b3bf53a63c585f507ac1a957ee60a89b0de50fc9fc"
 }

--- a/tools/heartbeats-processor/src/main.rs
+++ b/tools/heartbeats-processor/src/main.rs
@@ -99,13 +99,14 @@ async fn post_scores_to_firestore(pool: &SqlitePool, db: &FirestoreDb) -> Result
 async fn run_process_loop(
     pool: &SqlitePool,
     db: &FirestoreDb,
+    config: &Config,
     interval_seconds: u64,
 ) -> Result<()> {
     let interval = std::time::Duration::from_secs(interval_seconds);
 
     loop {
         println!("Processing heartbeats...");
-        local_db::process_heartbeats(db, pool).await?;
+        local_db::process_heartbeats(db, pool, config).await?;
 
         println!("Posting scores...");
         post_scores_to_firestore(pool, db).await?;
@@ -137,7 +138,7 @@ async fn main() -> Result<()> {
             local_db::create_tables_from_file(&pool).await?;
             local_db::ensure_initial_windows(&pool, &config).await?;
             local_db::mark_disabled_windows(&pool, &config).await?;
-            local_db::process_heartbeats(&db, &pool).await?;
+            local_db::process_heartbeats(&db, &pool, &config).await?;
             println!("Processing completed successfully!");
         }
         Commands::ToggleWindows {
@@ -167,7 +168,7 @@ async fn main() -> Result<()> {
             local_db::create_tables_from_file(&pool).await?;
             local_db::ensure_initial_windows(&pool, &config).await?;
             local_db::mark_disabled_windows(&pool, &config).await?;
-            run_process_loop(&pool, &db, interval_seconds).await?;
+            run_process_loop(&pool, &db, &config, interval_seconds).await?;
         }
     }
 

--- a/tools/heartbeats-processor/src/remote_db.rs
+++ b/tools/heartbeats-processor/src/remote_db.rs
@@ -184,7 +184,7 @@ pub async fn fetch_heartbeats_in_chunks(
 
                     q.for_all(conditions)
                 })
-                .order_by([("createTime", FirestoreQueryDirection::Descending)])
+                .order_by([("createTime", FirestoreQueryDirection::Ascending)])
                 .limit(FIRESTORE_BATCH_SIZE);
 
             let batch: Vec<HeartbeatEntry> = query.obj().query().await?;


### PR DESCRIPTION
- More reporting
- Use the window start as the lower bound for queries when the local database is first instantiated
- Process fetched chunks more eagerly
- Fix heartbeats fetch ordering, was causing some heartbeats to be lost in large batches