### PR TITLE
Changed action flow for transaction in pubsub

### DIFF
--- a/node/src/action_kind.rs
+++ b/node/src/action_kind.rs
@@ -607,6 +607,7 @@ pub enum ActionKind {
     TransactionPoolCandidateFetchPending,
     TransactionPoolCandidateFetchSuccess,
     TransactionPoolCandidateInfoReceived,
+    TransactionPoolCandidateLibp2pTransactionsReceived,
     TransactionPoolCandidatePeerPrune,
     TransactionPoolCandidateVerifyError,
     TransactionPoolCandidateVerifyNext,
@@ -719,7 +720,7 @@ pub enum ActionKind {
 }
 
 impl ActionKind {
-    pub const COUNT: u16 = 609;
+    pub const COUNT: u16 = 610;
 }
 
 impl std::fmt::Display for ActionKind {
@@ -1553,6 +1554,9 @@ impl ActionKindGet for TransactionPoolCandidateAction {
             Self::FetchPending { .. } => ActionKind::TransactionPoolCandidateFetchPending,
             Self::FetchError { .. } => ActionKind::TransactionPoolCandidateFetchError,
             Self::FetchSuccess { .. } => ActionKind::TransactionPoolCandidateFetchSuccess,
+            Self::Libp2pTransactionsReceived { .. } => {
+                ActionKind::TransactionPoolCandidateLibp2pTransactionsReceived
+            }
             Self::VerifyNext => ActionKind::TransactionPoolCandidateVerifyNext,
             Self::VerifyPending { .. } => ActionKind::TransactionPoolCandidateVerifyPending,
             Self::VerifyError { .. } => ActionKind::TransactionPoolCandidateVerifyError,

--- a/node/src/snark_pool/candidate/snark_pool_candidate_actions.rs
+++ b/node/src/snark_pool/candidate/snark_pool_candidate_actions.rs
@@ -112,7 +112,10 @@ impl redux::EnablingCondition<crate::State> for SnarkPoolCandidateAction {
                             }
                         })
             }
-            SnarkPoolCandidateAction::WorkVerifyNext => state.snark.work_verify.jobs.is_empty(),
+            SnarkPoolCandidateAction::WorkVerifyNext => {
+                state.snark.work_verify.jobs.is_empty()
+                    && state.transition_frontier.sync.is_synced()
+            }
             SnarkPoolCandidateAction::WorkVerifyPending {
                 peer_id, job_ids, ..
             } => {

--- a/node/src/state.rs
+++ b/node/src/state.rs
@@ -4,9 +4,7 @@ use std::time::Duration;
 use malloc_size_of_derive::MallocSizeOf;
 use mina_p2p_messages::v2;
 use openmina_core::constants::PROTOCOL_VERSION;
-use openmina_core::transaction::{
-    TransactionInfo, TransactionPoolMessageSource, TransactionWithHash,
-};
+use openmina_core::transaction::{TransactionInfo, TransactionWithHash};
 use p2p::P2pNetworkPubsubMessageCacheId;
 use rand::prelude::*;
 
@@ -59,7 +57,7 @@ pub use crate::transition_frontier::TransitionFrontierState;
 pub use crate::watched_accounts::WatchedAccountsState;
 pub use crate::Config;
 use crate::{config::GlobalConfig, SnarkPoolAction};
-use crate::{ActionWithMeta, RpcAction, TransactionPoolAction};
+use crate::{ActionWithMeta, RpcAction};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct State {
@@ -540,11 +538,12 @@ impl P2p {
                     }
                 }
             )),
-            on_p2p_channels_transaction_libp2p_received: Some(redux::callback!(
-                on_p2p_channels_transaction_libp2p_received((transactions: Vec<TransactionWithHash>, id: P2pNetworkPubsubMessageCacheId)) -> crate::Action {
-                    TransactionPoolAction::StartVerify {
-                        commands: transactions.into_iter().collect(),
-                        from_source: TransactionPoolMessageSource::pubsub(id),
+            on_p2p_channels_transactions_libp2p_received: Some(redux::callback!(
+                on_p2p_channels_transactions_libp2p_received((peer_id: PeerId, transactions: Vec<TransactionWithHash>, message_id: P2pNetworkPubsubMessageCacheId)) -> crate::Action {
+                    TransactionPoolCandidateAction::Libp2pTransactionsReceived {
+                        message_id,
+                        transactions,
+                        peer_id
                     }
                 }
             )),

--- a/node/src/transaction_pool/candidate/transaction_pool_candidate_actions.rs
+++ b/node/src/transaction_pool/candidate/transaction_pool_candidate_actions.rs
@@ -1,4 +1,6 @@
-use openmina_core::transaction::{TransactionHash, TransactionInfo, TransactionWithHash};
+use openmina_core::transaction::{
+    TransactionHash, TransactionInfo, TransactionPoolMessageSource, TransactionWithHash,
+};
 use openmina_core::ActionEvent;
 use p2p::P2pNetworkPubsubMessageCacheId;
 use serde::{Deserialize, Serialize};
@@ -50,7 +52,7 @@ pub enum TransactionPoolCandidateAction {
         peer_id: PeerId,
         transaction_hashes: Vec<TransactionHash>,
         verify_id: (),
-        from_source: Option<P2pNetworkPubsubMessageCacheId>,
+        from_source: TransactionPoolMessageSource,
     },
     VerifyError {
         peer_id: PeerId,
@@ -59,7 +61,7 @@ pub enum TransactionPoolCandidateAction {
     VerifySuccess {
         peer_id: PeerId,
         verify_id: (),
-        from_source: Option<P2pNetworkPubsubMessageCacheId>,
+        from_source: TransactionPoolMessageSource,
     },
     PeerPrune {
         peer_id: PeerId,

--- a/node/src/transaction_pool/candidate/transaction_pool_candidate_actions.rs
+++ b/node/src/transaction_pool/candidate/transaction_pool_candidate_actions.rs
@@ -111,6 +111,7 @@ impl redux::EnablingCondition<crate::State> for TransactionPoolCandidateAction {
                 .is_some(),
             TransactionPoolCandidateAction::Libp2pTransactionsReceived { .. } => true,
             TransactionPoolCandidateAction::VerifyNext => {
+                // TODO: if a block is being applied or produced, skip this action too
                 state.transition_frontier.sync.is_synced()
             }
             TransactionPoolCandidateAction::VerifyPending {

--- a/node/src/transaction_pool/candidate/transaction_pool_candidate_reducer.rs
+++ b/node/src/transaction_pool/candidate/transaction_pool_candidate_reducer.rs
@@ -90,6 +90,18 @@ impl TransactionPoolCandidatesState {
             } => {
                 state.transaction_received(meta.time(), *peer_id, transaction.clone());
             }
+            TransactionPoolCandidateAction::Libp2pTransactionsReceived {
+                peer_id,
+                transactions,
+                message_id,
+            } => {
+                state.transactions_received(
+                    meta.time(),
+                    *peer_id,
+                    transactions.clone(),
+                    *message_id,
+                );
+            }
             TransactionPoolCandidateAction::VerifyNext => {
                 let (dispatcher, global_state) = state_context.into_dispatcher_and_state();
 
@@ -97,31 +109,36 @@ impl TransactionPoolCandidatesState {
                     .transaction_pool
                     .candidates
                     .get_batch_to_verify();
-                let Some((peer_id, batch)) = batch else {
+                let Some((peer_id, batch, from_source)) = batch else {
                     return;
                 };
 
                 let transaction_hashes = batch.iter().map(|tx| tx.hash().clone()).collect();
                 dispatcher.push(TransactionPoolAction::StartVerify {
                     commands: batch.into_iter().collect(),
-                    from_source: TransactionPoolMessageSource::None,
+                    from_source: from_source
+                        .map(TransactionPoolMessageSource::pubsub)
+                        .unwrap_or_default(),
                 });
                 dispatcher.push(TransactionPoolCandidateAction::VerifyPending {
                     peer_id,
                     transaction_hashes,
                     verify_id: (),
+                    from_source,
                 });
             }
             TransactionPoolCandidateAction::VerifyPending {
                 peer_id,
                 transaction_hashes,
                 verify_id,
+                from_source,
             } => {
                 state.verify_pending(meta.time(), peer_id, *verify_id, transaction_hashes);
                 let dispatcher = state_context.into_dispatcher();
                 dispatcher.push(TransactionPoolCandidateAction::VerifySuccess {
                     peer_id: *peer_id,
                     verify_id: *verify_id,
+                    from_source: *from_source,
                 });
             }
             TransactionPoolCandidateAction::VerifyError {
@@ -139,8 +156,12 @@ impl TransactionPoolCandidatesState {
                 //     reason: P2pDisconnectionReason::TransactionPoolVerifyError,
                 // });
             }
-            TransactionPoolCandidateAction::VerifySuccess { peer_id, verify_id } => {
-                state.verify_result(meta.time(), peer_id, *verify_id, Ok(()));
+            TransactionPoolCandidateAction::VerifySuccess {
+                peer_id,
+                verify_id,
+                from_source,
+            } => {
+                state.verify_result(meta.time(), peer_id, *verify_id, from_source, Ok(()));
             }
             TransactionPoolCandidateAction::PeerPrune { peer_id } => {
                 state.peer_remove(*peer_id);

--- a/node/src/transaction_pool/candidate/transaction_pool_candidate_reducer.rs
+++ b/node/src/transaction_pool/candidate/transaction_pool_candidate_reducer.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::unit_arg)]
 
 use crate::{p2p_ready, TransactionPoolAction};
-use openmina_core::transaction::TransactionPoolMessageSource;
 use p2p::{
     channels::rpc::{P2pChannelsRpcAction, P2pRpcId, P2pRpcRequest},
     PeerId,
@@ -116,9 +115,7 @@ impl TransactionPoolCandidatesState {
                 let transaction_hashes = batch.iter().map(|tx| tx.hash().clone()).collect();
                 dispatcher.push(TransactionPoolAction::StartVerify {
                     commands: batch.into_iter().collect(),
-                    from_source: from_source
-                        .map(TransactionPoolMessageSource::pubsub)
-                        .unwrap_or_default(),
+                    from_source,
                 });
                 dispatcher.push(TransactionPoolCandidateAction::VerifyPending {
                     peer_id,

--- a/node/src/transaction_pool/transaction_pool_reducer.rs
+++ b/node/src/transaction_pool/transaction_pool_reducer.rs
@@ -165,7 +165,7 @@ impl TransactionPoolState {
                                         }),
                                         peer_id: None,
                                         reason: "Transaction diff rejected".to_owned(),
-                                    })
+                                    });
                                 }
                                 TransactionPoolMessageSource::None => {}
                             }

--- a/p2p/src/channels/transaction/p2p_channels_transaction_reducer.rs
+++ b/p2p/src/channels/transaction/p2p_channels_transaction_reducer.rs
@@ -215,6 +215,7 @@ impl P2pChannelsTransactionState {
             P2pChannelsTransactionAction::Libp2pReceived {
                 transactions,
                 message_id,
+                peer_id,
                 ..
             } => {
                 let (dispatcher, state) = state_context.into_dispatcher_and_state();
@@ -222,7 +223,7 @@ impl P2pChannelsTransactionState {
 
                 if let Some(callback) = &p2p_state
                     .callbacks
-                    .on_p2p_channels_transaction_libp2p_received
+                    .on_p2p_channels_transactions_libp2p_received
                 {
                     let transactions = transactions
                         .into_iter()
@@ -230,7 +231,7 @@ impl P2pChannelsTransactionState {
                         .filter_map(Result::ok)
                         .collect();
 
-                    dispatcher.push_callback(callback.clone(), (transactions, message_id));
+                    dispatcher.push_callback(callback.clone(), (peer_id, transactions, message_id));
                 }
 
                 Ok(())

--- a/p2p/src/p2p_state.rs
+++ b/p2p/src/p2p_state.rs
@@ -518,8 +518,11 @@ pub struct P2pCallbacks {
     /// Callback for [`P2pChannelsTransactionAction::Received`]
     pub on_p2p_channels_transaction_received: OptionalCallback<(PeerId, Box<TransactionInfo>)>,
     /// Callback for [`P2pChannelsTransactionAction::Libp2pReceived`]
-    pub on_p2p_channels_transaction_libp2p_received:
-        OptionalCallback<(Vec<TransactionWithHash>, P2pNetworkPubsubMessageCacheId)>,
+    pub on_p2p_channels_transactions_libp2p_received: OptionalCallback<(
+        PeerId,
+        Vec<TransactionWithHash>,
+        P2pNetworkPubsubMessageCacheId,
+    )>,
     /// Callback for [`P2pChannelsSnarkJobCommitmentAction::Received`]
     pub on_p2p_channels_snark_job_commitment_received:
         OptionalCallback<(PeerId, Box<SnarkJobCommitment>)>,


### PR DESCRIPTION
Solves: #1067

* Updated `TransactionPoolCandidatesState` to have transactions grouped by pubsub message id
* Changed flow for transactions received in pubsub to be stored in candidate state before before being processed
