### PR TITLE
Status Rpc: extend response to include current service queues

### DIFF
--- a/core/src/channels.rs
+++ b/core/src/channels.rs
@@ -1,4 +1,116 @@
-pub use tokio::sync::{mpsc, oneshot};
+pub use tokio::sync::oneshot;
+
+pub mod mpsc {
+    use std::{
+        sync::{Arc, Weak},
+        task::{Context, Poll},
+    };
+    use tokio::sync::mpsc::error::*;
+    pub use tokio::sync::mpsc::{self, *};
+
+    pub struct UnboundedSender<T>(mpsc::UnboundedSender<T>, Arc<()>);
+    pub struct UnboundedReceiver<T>(mpsc::UnboundedReceiver<T>);
+
+    pub type TrackedUnboundedSender<T> = UnboundedSender<Tracked<T>>;
+    pub type TrackedUnboundedReceiver<T> = UnboundedReceiver<Tracked<T>>;
+
+    #[allow(dead_code)]
+    pub struct Tracked<T>(pub T, pub Tracker);
+    #[allow(dead_code)]
+    pub struct Tracker(Weak<()>);
+
+    impl<T> std::fmt::Debug for UnboundedSender<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?} (len: {})", self.0, self.len())
+        }
+    }
+
+    impl<T> std::fmt::Debug for UnboundedReceiver<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?} (len: {})", self.0, self.len())
+        }
+    }
+
+    impl<T> Clone for UnboundedSender<T> {
+        fn clone(&self) -> Self {
+            Self(self.0.clone(), self.1.clone())
+        }
+    }
+
+    impl<T> std::ops::Deref for Tracked<T> {
+        type Target = T;
+
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    impl<T> std::ops::DerefMut for Tracked<T> {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.0
+        }
+    }
+
+    impl<T> UnboundedSender<T> {
+        pub fn is_empty(&self) -> bool {
+            self.len() == 0
+        }
+
+        pub fn len(&self) -> usize {
+            Arc::weak_count(&self.1)
+        }
+
+        pub fn send(&self, message: T) -> Result<(), SendError<T>> {
+            self.0.send(message)
+        }
+    }
+
+    impl<T> TrackedUnboundedSender<T> {
+        pub fn tracked_send(&self, message: T) -> Result<(), SendError<T>> {
+            let msg = Tracked(message, Tracker(Arc::downgrade(&self.1)));
+            self.send(msg).map_err(|err| SendError(err.0 .0))
+        }
+    }
+
+    impl<T> UnboundedReceiver<T> {
+        pub fn is_empty(&self) -> bool {
+            self.0.is_empty()
+        }
+
+        pub fn len(&self) -> usize {
+            self.0.len()
+        }
+
+        pub async fn recv(&mut self) -> Option<T> {
+            self.0.recv().await
+        }
+
+        pub fn try_recv(&mut self) -> Result<T, TryRecvError> {
+            self.0.try_recv()
+        }
+
+        pub fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
+            self.0.poll_recv(cx)
+        }
+
+        pub fn blocking_recv(&mut self) -> Option<T> {
+            self.0.blocking_recv()
+        }
+    }
+
+    pub fn unbounded_channel<T>() -> (UnboundedSender<T>, UnboundedReceiver<T>) {
+        let (tx, rx) = mpsc::unbounded_channel();
+
+        (UnboundedSender(tx, Arc::new(())), UnboundedReceiver(rx))
+    }
+
+    pub fn tracked_unbounded_channel<T>(
+    ) -> (UnboundedSender<Tracked<T>>, UnboundedReceiver<Tracked<T>>) {
+        let (tx, rx) = mpsc::unbounded_channel();
+
+        (UnboundedSender(tx, Arc::new(())), UnboundedReceiver(rx))
+    }
+}
 
 pub mod broadcast {
     pub use tokio::sync::broadcast::*;

--- a/node/common/src/service/event_receiver.rs
+++ b/node/common/src/service/event_receiver.rs
@@ -9,6 +9,14 @@ pub struct EventReceiver {
 }
 
 impl EventReceiver {
+    pub fn is_empty(&self) -> bool {
+        !self.has_next()
+    }
+
+    pub fn len(&self) -> usize {
+        self.rx.len() + self.queue.len()
+    }
+
     /// If `Err(())`, `mpsc::Sender` for this channel was dropped.
     pub async fn wait_for_events(&mut self) -> Result<(), ()> {
         if !self.queue.is_empty() {
@@ -19,17 +27,8 @@ impl EventReceiver {
         Ok(())
     }
 
-    pub fn has_next(&mut self) -> bool {
-        if self.queue.is_empty() {
-            if let Some(event) = self.try_next() {
-                self.queue.push(event);
-                true
-            } else {
-                false
-            }
-        } else {
-            true
-        }
+    pub fn has_next(&self) -> bool {
+        !self.queue.is_empty() || !self.rx.is_empty()
     }
 
     pub fn try_next(&mut self) -> Option<Event> {

--- a/node/common/src/service/p2p.rs
+++ b/node/common/src/service/p2p.rs
@@ -32,7 +32,7 @@ impl webrtc::P2pServiceWebrtc for NodeService {
         self.event_sender()
     }
 
-    fn cmd_sender(&self) -> &mpsc::UnboundedSender<webrtc::Cmd> {
+    fn cmd_sender(&self) -> &mpsc::TrackedUnboundedSender<webrtc::Cmd> {
         &self.p2p.webrtc.cmd_sender
     }
 

--- a/node/src/rpc/mod.rs
+++ b/node/src/rpc/mod.rs
@@ -48,6 +48,7 @@ use crate::ledger::write::LedgerWriteKind;
 use crate::p2p::connection::incoming::P2pConnectionIncomingInitOpts;
 use crate::p2p::connection::outgoing::P2pConnectionOutgoingInitOpts;
 use crate::p2p::PeerId;
+use crate::service::Queues;
 use crate::snark_pool::{JobCommitment, JobSummary};
 use crate::stats::actions::{ActionStatsForBlock, ActionStatsSnapshot};
 use crate::stats::block_producer::{
@@ -468,6 +469,7 @@ pub struct RpcNodeStatus {
     pub current_block_production_attempt: Option<BlockProductionAttempt>,
     pub peers: Vec<RpcPeerInfo>,
     pub resources_status: RpcNodeStatusResources,
+    pub service_queues: Queues,
 }
 
 #[derive(Serialize, Debug, Clone)]

--- a/node/src/rpc_effectful/rpc_effectful_effects.rs
+++ b/node/src/rpc_effectful/rpc_effectful_effects.rs
@@ -839,6 +839,7 @@ fn compute_node_status<S: Service>(store: &mut Store<S>) -> RpcNodeStatus {
             transition_frontier: state.transition_frontier.resources_usage(),
             snark_pool: state.snark_pool.resources_usage(),
         },
+        service_queues: store.service.queues(),
     };
     status
 }

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -34,7 +34,21 @@ pub trait Service:
     + RpcService
     + ArchiveService
 {
+    fn queues(&mut self) -> Queues;
     fn stats(&mut self) -> Option<&mut Stats>;
     fn recorder(&mut self) -> &mut Recorder;
     fn is_replay(&self) -> bool;
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+pub struct Queues {
+    pub events: usize,
+    pub snark_block_verify: usize,
+    pub ledger: usize,
+    pub vrf_evaluator: Option<usize>,
+    pub block_prover: Option<usize>,
+    pub p2p_webrtc: usize,
+    #[cfg(feature = "p2p-libp2p")]
+    pub p2p_libp2p: usize,
+    pub rpc: usize,
 }

--- a/node/testing/src/service/mod.rs
+++ b/node/testing/src/service/mod.rs
@@ -278,6 +278,10 @@ impl NodeTestingService {
 impl redux::Service for NodeTestingService {}
 
 impl node::Service for NodeTestingService {
+    fn queues(&mut self) -> node::service::Queues {
+        self.real.queues()
+    }
+
     fn stats(&mut self) -> Option<&mut Stats> {
         self.real.stats()
     }
@@ -360,7 +364,7 @@ impl P2pServiceWebrtc for NodeTestingService {
         P2pServiceWebrtc::event_sender(&self.real)
     }
 
-    fn cmd_sender(&self) -> &mpsc::UnboundedSender<Cmd> {
+    fn cmd_sender(&self) -> &mpsc::TrackedUnboundedSender<Cmd> {
         P2pServiceWebrtc::cmd_sender(&self.real)
     }
 

--- a/p2p/src/service_impl/mod.rs
+++ b/p2p/src/service_impl/mod.rs
@@ -47,7 +47,7 @@ pub mod webrtc {
 
         fn event_sender(&self) -> &mpsc::UnboundedSender<Self::Event>;
 
-        fn cmd_sender(&self) -> &mpsc::UnboundedSender<Cmd>;
+        fn cmd_sender(&self) -> &mpsc::TrackedUnboundedSender<Cmd>;
 
         fn peers(&mut self) -> &mut BTreeMap<PeerId, PeerState>;
 

--- a/p2p/testing/src/cluster.rs
+++ b/p2p/testing/src/cluster.rs
@@ -8,6 +8,7 @@ use std::{
 
 use futures::StreamExt;
 use libp2p::{multiaddr::multiaddr, swarm::DialError, Multiaddr};
+use openmina_core::channels::mpsc;
 use openmina_core::{ChainId, Substate, DEVNET_CHAIN_ID};
 use p2p::{
     connection::outgoing::{
@@ -18,7 +19,6 @@ use p2p::{
     P2pCallbacks, P2pConfig, P2pMeshsubConfig, P2pState, PeerId,
 };
 use redux::SystemTime;
-use tokio::sync::mpsc;
 
 use crate::{
     event::{event_mapper_effect, RustNodeEvent},

--- a/p2p/testing/src/rust_node.rs
+++ b/p2p/testing/src/rust_node.rs
@@ -5,9 +5,9 @@ use std::{
 };
 
 use futures::Stream;
+use openmina_core::channels::mpsc;
 use p2p::{P2pAction, P2pEvent, P2pLimits, P2pState, P2pTimeouts, PeerId};
 use redux::{Effects, EnablingCondition, Reducer, SubStore};
-use tokio::sync::mpsc;
 
 use crate::{
     cluster::{Listener, PeerIdConfig},

--- a/p2p/testing/src/service.rs
+++ b/p2p/testing/src/service.rs
@@ -1,5 +1,6 @@
 use std::{collections::VecDeque, time::Instant};
 
+use openmina_core::channels::mpsc;
 use p2p::{
     identity::SecretKey,
     service_impl::{
@@ -9,14 +10,13 @@ use p2p::{
 };
 use rand::{rngs::StdRng, seq::SliceRandom, Rng, SeedableRng};
 use redux::{Service, TimeService};
-use tokio::sync::mpsc;
 
 use crate::event::{RustNodeEvent, RustNodeEventStore};
 
 pub struct ClusterService {
     pub rng: StdRng,
     pub event_sender: mpsc::UnboundedSender<P2pEvent>,
-    pub cmd_sender: mpsc::UnboundedSender<p2p::service_impl::webrtc::Cmd>,
+    pub cmd_sender: mpsc::TrackedUnboundedSender<p2p::service_impl::webrtc::Cmd>,
     mio: MioService,
     peers: std::collections::BTreeMap<p2p::PeerId, p2p::service_impl::webrtc::PeerState>,
     time: Instant,
@@ -29,7 +29,7 @@ impl ClusterService {
         node_idx: usize,
         secret_key: SecretKey,
         event_sender: mpsc::UnboundedSender<P2pEvent>,
-        cmd_sender: mpsc::UnboundedSender<p2p::service_impl::webrtc::Cmd>,
+        cmd_sender: mpsc::TrackedUnboundedSender<p2p::service_impl::webrtc::Cmd>,
         time: Instant,
     ) -> Self {
         let mio = {
@@ -94,7 +94,7 @@ impl P2pServiceWebrtc for ClusterService {
         &self.event_sender
     }
 
-    fn cmd_sender(&self) -> &mpsc::UnboundedSender<p2p::service_impl::webrtc::Cmd> {
+    fn cmd_sender(&self) -> &mpsc::TrackedUnboundedSender<p2p::service_impl::webrtc::Cmd> {
         &self.cmd_sender
     }
 


### PR DESCRIPTION
In rust node, we have queues/channels between state machine and services. It would be useful to inspect current state of those queues at any given moment.
```
{
    "events": 0,
    "snark_block_verify": 0,
    "ledger": 0,
    "vrf_evaluator": 0,
    "block_prover": 0,
    "p2p_webrtc": 10,
    "rpc": 0
}
```