### PR TITLE
Display panics from other threads when main thread panics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,6 +1145,7 @@ name = "cli"
 version = "0.14.0"
 dependencies = [
  "anyhow",
+ "backtrace",
  "bytes",
  "clap 4.5.20",
  "console",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -38,6 +38,7 @@ nix = { version = "0.26.2", features = ["signal"] }
 shellexpand = "3.1.0"
 dialoguer = "0.10.4"
 serde_json = "1.0.107"
+backtrace = "0.3"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 redux = { workspace = true, features=["serializable_callbacks"] }


### PR DESCRIPTION
<details>

<summary>Example when the main thread panics:</summary>

```
thread 'main' panicked at node/src/ledger/ledger_manager.rs:438:18:
get_accounts failed
   0:     0x55f1b7788089 - backtrace::backtrace::libunwind::trace::hda77ddeedf7bc2d6
                               at /home/sebastien/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/backtrace-0.3.69/src/backtrace/libunwind.rs:93:5
                           backtrace::backtrace::trace_unsynchronized::h061fee87c82cf614
                               at /home/sebastien/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/backtrace-0.3.69/src/backtrace/mod.rs:66:5
                           backtrace::backtrace::trace::h2225c7518a9fac40
                               at /home/sebastien/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/backtrace-0.3.69/src/backtrace/mod.rs:53:14
                           backtrace::capture::Backtrace::create::h73e8bf6078684b8f
                               at /home/sebastien/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/backtrace-0.3.69/src/capture.rs:176:9
                           backtrace::capture::Backtrace::new::h637eac1a54c90bf9
                               at /home/sebastien/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/backtrace-0.3.69/src/capture.rs:140:22
   1:     0x55f1b57ea611 - openmina::new_hook::h79b03c3638e85251
                               at /home/sebastien/travaux/openmina/cli/src/main.rs:86:21
   2:     0x55f1b77e72a3 - <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call::h2673335cca16d632
                               at /rustc/38213856a8a3a6d49a234e0d95a722a4f28a2b18/library/alloc/src/boxed.rs:2007:9
                           std::panicking::rust_panic_with_hook::h5183c9e4612eaffc
                               at /rustc/38213856a8a3a6d49a234e0d95a722a4f28a2b18/library/std/src/panicking.rs:836:13
   3:     0x55f1b77e6f46 - std::panicking::begin_panic_handler::{{closure}}::hfb6a7d175dde7957
                               at /rustc/38213856a8a3a6d49a234e0d95a722a4f28a2b18/library/std/src/panicking.rs:694:13
   4:     0x55f1b77e5f29 - std::sys::backtrace::__rust_end_short_backtrace::hc9054822461dd5c6
                               at /rustc/38213856a8a3a6d49a234e0d95a722a4f28a2b18/library/std/src/sys/backtrace.rs:168:18
   5:     0x55f1b77e6c0d - rust_begin_unwind
                               at /rustc/38213856a8a3a6d49a234e0d95a722a4f28a2b18/library/std/src/panicking.rs:692:5
   6:     0x55f1b57415e0 - core::panicking::panic_fmt::h3892ce0a2207350f
                               at /rustc/38213856a8a3a6d49a234e0d95a722a4f28a2b18/library/core/src/panicking.rs:75:14
   7:     0x55f1b69646d4 - node::ledger::ledger_manager::LedgerManager::get_accounts::h3d1f92d4d14860d5
                               at /home/sebastien/travaux/openmina/node/src/ledger/ledger_manager.rs:438:18
   8:     0x55f1b5f83278 - node::transaction_pool::transaction_pool_effects::<impl node::transaction_pool::transaction_pool_actions::TransactionPoolEffectfulAction>::effects::hde43437b396cfe91
                               at /home/sebastien/travaux/openmina/node/src/transaction_pool/transaction_pool_effects.rs:31:38
                           node::effects::effects::h934ee7cc8bddf2c7
                               at /home/sebastien/travaux/openmina/node/src/effects.rs:76:13
   9:     0x55f1b5b432b1 - redux::store::Store<State,Service,Action>::dispatch_effects::haecd1165c16d41fa
                               at /home/sebastien/.cargo/git/checkouts/redux-rs-b0646d2e540fbccd/ab14890/src/store.rs:232:9
                           redux::store::Store<State,Service,Action>::dispatch_enabled::h3774e0071131468e
                               at /home/sebastien/.cargo/git/checkouts/redux-rs-b0646d2e540fbccd/ab14890/src/store.rs:209:9
  10:     0x55f1b5b433ce - redux::store::Store<State,Service,Action>::dispatch_effects::haecd1165c16d41fa
                               at /home/sebastien/.cargo/git/checkouts/redux-rs-b0646d2e540fbccd/ab14890/src/store.rs:237:17
                           redux::store::Store<State,Service,Action>::dispatch_enabled::h3774e0071131468e
                               at /home/sebastien/.cargo/git/checkouts/redux-rs-b0646d2e540fbccd/ab14890/src/store.rs:209:9
  11:     0x55f1b5fce9e7 - redux::store::Store<State,Service,Action>::dispatch::hd6434273d965f3ad
                               at /home/sebastien/.cargo/git/checkouts/redux-rs-b0646d2e540fbccd/ab14890/src/store.rs:149:9
                           node::transition_frontier::transition_frontier_effects::synced_effects::hce97d2ff4cd9da5b
                               at /home/sebastien/travaux/openmina/node/src/transition_frontier/transition_frontier_effects.rs:330:5
                           node::transition_frontier::transition_frontier_effects::transition_frontier_effects::h3e7bc99729976b7f
  12:     0x55f1b5f82ae8 - node::effects::effects::h934ee7cc8bddf2c7
                               at /home/sebastien/travaux/openmina/node/src/effects.rs:79:13
  13:     0x55f1b5b432b1 - redux::store::Store<State,Service,Action>::dispatch_effects::haecd1165c16d41fa
                               at /home/sebastien/.cargo/git/checkouts/redux-rs-b0646d2e540fbccd/ab14890/src/store.rs:232:9
                           redux::store::Store<State,Service,Action>::dispatch_enabled::h3774e0071131468e
                               at /home/sebastien/.cargo/git/checkouts/redux-rs-b0646d2e540fbccd/ab14890/src/store.rs:209:9
  14:     0x55f1b5fce794 - redux::store::Store<State,Service,Action>::dispatch::h7ed2aa823321a75e
                               at /home/sebastien/.cargo/git/checkouts/redux-rs-b0646d2e540fbccd/ab14890/src/store.rs:149:9
                           node::transition_frontier::transition_frontier_effects::transition_frontier_effects::h3e7bc99729976b7f
                               at /home/sebastien/travaux/openmina/node/src/transition_frontier/transition_frontier_effects.rs:40:21
  15:     0x55f1b5f82ae8 - node::effects::effects::h934ee7cc8bddf2c7
                               at /home/sebastien/travaux/openmina/node/src/effects.rs:79:13
  16:     0x55f1b5b432b1 - redux::store::Store<State,Service,Action>::dispatch_effects::haecd1165c16d41fa
                               at /home/sebastien/.cargo/git/checkouts/redux-rs-b0646d2e540fbccd/ab14890/src/store.rs:232:9
                           redux::store::Store<State,Service,Action>::dispatch_enabled::h3774e0071131468e
                               at /home/sebastien/.cargo/git/checkouts/redux-rs-b0646d2e540fbccd/ab14890/src/store.rs:209:9
  17:     0x55f1b5b433ce - redux::store::Store<State,Service,Action>::dispatch_effects::haecd1165c16d41fa
                               at /home/sebastien/.cargo/git/checkouts/redux-rs-b0646d2e540fbccd/ab14890/src/store.rs:237:17
                           redux::store::Store<State,Service,Action>::dispatch_enabled::h3774e0071131468e
                               at /home/sebastien/.cargo/git/checkouts/redux-rs-b0646d2e540fbccd/ab14890/src/store.rs:209:9
  18:     0x55f1b5b44b0d - redux::store::Store<State,Service,Action>::dispatch::hcc91b2455db8b562
                               at /home/sebastien/.cargo/git/checkouts/redux-rs-b0646d2e540fbccd/ab14890/src/store.rs:149:9
  19:     0x55f1b5f84eb7 - node::event_source::event_source_effects::event_source_effects::hc74bb0a13d3d8ed0
                               at /home/sebastien/travaux/openmina/node/src/event_source/event_source_effects.rs:449:21
                           node::effects::effects::h934ee7cc8bddf2c7
                               at /home/sebastien/travaux/openmina/node/src/effects.rs:70:13
  20:     0x55f1b5b432b1 - redux::store::Store<State,Service,Action>::dispatch_effects::haecd1165c16d41fa
                               at /home/sebastien/.cargo/git/checkouts/redux-rs-b0646d2e540fbccd/ab14890/src/store.rs:232:9
                           redux::store::Store<State,Service,Action>::dispatch_enabled::h3774e0071131468e
                               at /home/sebastien/.cargo/git/checkouts/redux-rs-b0646d2e540fbccd/ab14890/src/store.rs:209:9
  21:     0x55f1b5f82207 - redux::store::Store<State,Service,Action>::dispatch::h861c6b1cc212dc47
                               at /home/sebastien/.cargo/git/checkouts/redux-rs-b0646d2e540fbccd/ab14890/src/store.rs:149:9
                           node::event_source::event_source_effects::event_source_effects::hc74bb0a13d3d8ed0
                               at /home/sebastien/travaux/openmina/node/src/event_source/event_source_effects.rs:50:25
                           node::effects::effects::h934ee7cc8bddf2c7
                               at /home/sebastien/travaux/openmina/node/src/effects.rs:70:13
  22:     0x55f1b57891c1 - redux::store::Store<State,Service,Action>::dispatch_effects::hd2700bdb85e3e0d9
                               at /home/sebastien/.cargo/git/checkouts/redux-rs-b0646d2e540fbccd/ab14890/src/store.rs:232:9
                           redux::store::Store<State,Service,Action>::dispatch_enabled::h62634312836093f6
                               at /home/sebastien/.cargo/git/checkouts/redux-rs-b0646d2e540fbccd/ab14890/src/store.rs:209:9
  23:     0x55f1b576e7ed - redux::store::Store<State,Service,Action>::dispatch::ha6c7e8bc1a643141
                               at /home/sebastien/.cargo/git/checkouts/redux-rs-b0646d2e540fbccd/ab14890/src/store.rs:149:9
                           openmina_node_common::node::node::Node<Serv>::run_forever::{{closure}}::h8f533a2de09d9cdd
                               at /home/sebastien/travaux/openmina/node/common/src/node/node.rs:93:25
  24:     0x55f1b578d904 - <core::pin::Pin<P> as core::future::future::Future>::poll::h967cbb7181e71b48
                               at /home/sebastien/.rustup/toolchains/beta-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/future/future.rs:124:9
                           tokio::runtime::scheduler::current_thread::CoreGuard::block_on::{{closure}}::{{closure}}::{{closure}}::h43cb0bb4861bfc21
                               at /home/sebastien/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.37.0/src/runtime/scheduler/current_thread/mod.rs:659:57
                           tokio::runtime::coop::with_budget::h43caabb28c1a6b55
                               at /home/sebastien/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.37.0/src/runtime/coop.rs:107:5
                           tokio::runtime::coop::budget::h5c4f8e8b41149b91
                               at /home/sebastien/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.37.0/src/runtime/coop.rs:73:5
                           tokio::runtime::scheduler::current_thread::CoreGuard::block_on::{{closure}}::{{closure}}::h583bf4d7b59038d7
                               at /home/sebastien/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.37.0/src/runtime/scheduler/current_thread/mod.rs:659:25
                           tokio::runtime::scheduler::current_thread::Context::enter::h14387ce36f3fef83
                               at /home/sebastien/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.37.0/src/runtime/scheduler/current_thread/mod.rs:404:19
  25:     0x55f1b5815efb - tokio::runtime::scheduler::current_thread::CoreGuard::block_on::{{closure}}::h1649d2eec2b082b4
                               at /home/sebastien/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.37.0/src/runtime/scheduler/current_thread/mod.rs:658:36
                           tokio::runtime::scheduler::current_thread::CoreGuard::enter::{{closure}}::h70013d499ab604f0
                               at /home/sebastien/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.37.0/src/runtime/scheduler/current_thread/mod.rs:737:68
                           tokio::runtime::context::scoped::Scoped<T>::set::h42adddb3797b9774
                               at /home/sebastien/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.37.0/src/runtime/context/scoped.rs:40:9
  26:     0x55f1b578d079 - tokio::runtime::context::set_scheduler::{{closure}}::ha4c7ce5eadb20404
                               at /home/sebastien/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.37.0/src/runtime/context.rs:176:26
                           std::thread::local::LocalKey<T>::try_with::hd9b816f66af0004c
                               at /home/sebastien/.rustup/toolchains/beta-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/local.rs:308:12
                           std::thread::local::LocalKey<T>::with::hb1d73f20cf792909
                               at /home/sebastien/.rustup/toolchains/beta-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/local.rs:272:9
                           tokio::runtime::context::set_scheduler::h545b226a104f43f5
                               at /home/sebastien/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.37.0/src/runtime/context.rs:176:17
                           tokio::runtime::scheduler::current_thread::CoreGuard::enter::h84981dfccfa2f172
                               at /home/sebastien/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.37.0/src/runtime/scheduler/current_thread/mod.rs:737:27
                           tokio::runtime::scheduler::current_thread::CoreGuard::block_on::h92da9f8bfa034f10
                               at /home/sebastien/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.37.0/src/runtime/scheduler/current_thread/mod.rs:646:19
                           tokio::runtime::scheduler::current_thread::CurrentThread::block_on::{{closure}}::ha2bd563c8c6a0e86
                               at /home/sebastien/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.37.0/src/runtime/scheduler/current_thread/mod.rs:175:28
                           tokio::runtime::context::runtime::enter_runtime::he210eb2cbd13bd12
                               at /home/sebastien/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.37.0/src/runtime/context/runtime.rs:65:16
                           tokio::runtime::scheduler::current_thread::CurrentThread::block_on::hbd617e42d089c7a1
                               at /home/sebastien/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.37.0/src/runtime/scheduler/current_thread/mod.rs:167:9
                           tokio::runtime::runtime::Runtime::block_on::h547656cd1cc1ebb0
                               at /home/sebastien/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.37.0/src/runtime/runtime.rs:349:47
  27:     0x55f1b59ba6a9 - openmina::commands::node::Node::run::he36720cd25e4fb34
                               at /home/sebastien/travaux/openmina/cli/src/commands/node/mod.rs:317:9
  28:     0x55f1b59be03f - openmina::commands::Command::run::h7537a79e1bba86c7
                               at /home/sebastien/travaux/openmina/cli/src/commands/mod.rs:46:30
  29:     0x55f1b57eb0e6 - openmina::main::h1483265117326bfd
                               at /home/sebastien/travaux/openmina/cli/src/main.rs:134:5
  30:     0x55f1b5901ce3 - core::ops::function::FnOnce::call_once::h0f88cad768ddea57
                               at /home/sebastien/.rustup/toolchains/beta-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
                           std::sys::backtrace::__rust_begin_short_backtrace::h6b43078e45e9289b
                               at /home/sebastien/.rustup/toolchains/beta-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/backtrace.rs:152:18
  31:     0x55f1b599f28d - std::rt::lang_start::{{closure}}::hb53b05cbc83ea6cc
                               at /home/sebastien/.rustup/toolchains/beta-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/rt.rs:195:18
  32:     0x55f1b77d85b7 - core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once::h8d290866c3b7258a
                               at /rustc/38213856a8a3a6d49a234e0d95a722a4f28a2b18/library/core/src/ops/function.rs:284:13
                           std::panicking::try::do_call::hfafb049db3030ac8
                               at /rustc/38213856a8a3a6d49a234e0d95a722a4f28a2b18/library/std/src/panicking.rs:584:40
                           std::panicking::try::hbab72fdddf35a20e
                               at /rustc/38213856a8a3a6d49a234e0d95a722a4f28a2b18/library/std/src/panicking.rs:547:19
                           std::panic::catch_unwind::ha99060295a47af6b
                               at /rustc/38213856a8a3a6d49a234e0d95a722a4f28a2b18/library/std/src/panic.rs:358:14
                           std::rt::lang_start_internal::{{closure}}::h4d83cdea005c08a5
                               at /rustc/38213856a8a3a6d49a234e0d95a722a4f28a2b18/library/std/src/rt.rs:174:48
                           std::panicking::try::do_call::hb4864abdc0dcff99
                               at /rustc/38213856a8a3a6d49a234e0d95a722a4f28a2b18/library/std/src/panicking.rs:584:40
                           std::panicking::try::h894e21c88ebad88e
                               at /rustc/38213856a8a3a6d49a234e0d95a722a4f28a2b18/library/std/src/panicking.rs:547:19
                           std::panic::catch_unwind::h1d87ea0c3e4163b0
                               at /rustc/38213856a8a3a6d49a234e0d95a722a4f28a2b18/library/std/src/panic.rs:358:14
                           std::rt::lang_start_internal::h28d87431e08600eb
                               at /rustc/38213856a8a3a6d49a234e0d95a722a4f28a2b18/library/std/src/rt.rs:174:20
  33:     0x55f1b57eb26c - main
  34:     0x7f3e52554088 - __libc_start_call_main
  35:     0x7f3e5255414b - __libc_start_main@GLIBC_2.2.5
  36:     0x55f1b5741cf5 - _start
  37:                0x0 - <unknown>



Number of panics from others threads: 1

thread 'ledger-manager' panicked at node/src/ledger/ledger_manager.rs:89:9:
explicit panic
   0:     0x55f1b7788089 - backtrace::backtrace::libunwind::trace::hda77ddeedf7bc2d6
                               at /home/sebastien/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/backtrace-0.3.69/src/backtrace/libunwind.rs:93:5
                           backtrace::backtrace::trace_unsynchronized::h061fee87c82cf614
                               at /home/sebastien/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/backtrace-0.3.69/src/backtrace/mod.rs:66:5
                           backtrace::backtrace::trace::h2225c7518a9fac40
                               at /home/sebastien/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/backtrace-0.3.69/src/backtrace/mod.rs:53:14
                           backtrace::capture::Backtrace::create::h73e8bf6078684b8f
                               at /home/sebastien/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/backtrace-0.3.69/src/capture.rs:176:9
                           backtrace::capture::Backtrace::new::h637eac1a54c90bf9
                               at /home/sebastien/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/backtrace-0.3.69/src/capture.rs:140:22
   1:     0x55f1b57ea611 - openmina::new_hook::h79b03c3638e85251
                               at /home/sebastien/travaux/openmina/cli/src/main.rs:86:21
   2:     0x55f1b77e72a3 - <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call::h2673335cca16d632
                               at /rustc/38213856a8a3a6d49a234e0d95a722a4f28a2b18/library/alloc/src/boxed.rs:2007:9
                           std::panicking::rust_panic_with_hook::h5183c9e4612eaffc
                               at /rustc/38213856a8a3a6d49a234e0d95a722a4f28a2b18/library/std/src/panicking.rs:836:13
   3:     0x55f1b77e6f7a - std::panicking::begin_panic_handler::{{closure}}::hfb6a7d175dde7957
                               at /rustc/38213856a8a3a6d49a234e0d95a722a4f28a2b18/library/std/src/panicking.rs:701:13
   4:     0x55f1b77e5f29 - std::sys::backtrace::__rust_end_short_backtrace::hc9054822461dd5c6
                               at /rustc/38213856a8a3a6d49a234e0d95a722a4f28a2b18/library/std/src/sys/backtrace.rs:168:18
   5:     0x55f1b77e6c0d - rust_begin_unwind
                               at /rustc/38213856a8a3a6d49a234e0d95a722a4f28a2b18/library/std/src/panicking.rs:692:5
   6:     0x55f1b57415e0 - core::panicking::panic_fmt::h3892ce0a2207350f
                               at /rustc/38213856a8a3a6d49a234e0d95a722a4f28a2b18/library/core/src/panicking.rs:75:14
   7:     0x55f1b5741766 - core::panicking::panic_display::hc12d7b11e8a9e5a0
                               at /rustc/38213856a8a3a6d49a234e0d95a722a4f28a2b18/library/core/src/panicking.rs:261:5
                           core::panicking::panic_explicit::h796dd3740334699c
                               at /rustc/38213856a8a3a6d49a234e0d95a722a4f28a2b18/library/core/src/panicking.rs:234:5
   8:     0x55f1b56e646e - node::ledger::ledger_manager::LedgerRequest::handle::panic_cold_explicit::h18eee4516f88fb03
                               at /home/sebastien/.rustup/toolchains/beta-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panic.rs:88:13
   9:     0x55f1b69639ec - node::ledger::ledger_manager::LedgerRequest::handle::h2af100485128e3cb
                               at /home/sebastien/travaux/openmina/node/src/ledger/ledger_manager.rs:89:9
  10:     0x55f1b654b1a9 - node::ledger::ledger_manager::LedgerManager::spawn::{{closure}}::hb662ce9c91714372
                               at /home/sebastien/travaux/openmina/node/src/ledger/ledger_manager.rs:365:32
                           std::sys::backtrace::__rust_begin_short_backtrace::h7c3621ef25e996e7
                               at /home/sebastien/.rustup/toolchains/beta-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/backtrace.rs:152:18
  11:     0x55f1b693d938 - std::thread::Builder::spawn_unchecked_::{{closure}}::{{closure}}::hca59506e730a2a3d
                               at /home/sebastien/.rustup/toolchains/beta-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/mod.rs:564:17
                           <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once::h6aef4506d704a2f6
                               at /home/sebastien/.rustup/toolchains/beta-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panic/unwind_safe.rs:272:9
                           std::panicking::try::do_call::h4c7c549295350b40
                               at /home/sebastien/.rustup/toolchains/beta-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:584:40
                           std::panicking::try::h53544cff07cb81ea
                               at /home/sebastien/.rustup/toolchains/beta-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:547:19
                           std::panic::catch_unwind::h2675f1a7b6c8f5a2
                               at /home/sebastien/.rustup/toolchains/beta-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panic.rs:358:14
                           std::thread::Builder::spawn_unchecked_::{{closure}}::h2fc0c8a08384e274
                               at /home/sebastien/.rustup/toolchains/beta-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/mod.rs:562:30
                           core::ops::function::FnOnce::call_once{{vtable.shim}}::h9f07b35ceb7852f9
                               at /home/sebastien/.rustup/toolchains/beta-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
  12:     0x55f1b77ea7db - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::h0be520bdeb30de61
                               at /rustc/38213856a8a3a6d49a234e0d95a722a4f28a2b18/library/alloc/src/boxed.rs:1993:9
                           <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::hd504aa0dad344db7
                               at /rustc/38213856a8a3a6d49a234e0d95a722a4f28a2b18/library/alloc/src/boxed.rs:1993:9
                           std::sys::pal::unix::thread::Thread::new::thread_start::h348dc73109f901c9
                               at /rustc/38213856a8a3a6d49a234e0d95a722a4f28a2b18/library/std/src/sys/pal/unix/thread.rs:106:17
  13:     0x7f3e525c2088 - start_thread
  14:     0x7f3e52645f8c - clone3
  15:                0x0 - <unknown>
```

</details>

Make panics reported by community easier to debug/read