### PR TITLE
Transition Frontier: do cheap consensus first then expensive verification

### DIFF
--- a/node/src/action_kind.rs
+++ b/node/src/action_kind.rs
@@ -618,7 +618,6 @@ pub enum ActionKind {
     TransitionFrontierGenesisProvenInject,
     TransitionFrontierSyncFailed,
     TransitionFrontierSynced,
-    TransitionFrontierCandidateBestTipUpdate,
     TransitionFrontierCandidateBlockChainProofUpdate,
     TransitionFrontierCandidateBlockPrevalidateError,
     TransitionFrontierCandidateBlockPrevalidateSuccess,
@@ -626,11 +625,8 @@ pub enum ActionKind {
     TransitionFrontierCandidateBlockSnarkVerifyError,
     TransitionFrontierCandidateBlockSnarkVerifyPending,
     TransitionFrontierCandidateBlockSnarkVerifySuccess,
-    TransitionFrontierCandidateDetectForkRange,
-    TransitionFrontierCandidateLongRangeForkResolve,
     TransitionFrontierCandidateP2pBestTipUpdate,
     TransitionFrontierCandidatePrune,
-    TransitionFrontierCandidateShortRangeForkResolve,
     TransitionFrontierCandidateTransitionFrontierSyncTargetUpdate,
     TransitionFrontierGenesisLedgerLoadInit,
     TransitionFrontierGenesisLedgerLoadPending,
@@ -720,7 +716,7 @@ pub enum ActionKind {
 }
 
 impl ActionKind {
-    pub const COUNT: u16 = 610;
+    pub const COUNT: u16 = 606;
 }
 
 impl std::fmt::Display for ActionKind {
@@ -1434,6 +1430,9 @@ impl ActionKindGet for TransitionFrontierGenesisEffectfulAction {
 impl ActionKindGet for TransitionFrontierCandidateAction {
     fn kind(&self) -> ActionKind {
         match self {
+            Self::P2pBestTipUpdate { .. } => {
+                ActionKind::TransitionFrontierCandidateP2pBestTipUpdate
+            }
             Self::BlockReceived { .. } => ActionKind::TransitionFrontierCandidateBlockReceived,
             Self::BlockPrevalidateSuccess { .. } => {
                 ActionKind::TransitionFrontierCandidateBlockPrevalidateSuccess
@@ -1453,19 +1452,8 @@ impl ActionKindGet for TransitionFrontierCandidateAction {
             Self::BlockSnarkVerifyError { .. } => {
                 ActionKind::TransitionFrontierCandidateBlockSnarkVerifyError
             }
-            Self::DetectForkRange { .. } => ActionKind::TransitionFrontierCandidateDetectForkRange,
-            Self::ShortRangeForkResolve { .. } => {
-                ActionKind::TransitionFrontierCandidateShortRangeForkResolve
-            }
-            Self::LongRangeForkResolve { .. } => {
-                ActionKind::TransitionFrontierCandidateLongRangeForkResolve
-            }
-            Self::BestTipUpdate { .. } => ActionKind::TransitionFrontierCandidateBestTipUpdate,
             Self::TransitionFrontierSyncTargetUpdate => {
                 ActionKind::TransitionFrontierCandidateTransitionFrontierSyncTargetUpdate
-            }
-            Self::P2pBestTipUpdate { .. } => {
-                ActionKind::TransitionFrontierCandidateP2pBestTipUpdate
             }
             Self::Prune => ActionKind::TransitionFrontierCandidatePrune,
         }

--- a/node/src/logger/logger_effects.rs
+++ b/node/src/logger/logger_effects.rs
@@ -9,6 +9,7 @@ use crate::p2p::connection::P2pConnectionAction;
 use crate::p2p::network::P2pNetworkAction;
 use crate::p2p::P2pAction;
 use crate::snark::SnarkAction;
+use crate::transition_frontier::candidate::TransitionFrontierCandidateAction;
 use crate::{
     Action, ActionWithMetaRef, BlockProducerAction, Service, Store, TransitionFrontierAction,
 };
@@ -119,6 +120,18 @@ pub fn logger_effects<S: Service>(store: &Store<S>, action: ActionWithMetaRef<'_
         Action::Snark(SnarkAction::WorkVerify(a)) => a.action_event(&context),
         Action::Snark(SnarkAction::UserCommandVerify(a)) => a.action_event(&context),
         Action::TransitionFrontier(a) => match a {
+            TransitionFrontierAction::Candidate(
+                TransitionFrontierCandidateAction::BlockReceived { block, chain_proof },
+            ) => {
+                openmina_core::action_info!(
+                    context,
+                    kind = action.kind().to_string(),
+                    summary = "candidate block received",
+                    block_hash = block.hash().to_string(),
+                    block_height = block.height(),
+                    has_chain_proof = chain_proof.is_some(),
+                );
+            }
             TransitionFrontierAction::Synced { .. } => {
                 let tip = store.state().transition_frontier.best_tip().unwrap();
 

--- a/node/src/transition_frontier/candidate/transition_frontier_candidate_reducer.rs
+++ b/node/src/transition_frontier/candidate/transition_frontier_candidate_reducer.rs
@@ -1,7 +1,6 @@
 use openmina_core::{
     block::{ArcBlockWithHash, BlockHash},
     bug_condition,
-    consensus::{is_short_range_fork, long_range_fork_take, short_range_fork_take},
 };
 use snark::block_verify::{SnarkBlockVerifyAction, SnarkBlockVerifyError, SnarkBlockVerifyId};
 
@@ -17,10 +16,8 @@ use crate::{
 };
 
 use super::{
-    ConsensusLongRangeForkDecision, ConsensusShortRangeForkDecision,
     TransitionFrontierCandidateAction, TransitionFrontierCandidateActionWithMetaRef,
-    TransitionFrontierCandidateState, TransitionFrontierCandidateStatus,
-    TransitionFrontierCandidatesState,
+    TransitionFrontierCandidateStatus, TransitionFrontierCandidatesState,
 };
 
 impl TransitionFrontierCandidatesState {
@@ -35,55 +32,55 @@ impl TransitionFrontierCandidatesState {
         let (action, meta) = action.split();
 
         match action {
-            TransitionFrontierCandidateAction::BlockReceived {
-                hash,
-                block,
-                chain_proof,
-            } => {
-                state.blocks.insert(
-                    hash.clone(),
-                    TransitionFrontierCandidateState {
-                        block: block.clone(),
-                        status: TransitionFrontierCandidateStatus::Received { time: meta.time() },
-                        chain_proof: chain_proof.clone(),
-                    },
-                );
+            TransitionFrontierCandidateAction::P2pBestTipUpdate { best_tip } => {
+                let dispatcher = state_context.into_dispatcher();
+                dispatcher.push(TransitionFrontierCandidateAction::BlockReceived {
+                    block: best_tip.clone(),
+                    chain_proof: None,
+                });
+
+                dispatcher.push(TransitionFrontierSyncLedgerSnarkedAction::PeersQuery);
+                dispatcher.push(TransitionFrontierSyncLedgerStagedAction::PartsPeerFetchInit);
+                dispatcher.push(TransitionFrontierSyncAction::BlocksPeersQuery);
+            }
+            TransitionFrontierCandidateAction::BlockReceived { block, chain_proof } => {
+                state.add(meta.time(), block.clone(), chain_proof.clone());
 
                 // Dispatch
                 let (dispatcher, state) = state_context.into_dispatcher_and_state();
 
-                let hash = hash.clone();
-                let block = ArcBlockWithHash {
-                    hash: hash.clone(),
-                    block: block.clone(),
-                };
-                let allow_block_too_late = allow_block_too_late(state, &block);
+                let allow_block_too_late = allow_block_too_late(state, block);
 
-                match state.prevalidate_block(&block, allow_block_too_late) {
+                match state.prevalidate_block(block, allow_block_too_late) {
                     Ok(()) => {
                         dispatcher.push(
-                            TransitionFrontierCandidateAction::BlockPrevalidateSuccess { hash },
+                            TransitionFrontierCandidateAction::BlockPrevalidateSuccess {
+                                hash: block.hash().clone(),
+                            },
                         );
                     }
                     Err(error) => {
                         dispatcher.push(TransitionFrontierCandidateAction::BlockPrevalidateError {
-                            hash,
+                            hash: block.hash().clone(),
                             error,
                         });
                     }
                 }
             }
+            TransitionFrontierCandidateAction::BlockPrevalidateError { hash, .. } => {
+                state.invalidate(hash);
+            }
             TransitionFrontierCandidateAction::BlockPrevalidateSuccess { hash } => {
-                let Some(block) = state.blocks.get_mut(hash) else {
+                state.update_status(hash, |_| TransitionFrontierCandidateStatus::Prevalidated);
+                let Some(block) = state.get(hash).map(|s| s.block.clone()) else {
+                    bug_condition!("TransitionFrontierCandidateAction::BlockPrevalidateSuccess block not found but action enabled");
                     return;
                 };
-                block.status = TransitionFrontierCandidateStatus::Prevalidated;
 
                 // Dispatch
-                let block = (hash.clone(), block.block.clone()).into();
                 let dispatcher = state_context.into_dispatcher();
                 dispatcher.push(SnarkBlockVerifyAction::Init {
-                    block,
+                    block: block.into(),
                     on_init: redux::callback!(
                         on_received_block_snark_verify_init((hash: BlockHash, req_id: SnarkBlockVerifyId)) -> crate::Action {
                             TransitionFrontierCandidateAction::BlockSnarkVerifyPending { hash, req_id }
@@ -98,185 +95,35 @@ impl TransitionFrontierCandidatesState {
                         }),
                 });
             }
-            TransitionFrontierCandidateAction::BlockPrevalidateError { hash, .. } => {
-                state.blocks.remove(hash);
-            }
             TransitionFrontierCandidateAction::BlockChainProofUpdate { hash, chain_proof } => {
-                if state.best_tip.as_ref() == Some(hash) {
-                    state.best_tip_chain_proof = Some(chain_proof.clone());
-                } else if let Some(block) = state.blocks.get_mut(hash) {
-                    block.chain_proof = Some(chain_proof.clone());
-                }
+                state.set_chain_proof(hash, chain_proof.clone());
 
-                let (dispatcher, global_state) = state_context.into_dispatcher_and_state();
-                if global_state
-                    .transition_frontier
-                    .candidates
-                    .best_tip
-                    .as_ref()
-                    != Some(hash)
-                {
-                    return;
-                }
-
+                let dispatcher = state_context.into_dispatcher();
                 dispatcher
                     .push(TransitionFrontierCandidateAction::TransitionFrontierSyncTargetUpdate);
             }
             TransitionFrontierCandidateAction::BlockSnarkVerifyPending { req_id, hash } => {
-                if let Some(block) = state.blocks.get_mut(hash) {
-                    block.status = TransitionFrontierCandidateStatus::SnarkVerifyPending {
+                state.update_status(hash, |_| {
+                    TransitionFrontierCandidateStatus::SnarkVerifyPending {
                         time: meta.time(),
                         req_id: *req_id,
-                    };
-                }
+                    }
+                });
+            }
+            TransitionFrontierCandidateAction::BlockSnarkVerifyError { hash, .. } => {
+                state.invalidate(hash);
             }
             TransitionFrontierCandidateAction::BlockSnarkVerifySuccess { hash } => {
-                if let Some(block) = state.blocks.get_mut(hash) {
-                    block.status =
-                        TransitionFrontierCandidateStatus::SnarkVerifySuccess { time: meta.time() };
-                }
-
-                // Dispatch
-                let hash = hash.clone();
-                let dispatcher = state_context.into_dispatcher();
-                dispatcher.push(TransitionFrontierCandidateAction::DetectForkRange { hash });
-            }
-            TransitionFrontierCandidateAction::BlockSnarkVerifyError { .. } => {
-                // TODO: handle block verification error.
-            }
-            TransitionFrontierCandidateAction::DetectForkRange { hash } => {
-                let candidate_hash = hash;
-                let Some(candidate_state) = state.blocks.get(candidate_hash) else {
-                    return;
-                };
-                let candidate = &candidate_state.block.header;
-                let (tip_hash, short_fork) = if let Some(tip_ref) = state.best_tip() {
-                    let tip = tip_ref.header;
-                    (
-                        Some(tip_ref.hash.clone()),
-                        is_short_range_fork(
-                            &candidate.protocol_state.body.consensus_state,
-                            &tip.protocol_state.body.consensus_state,
-                        ),
-                    )
-                } else {
-                    (None, true)
-                };
-                if let Some(candidate_state) = state.blocks.get_mut(candidate_hash) {
-                    candidate_state.status = TransitionFrontierCandidateStatus::ForkRangeDetected {
-                        time: meta.time(),
-                        compared_with: tip_hash,
-                        short_fork,
-                    };
-                    openmina_core::log::debug!(openmina_core::log::system_time(); kind = "ConsensusAction::DetectForkRange", status = serde_json::to_string(&candidate_state.status).unwrap());
-                }
-                openmina_core::log::debug!(openmina_core::log::system_time(); kind = "ConsensusAction::DetectForkRange");
-
-                // Dispatch
-                let hash = hash.clone();
-                let dispatcher = state_context.into_dispatcher();
-                dispatcher.push(TransitionFrontierCandidateAction::ShortRangeForkResolve {
-                    hash: hash.clone(),
+                state.update_status(hash, |_| {
+                    TransitionFrontierCandidateStatus::SnarkVerifySuccess { time: meta.time() }
                 });
-                dispatcher.push(TransitionFrontierCandidateAction::LongRangeForkResolve { hash });
-            }
-            TransitionFrontierCandidateAction::ShortRangeForkResolve { hash } => {
-                let candidate_hash = hash;
-                if let Some(candidate) = state.blocks.get(candidate_hash) {
-                    let (best_tip_hash, decision): (_, ConsensusShortRangeForkDecision) =
-                        match state.best_tip() {
-                            Some(tip) => (Some(tip.hash.clone()), {
-                                let tip_cs = &tip.header.protocol_state.body.consensus_state;
-                                let candidate_cs =
-                                    &candidate.block.header.protocol_state.body.consensus_state;
-                                let (take, why) = short_range_fork_take(
-                                    tip_cs,
-                                    candidate_cs,
-                                    tip.hash,
-                                    candidate_hash,
-                                );
-                                if take {
-                                    ConsensusShortRangeForkDecision::Take(why)
-                                } else {
-                                    ConsensusShortRangeForkDecision::Keep(why)
-                                }
-                            }),
-                            None => (None, ConsensusShortRangeForkDecision::TakeNoBestTip),
-                        };
-                    if let Some(best_tip_hash) = &best_tip_hash {
-                        openmina_core::log::info!(openmina_core::log::system_time(); best_tip_hash = best_tip_hash.to_string(), candidate_hash = candidate_hash.to_string(), decision = format!("{decision:?}"));
-                    }
-                    if let Some(candidate) = state.blocks.get_mut(candidate_hash) {
-                        if !decision.use_as_best_tip() {
-                            candidate.chain_proof = None;
-                        }
-
-                        candidate.status =
-                            TransitionFrontierCandidateStatus::ShortRangeForkResolve {
-                                time: meta.time(),
-                                compared_with: best_tip_hash,
-                                decision,
-                            };
-                    }
-                }
-
-                // Dispatch
-                let hash = hash.clone();
-                let dispatcher = state_context.into_dispatcher();
-                dispatcher.push(TransitionFrontierCandidateAction::BestTipUpdate { hash });
-            }
-            TransitionFrontierCandidateAction::LongRangeForkResolve { hash } => {
-                openmina_core::log::debug!(openmina_core::log::system_time(); kind = "ConsensusAction::LongRangeForkResolve");
-                let candidate_hash = hash;
-                let Some(tip_ref) = state.best_tip() else {
-                    return;
-                };
-                let Some(candidate_state) = state.blocks.get(candidate_hash) else {
-                    return;
-                };
-                openmina_core::log::debug!(openmina_core::log::system_time(); kind = "ConsensusAction::LongRangeForkResolve", pre_status = serde_json::to_string(&candidate_state.status).unwrap());
-                let tip_hash = tip_ref.hash.clone();
-                let tip = tip_ref.header;
-                let tip_cs = &tip.protocol_state.body.consensus_state;
-                let candidate = &candidate_state.block.header;
-                let candidate_cs = &candidate.protocol_state.body.consensus_state;
-
-                let (take, why) =
-                    long_range_fork_take(tip_cs, candidate_cs, &tip_hash, candidate_hash);
-
-                let Some(candidate_state) = state.blocks.get_mut(candidate_hash) else {
-                    return;
-                };
-                candidate_state.status = TransitionFrontierCandidateStatus::LongRangeForkResolve {
-                    time: meta.time(),
-                    compared_with: tip_hash,
-                    decision: if take {
-                        ConsensusLongRangeForkDecision::Take(why)
-                    } else {
-                        candidate_state.chain_proof = None;
-                        ConsensusLongRangeForkDecision::Keep(why)
-                    },
-                };
-                openmina_core::log::debug!(openmina_core::log::system_time(); kind = "ConsensusAction::LongRangeForkResolve", status = serde_json::to_string(&candidate_state.status).unwrap());
-
-                // Dispatch
-                let hash = hash.clone();
-                let dispatcher = state_context.into_dispatcher();
-                dispatcher.push(TransitionFrontierCandidateAction::BestTipUpdate { hash });
-            }
-            TransitionFrontierCandidateAction::BestTipUpdate { hash } => {
-                state.best_tip = Some(hash.clone());
-
-                if let Some(tip) = state.blocks.get_mut(hash) {
-                    state.best_tip_chain_proof = tip.chain_proof.take();
-                }
 
                 // Dispatch
                 let (dispatcher, global_state) = state_context.into_dispatcher_and_state();
                 let Some(block) = global_state
                     .transition_frontier
                     .candidates
-                    .best_tip_block_with_hash()
+                    .best_verified_block()
                 else {
                     return;
                 };
@@ -295,10 +142,7 @@ impl TransitionFrontierCandidatesState {
             }
             TransitionFrontierCandidateAction::TransitionFrontierSyncTargetUpdate => {
                 let (dispatcher, state) = state_context.into_dispatcher_and_state();
-                let Some(best_tip) = state
-                    .transition_frontier
-                    .candidates
-                    .best_tip_block_with_hash()
+                let Some(best_tip) = state.transition_frontier.candidates.best_verified_block()
                 else {
                     bug_condition!(
                         "ConsensusAction::TransitionFrontierSyncTargetUpdate | no chosen best tip"
@@ -309,7 +153,7 @@ impl TransitionFrontierCandidatesState {
                 let Some((blocks_inbetween, root_block)) = state
                     .transition_frontier
                     .candidates
-                    .best_tip_chain_proof(&state.transition_frontier)
+                    .best_verified_block_chain_proof(&state.transition_frontier)
                 else {
                     bug_condition!("ConsensusAction::TransitionFrontierSyncTargetUpdate | no best tip chain proof");
                     return;
@@ -322,44 +166,14 @@ impl TransitionFrontierCandidatesState {
 
                 dispatcher.push(TransitionFrontierSyncAction::BestTipUpdate {
                     previous_root_snarked_ledger_hash,
-                    best_tip,
+                    best_tip: best_tip.clone(),
                     root_block,
                     blocks_inbetween,
                     on_success: None,
                 });
             }
-            TransitionFrontierCandidateAction::P2pBestTipUpdate { best_tip } => {
-                let dispatcher = state_context.into_dispatcher();
-                dispatcher.push(TransitionFrontierCandidateAction::BlockReceived {
-                    hash: best_tip.hash.clone(),
-                    block: best_tip.block.clone(),
-                    chain_proof: None,
-                });
-
-                dispatcher.push(TransitionFrontierSyncLedgerSnarkedAction::PeersQuery);
-                dispatcher.push(TransitionFrontierSyncLedgerStagedAction::PartsPeerFetchInit);
-                dispatcher.push(TransitionFrontierSyncAction::BlocksPeersQuery);
-            }
             TransitionFrontierCandidateAction::Prune => {
-                let Some(best_tip_hash) = state.best_tip.clone() else {
-                    return;
-                };
-                let blocks = &mut state.blocks;
-
-                // keep at most latest 32 candidate blocks.
-                let blocks_to_keep = (0..32)
-                    .scan(best_tip_hash, |block_hash, _| {
-                        let block_state = blocks.remove(block_hash)?;
-                        let block_hash = match block_state.status.compared_with() {
-                            None => block_hash.clone(),
-                            Some(compared_with) => {
-                                std::mem::replace(block_hash, compared_with.clone())
-                            }
-                        };
-                        Some((block_hash, block_state))
-                    })
-                    .collect();
-                *blocks = blocks_to_keep;
+                state.prune();
             }
         }
     }

--- a/node/src/transition_frontier/candidate/transition_frontier_candidate_state.rs
+++ b/node/src/transition_frontier/candidate/transition_frontier_candidate_state.rs
@@ -1,14 +1,11 @@
-use std::collections::BTreeMap;
-use std::sync::Arc;
+use std::collections::BTreeSet;
 
-use mina_p2p_messages::v2::{
-    MinaBlockBlockStableV2, MinaBlockHeaderStableV2, StagedLedgerDiffDiffStableV2, StateHash,
-};
+use mina_p2p_messages::v2::StateHash;
 use serde::{Deserialize, Serialize};
 
-use openmina_core::block::{ArcBlockWithHash, BlockWithHash};
+use openmina_core::block::ArcBlockWithHash;
 use openmina_core::consensus::{
-    ConsensusLongRangeForkDecisionReason, ConsensusShortRangeForkDecisionReason,
+    consensus_take, ConsensusLongRangeForkDecisionReason, ConsensusShortRangeForkDecisionReason,
 };
 
 use crate::snark::block_verify::SnarkBlockVerifyId;
@@ -52,21 +49,6 @@ pub enum TransitionFrontierCandidateStatus {
     SnarkVerifySuccess {
         time: redux::Timestamp,
     },
-    ForkRangeDetected {
-        time: redux::Timestamp,
-        compared_with: Option<StateHash>,
-        short_fork: bool,
-    },
-    ShortRangeForkResolve {
-        time: redux::Timestamp,
-        compared_with: Option<StateHash>,
-        decision: ConsensusShortRangeForkDecision,
-    },
-    LongRangeForkResolve {
-        time: redux::Timestamp,
-        compared_with: StateHash,
-        decision: ConsensusLongRangeForkDecision,
-    },
 }
 
 impl TransitionFrontierCandidateStatus {
@@ -89,41 +71,63 @@ impl TransitionFrontierCandidateStatus {
     pub fn is_pending(&self) -> bool {
         matches!(self, Self::SnarkVerifyPending { .. })
     }
-
-    pub fn compared_with(&self) -> Option<&StateHash> {
-        match self {
-            Self::ShortRangeForkResolve { compared_with, .. } => compared_with.as_ref(),
-            _ => None,
-        }
-    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct TransitionFrontierCandidateState {
-    pub block: Arc<MinaBlockBlockStableV2>,
+    pub block: ArcBlockWithHash,
     pub status: TransitionFrontierCandidateStatus,
     pub chain_proof: Option<(Vec<StateHash>, ArcBlockWithHash)>,
 }
 
+impl Ord for TransitionFrontierCandidateState {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        if self.eq(other) {
+            return std::cmp::Ordering::Equal;
+        }
+        let is_candidate_better = consensus_take(
+            self.block.consensus_state(),
+            other.block.consensus_state(),
+            self.block.hash(),
+            other.block.hash(),
+        );
+        match is_candidate_better {
+            true => std::cmp::Ordering::Less,
+            false => std::cmp::Ordering::Greater,
+        }
+    }
+}
+
+impl PartialOrd for TransitionFrontierCandidateState {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Eq for TransitionFrontierCandidateState {}
+
+impl PartialEq for TransitionFrontierCandidateState {
+    fn eq(&self, other: &Self) -> bool {
+        self.block.hash() == other.block.hash()
+    }
+}
+
 impl TransitionFrontierCandidateState {
     pub fn height(&self) -> u32 {
-        self.block
-            .header
-            .protocol_state
-            .body
-            .consensus_state
-            .blockchain_length
-            .0
-             .0
+        self.block.height()
     }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct TransitionFrontierCandidatesState {
-    pub blocks: BTreeMap<StateHash, TransitionFrontierCandidateState>,
-    // TODO(binier): rename to best candidate. Best tip will be in transition_frontier state.
-    pub best_tip: Option<StateHash>,
-    pub best_tip_chain_proof: Option<(Vec<StateHash>, ArcBlockWithHash)>,
+    /// Maintains an ordered list of transition frontier Candidates,
+    /// ordered using consensus rules worst to best.
+    ordered: BTreeSet<TransitionFrontierCandidateState>,
+    /// Candidate block hashes, which failed either the prevalidation
+    /// or block proof verification. We move them here so that they
+    /// consume less memory while still preventing us from triggering
+    /// revalidation for an invalid block if we receive it on p2p again.
+    invalid: BTreeSet<StateHash>,
 }
 
 impl TransitionFrontierCandidatesState {
@@ -131,71 +135,117 @@ impl TransitionFrontierCandidatesState {
         Self::default()
     }
 
-    pub fn best_tip_block_with_hash(&self) -> Option<BlockWithHash<Arc<MinaBlockBlockStableV2>>> {
-        let hash = self.best_tip.as_ref()?;
-        let block = self.blocks.get(hash)?;
-        Some(BlockWithHash {
-            hash: hash.clone(),
-            block: block.block.clone(),
-        })
+    pub fn contains(&self, hash: &StateHash) -> bool {
+        self.invalid.contains(hash) || self.get(hash).is_some()
     }
 
-    pub fn best_tip(&self) -> Option<BlockRef<'_>> {
-        self.best_tip.as_ref().and_then(|hash| {
-            let block = self.blocks.get(hash)?;
-            Some(BlockRef {
-                hash,
-                header: &block.block.header,
-                body: &block.block.body.staged_ledger_diff,
-                status: &block.status,
-            })
-        })
+    pub(super) fn get(&self, hash: &StateHash) -> Option<&TransitionFrontierCandidateState> {
+        self.ordered.iter().rev().find(|s| s.block.hash() == hash)
     }
 
-    pub fn previous_best_tip(&self) -> Option<BlockRef<'_>> {
-        self.best_tip.as_ref().and_then(|hash| {
-            let block = self.blocks.get(hash)?;
-            let prev_hash = block.status.compared_with()?;
-            let prev = self.blocks.get(prev_hash)?;
-            Some(BlockRef {
-                hash: prev_hash,
-                header: &prev.block.header,
-                body: &prev.block.body.staged_ledger_diff,
-                status: &prev.status,
-            })
-        })
+    pub(super) fn add(
+        &mut self,
+        time: redux::Timestamp,
+        block: ArcBlockWithHash,
+        chain_proof: Option<(Vec<StateHash>, ArcBlockWithHash)>,
+    ) {
+        self.ordered.insert(TransitionFrontierCandidateState {
+            block,
+            status: TransitionFrontierCandidateStatus::Received { time },
+            chain_proof,
+        });
     }
 
-    pub fn is_candidate_decided_to_use_as_tip(&self, hash: &StateHash) -> bool {
-        let Some(candidate) = self.blocks.get(hash) else {
+    fn update(
+        &mut self,
+        hash: &StateHash,
+        update: impl FnOnce(TransitionFrontierCandidateState) -> TransitionFrontierCandidateState,
+    ) -> bool {
+        let Some(state) = self.get(hash).cloned() else {
             return false;
         };
-        match &candidate.status {
-            TransitionFrontierCandidateStatus::Received { .. } => false,
-            TransitionFrontierCandidateStatus::Prevalidated => false,
-            TransitionFrontierCandidateStatus::SnarkVerifyPending { .. } => false,
-            TransitionFrontierCandidateStatus::SnarkVerifySuccess { .. } => false,
-            TransitionFrontierCandidateStatus::ForkRangeDetected { .. } => false,
-            TransitionFrontierCandidateStatus::ShortRangeForkResolve {
-                compared_with,
-                decision,
-                ..
-            } => decision.use_as_best_tip() && &self.best_tip == compared_with,
-            TransitionFrontierCandidateStatus::LongRangeForkResolve {
-                compared_with,
-                decision,
-                ..
-            } => decision.use_as_best_tip() && self.best_tip.as_ref() == Some(compared_with),
-        }
+        self.ordered.remove(&state);
+        self.ordered.insert(update(state));
+        true
     }
 
-    pub fn best_tip_chain_proof(
+    pub(super) fn update_status(
+        &mut self,
+        hash: &StateHash,
+        update: impl FnOnce(TransitionFrontierCandidateStatus) -> TransitionFrontierCandidateStatus,
+    ) -> bool {
+        self.update(hash, move |mut state| {
+            state.status = update(state.status);
+            state
+        })
+    }
+
+    pub(super) fn invalidate(&mut self, hash: &StateHash) {
+        self.ordered.retain(|s| s.block.hash() != hash);
+        self.invalid.insert(hash.clone());
+    }
+
+    pub(super) fn set_chain_proof(
+        &mut self,
+        hash: &StateHash,
+        chain_proof: (Vec<StateHash>, ArcBlockWithHash),
+    ) -> bool {
+        self.update(hash, move |mut s| {
+            s.chain_proof = Some(chain_proof);
+            s
+        })
+    }
+
+    pub(super) fn prune(&mut self) {
+        let mut has_reached_best_candidate = false;
+        let Some(best_candidate_hash) = self.best_verified().map(|s| s.block.hash().clone()) else {
+            return;
+        };
+
+        // prune all blocks that are worse(consensus-wise) than the best
+        // verified candidate.
+        self.ordered.retain(|s| {
+            if s.block.hash() == &best_candidate_hash {
+                has_reached_best_candidate = true;
+            }
+
+            has_reached_best_candidate
+        });
+    }
+
+    pub(super) fn best(&self) -> Option<&TransitionFrontierCandidateState> {
+        self.ordered.last()
+    }
+
+    pub fn best_verified(&self) -> Option<&TransitionFrontierCandidateState> {
+        self.ordered
+            .iter()
+            .rev()
+            .find(|s| s.status.is_snark_verify_success())
+    }
+
+    pub fn is_chain_proof_needed(&self, hash: &StateHash) -> bool {
+        self.get(hash).is_some_and(|s| s.chain_proof.is_none())
+    }
+
+    pub fn best_verified_block(&self) -> Option<&ArcBlockWithHash> {
+        self.best_verified().map(|s| &s.block)
+    }
+
+    pub fn best_verified_block_chain_proof(
         &self,
         transition_frontier: &TransitionFrontierState,
     ) -> Option<(Vec<StateHash>, ArcBlockWithHash)> {
-        let best_tip = self.best_tip_block_with_hash()?;
-        let pred_hash = best_tip.pred_hash();
-        self.best_tip_chain_proof.clone().or_else(|| {
+        self.block_chain_proof(self.best_verified()?, transition_frontier)
+    }
+
+    fn block_chain_proof(
+        &self,
+        block_state: &TransitionFrontierCandidateState,
+        transition_frontier: &TransitionFrontierState,
+    ) -> Option<(Vec<StateHash>, ArcBlockWithHash)> {
+        let pred_hash = block_state.block.pred_hash();
+        block_state.chain_proof.clone().or_else(|| {
             let old_best_tip = transition_frontier.best_tip()?;
             let mut iter = transition_frontier.best_chain.iter();
             if old_best_tip.hash() == pred_hash {
@@ -213,25 +263,5 @@ impl TransitionFrontierCandidatesState {
                 None
             }
         })
-    }
-}
-
-#[derive(Serialize, Debug, Clone, Copy)]
-pub struct BlockRef<'a> {
-    pub hash: &'a StateHash,
-    pub header: &'a MinaBlockHeaderStableV2,
-    pub body: &'a StagedLedgerDiffDiffStableV2,
-    pub status: &'a TransitionFrontierCandidateStatus,
-}
-
-impl BlockRef<'_> {
-    pub fn height(&self) -> u32 {
-        self.header
-            .protocol_state
-            .body
-            .consensus_state
-            .blockchain_length
-            .0
-             .0
     }
 }

--- a/node/src/transition_frontier/sync/transition_frontier_sync_actions.rs
+++ b/node/src/transition_frontier/sync/transition_frontier_sync_actions.rs
@@ -141,8 +141,8 @@ impl redux::EnablingCondition<crate::State> for TransitionFrontierSyncAction {
                     && state
                         .transition_frontier
                         .candidates
-                        .best_tip()
-                        .is_some_and(|tip| &best_tip.hash == tip.hash)
+                        .best_verified_block()
+                        .is_some_and(|block| best_tip.hash() == block.hash())
             }
             TransitionFrontierSyncAction::BestTipUpdate {
                 best_tip,

--- a/node/src/watched_accounts/watched_accounts_actions.rs
+++ b/node/src/watched_accounts/watched_accounts_actions.rs
@@ -64,15 +64,22 @@ fn should_request_ledger_initial_state(state: &crate::State, pub_key: &NonZeroCu
     state
         .watched_accounts
         .get(pub_key)
-        .filter(|_| state.transition_frontier.candidates.best_tip.is_some())
+        .filter(|_| {
+            state
+                .transition_frontier
+                .candidates
+                .best_verified()
+                .is_some()
+        })
         .is_some_and(|a| match &a.initial_state {
             WatchedAccountLedgerInitialState::Idle { .. } => true,
             WatchedAccountLedgerInitialState::Error { .. } => true,
             WatchedAccountLedgerInitialState::Pending { block, .. } => {
-                let Some(best_tip) = state.transition_frontier.candidates.best_tip() else {
+                let Some(best_tip) = state.transition_frontier.candidates.best_verified_block()
+                else {
                     return false;
                 };
-                &block.hash != best_tip.hash
+                &block.hash != best_tip.hash()
             }
             // TODO(binier)
             WatchedAccountLedgerInitialState::Success { .. } => false,


### PR DESCRIPTION
After receiving a new block from peer, check consensus first, if it's better than the current best tip, only then proceed to do a more expensive proof verification.

re: #998 