### PR TITLE
Fix(transition_frontier/candidate): don't forever invalidate early received blocks

### DIFF
--- a/core/src/block/prevalidate.rs
+++ b/core/src/block/prevalidate.rs
@@ -22,6 +22,12 @@ pub enum BlockPrevalidationError {
     InvalidDeltaBlockChainProof,
 }
 
+impl BlockPrevalidationError {
+    pub fn is_forever_invalid(&self) -> bool {
+        !matches!(self, Self::ReceivedTooEarly { .. })
+    }
+}
+
 pub fn validate_block_timing(
     block: &ArcBlockWithHash,
     genesis: &ArcBlockWithHash,

--- a/node/src/transition_frontier/candidate/transition_frontier_candidate_reducer.rs
+++ b/node/src/transition_frontier/candidate/transition_frontier_candidate_reducer.rs
@@ -67,8 +67,8 @@ impl TransitionFrontierCandidatesState {
                     }
                 }
             }
-            TransitionFrontierCandidateAction::BlockPrevalidateError { hash, .. } => {
-                state.invalidate(hash);
+            TransitionFrontierCandidateAction::BlockPrevalidateError { hash, error } => {
+                state.invalidate(hash, error.is_forever_invalid());
             }
             TransitionFrontierCandidateAction::BlockPrevalidateSuccess { hash } => {
                 state.update_status(hash, |_| TransitionFrontierCandidateStatus::Prevalidated);
@@ -111,7 +111,7 @@ impl TransitionFrontierCandidatesState {
                 });
             }
             TransitionFrontierCandidateAction::BlockSnarkVerifyError { hash, .. } => {
-                state.invalidate(hash);
+                state.invalidate(hash, true);
             }
             TransitionFrontierCandidateAction::BlockSnarkVerifySuccess { hash } => {
                 state.update_status(hash, |_| {

--- a/node/src/transition_frontier/candidate/transition_frontier_candidate_state.rs
+++ b/node/src/transition_frontier/candidate/transition_frontier_candidate_state.rs
@@ -180,10 +180,12 @@ impl TransitionFrontierCandidatesState {
         })
     }
 
-    pub(super) fn invalidate(&mut self, hash: &StateHash) {
+    pub(super) fn invalidate(&mut self, hash: &StateHash, is_forever_invalid: bool) {
         self.ordered.retain(|s| {
             if s.block.hash() == hash {
-                self.invalid.insert(hash.clone(), s.block.global_slot());
+                if is_forever_invalid {
+                    self.invalid.insert(hash.clone(), s.block.global_slot());
+                }
                 false
             } else {
                 true


### PR DESCRIPTION
As pointed out by @tizoc , this pr: #1090 introduced a bug which would cause too early received blocks to be invalidated forever.
This pr fixes that.