### PR TITLE
Add error + backtrace to `failed_block_proof_input_HASH.binprot`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5892,6 +5892,7 @@ dependencies = [
 name = "openmina-node-common"
 version = "0.14.0"
 dependencies = [
+ "anyhow",
  "ark-ff",
  "aws-config",
  "aws-sdk-s3",

--- a/ledger/src/proofs/merge.rs
+++ b/ledger/src/proofs/merge.rs
@@ -29,7 +29,7 @@ use super::{
     step::{
         extract_recursion_challenges, InductiveRule, OptFlag, PreviousProofStatement, StepProof,
     },
-    transaction::{PlonkVerificationKeyEvals, ProofError, Prover},
+    transaction::{PlonkVerificationKeyEvals, Prover},
     util::two_u64_to_field,
     witness::Witness,
     wrap::WrapProof,
@@ -39,7 +39,7 @@ fn merge_main(
     statement: &Statement<SokDigest>,
     proofs: &[v2::LedgerProofProdStableV2; 2],
     w: &mut Witness<Fp>,
-) -> Result<(Statement<SokDigest>, Statement<SokDigest>), InvalidBigInt> {
+) -> anyhow::Result<(Statement<SokDigest>, Statement<SokDigest>)> {
     let (s1, s2) = w.exists({
         let [p1, p2] = proofs;
         let (s1, s2) = (&p1.0.statement, &p2.0.statement);
@@ -216,7 +216,7 @@ const MERGE_N_PREVIOUS_PROOFS: usize = 2;
 pub(super) fn generate_merge_proof(
     params: MergeParams,
     w: &mut Witness<Fp>,
-) -> Result<WrapProof, ProofError> {
+) -> anyhow::Result<WrapProof> {
     let MergeParams {
         statement,
         proofs,

--- a/ledger/src/proofs/mod.rs
+++ b/ledger/src/proofs/mod.rs
@@ -46,21 +46,17 @@ pub type ProverProof<F> = kimchi::proof::ProverProof<
 
 pub fn generate_tx_proof(
     params: transaction::TransactionParams,
-) -> Result<wrap::WrapProof, transaction::ProofError> {
+) -> anyhow::Result<wrap::WrapProof> {
     use {mina_hasher::Fp, witness::Witness};
     let mut w: Witness<Fp> = Witness::new::<constants::StepTransactionProof>();
     transaction::generate_tx_proof(params, &mut w)
 }
-pub fn generate_merge_proof(
-    params: merge::MergeParams,
-) -> Result<wrap::WrapProof, transaction::ProofError> {
+pub fn generate_merge_proof(params: merge::MergeParams) -> anyhow::Result<wrap::WrapProof> {
     use {mina_hasher::Fp, witness::Witness};
     let mut w: Witness<Fp> = Witness::new::<constants::StepMergeProof>();
     merge::generate_merge_proof(params, &mut w)
 }
-pub fn generate_block_proof(
-    params: block::BlockParams,
-) -> Result<wrap::WrapProof, transaction::ProofError> {
+pub fn generate_block_proof(params: block::BlockParams) -> anyhow::Result<wrap::WrapProof> {
     use {mina_hasher::Fp, witness::Witness};
     let mut w: Witness<Fp> = Witness::new::<constants::StepBlockProof>();
     block::generate_block_proof(params, &mut w)

--- a/ledger/src/proofs/prover.rs
+++ b/ledger/src/proofs/prover.rs
@@ -1,6 +1,5 @@
 use std::{borrow::Cow, str::FromStr};
 
-use ark_ff::fields::arithmetic::InvalidBigInt;
 use kimchi::{
     poly_commitment::PolyComm,
     proof::{PointEvaluations, ProofEvaluations, ProverCommitments, RecursionChallenge},
@@ -37,11 +36,12 @@ pub fn make_padded_proof_from_p2p(
         prev_evals: _, // unused
         proof,
     }: &PicklesProofProofsVerified2ReprStableV2,
-) -> Result<ProverProof<Fq>, InvalidBigInt> {
-    let of_coord =
-        |(a, b): &(BigInt, BigInt)| Ok(Pallas::of_coordinates(a.to_field()?, b.to_field()?));
+) -> anyhow::Result<ProverProof<Fq>> {
+    let of_coord = |(a, b): &(BigInt, BigInt)| -> anyhow::Result<_> {
+        Ok(Pallas::of_coordinates(a.to_field()?, b.to_field()?))
+    };
 
-    let make_poly = |poly: &(BigInt, BigInt)| {
+    let make_poly = |poly: &(BigInt, BigInt)| -> anyhow::Result<_> {
         Ok(PolyComm {
             elems: vec![of_coord(poly)?],
         })
@@ -66,7 +66,7 @@ pub fn make_padded_proof_from_p2p(
     let lr: Vec<(Pallas, Pallas)> = lr
         .iter()
         .map(|(a, b)| Ok((of_coord(a)?, of_coord(b)?)))
-        .collect::<Result<_, _>>()?;
+        .collect::<anyhow::Result<_>>()?;
 
     let delta: Pallas = of_coord(&bulletproof.delta)?;
     let z1: Fq = bulletproof.z_1.to_field()?;
@@ -83,7 +83,7 @@ pub fn make_padded_proof_from_p2p(
     // };
 
     // let to_fields = |x: &Vec<BigInt>| x.iter().map(BigInt::to_field).collect();
-    let to_pt_eval = |(first, second): &(BigInt, BigInt)| {
+    let to_pt_eval = |(first, second): &(BigInt, BigInt)| -> anyhow::Result<_> {
         Ok(PointEvaluations {
             zeta: vec![first.to_field::<Fq>()?],
             zeta_omega: vec![second.to_field::<Fq>()?],
@@ -130,7 +130,7 @@ pub fn make_padded_proof_from_p2p(
         old_bulletproof_challenges.0[1].0.clone(),
     ]);
 
-    let make_poly = |poly: &(BigInt, BigInt)| {
+    let make_poly = |poly: &(BigInt, BigInt)| -> anyhow::Result<_> {
         let point = of_coord(poly)?;
         Ok(PolyComm { elems: vec![point] })
     };

--- a/ledger/src/proofs/public_input/prepared_statement.rs
+++ b/ledger/src/proofs/public_input/prepared_statement.rs
@@ -1,4 +1,4 @@
-use ark_ff::{fields::arithmetic::InvalidBigInt, BigInteger256, Zero};
+use ark_ff::{BigInteger256, Zero};
 use mina_curves::pasta::Fq;
 use mina_hasher::Fp;
 use mina_p2p_messages::v2::{
@@ -51,7 +51,7 @@ pub struct PreparedStatement {
 impl PreparedStatement {
     /// Implementation of `tock_unpadded_public_input_of_statement`
     /// https://github.com/MinaProtocol/mina/blob/32a91613c388a71f875581ad72276e762242f802/src/lib/pickles/common.ml#L202
-    pub fn to_public_input(&self, npublic_input: usize) -> Result<Vec<Fq>, InvalidBigInt> {
+    pub fn to_public_input(&self, npublic_input: usize) -> anyhow::Result<Vec<Fq>> {
         let PreparedStatement {
             proof_state:
                 ProofState {
@@ -186,7 +186,7 @@ impl PreparedStatement {
         &self,
         hack_feature_flags: OptFlag,
         npublic_input: usize,
-    ) -> Result<Vec<Packed>, InvalidBigInt> {
+    ) -> anyhow::Result<Vec<Packed>> {
         let PreparedStatement {
             proof_state:
                 ProofState {

--- a/ledger/src/proofs/step.rs
+++ b/ledger/src/proofs/step.rs
@@ -17,6 +17,7 @@ use crate::{
     },
     verifier::{get_srs, get_srs_mut},
 };
+use anyhow::Context;
 use ark_ff::{fields::arithmetic::InvalidBigInt, BigInteger256, One, Zero};
 use ark_poly::{
     univariate::DensePolynomial, EvaluationDomain, Radix2EvaluationDomain, UVPolynomial,
@@ -52,7 +53,7 @@ use super::{
         create_proof, make_group, messages_for_next_wrap_proof_padding,
         scalar_challenge::to_field_checked, Check, CircuitPlonkVerificationKeyEvals,
         CreateProofParams, InnerCurve, MessagesForNextStepProof, PlonkVerificationKeyEvals,
-        ProofError, ProofWithPublic, Prover, ReducedMessagesForNextStepProof, StepStatement,
+        ProofWithPublic, Prover, ReducedMessagesForNextStepProof, StepStatement,
     },
     unfinalized::{evals_from_p2p, AllEvals, EvalsWithPublicInput, Unfinalized},
     util::{extract_bulletproof, two_u64_to_field},
@@ -336,7 +337,6 @@ pub mod step_verifier {
             MakeScalarsEnvParams, PERMUTS_MINUS_1_ADD_N1,
         },
     };
-    use ark_ff::fields::arithmetic::InvalidBigInt;
     use itertools::Itertools;
     use kimchi::circuits::wires::PERMUTS;
     use poly_commitment::{srs::SRS, PolyComm};
@@ -532,7 +532,7 @@ pub mod step_verifier {
     pub(super) fn finalize_other_proof(
         params: FinalizeOtherProofParams,
         w: &mut Witness<Fp>,
-    ) -> Result<(Boolean, Vec<Fp>), InvalidBigInt> {
+    ) -> anyhow::Result<(Boolean, Vec<Fp>)> {
         let FinalizeOtherProofParams {
             max_proof_verified,
             feature_flags: _,
@@ -1387,7 +1387,7 @@ pub mod step_verifier {
     fn check_bulletproof(
         params: CheckBulletProofParams,
         w: &mut Witness<Fp>,
-    ) -> Result<(Boolean, Vec<Fp>), InvalidBigInt> {
+    ) -> anyhow::Result<(Boolean, Vec<Fp>)> {
         let CheckBulletProofParams {
             pcs_batch: _,
             mut sponge,
@@ -1550,7 +1550,7 @@ pub mod step_verifier {
     fn incrementally_verify_proof(
         params: IncrementallyVerifyProofParams,
         w: &mut Witness<Fp>,
-    ) -> Result<(Fp, (Boolean, Vec<Fp>)), InvalidBigInt> {
+    ) -> anyhow::Result<(Fp, (Boolean, Vec<Fp>))> {
         let IncrementallyVerifyProofParams {
             proofs_verified: _,
             srs,
@@ -1707,10 +1707,7 @@ pub mod step_verifier {
         pub(super) unfinalized: &'a Unfinalized,
     }
 
-    pub(super) fn verify(
-        params: VerifyParams,
-        w: &mut Witness<Fp>,
-    ) -> Result<Boolean, InvalidBigInt> {
+    pub(super) fn verify(params: VerifyParams, w: &mut Witness<Fp>) -> anyhow::Result<Boolean> {
         let VerifyParams {
             srs,
             feature_flags: _,
@@ -1800,10 +1797,7 @@ struct VerifyOneParams<'a> {
     should_verify: CircuitVar<Boolean>,
 }
 
-fn verify_one(
-    params: VerifyOneParams,
-    w: &mut Witness<Fp>,
-) -> Result<(Vec<Fp>, Boolean), InvalidBigInt> {
+fn verify_one(params: VerifyOneParams, w: &mut Witness<Fp>) -> anyhow::Result<(Vec<Fp>, Boolean)> {
     let VerifyOneParams {
         srs,
         proof,
@@ -1931,7 +1925,7 @@ pub struct ExpandDeferredParams<'a> {
     pub zk_rows: u64,
 }
 
-pub fn expand_deferred(params: ExpandDeferredParams) -> Result<DeferredValues<Fp>, InvalidBigInt> {
+pub fn expand_deferred(params: ExpandDeferredParams) -> anyhow::Result<DeferredValues<Fp>> {
     let ExpandDeferredParams {
         evals,
         old_bulletproof_challenges,
@@ -1950,11 +1944,11 @@ pub fn expand_deferred(params: ExpandDeferredParams) -> Result<DeferredValues<Fp
     let step_domain: u8 = proof_state.deferred_values.branch_data.domain_log2.as_u8();
 
     let Some(num_coeffs) = 1u64.checked_shl(step_domain as u32) else {
-        return Err(InvalidBigInt);
+        return Err(InvalidBigInt)?;
     };
 
     let Some(domain) = Radix2EvaluationDomain::<Fp>::new(num_coeffs as usize) else {
-        return Err(InvalidBigInt);
+        return Err(InvalidBigInt)?;
     };
 
     let zetaw = zeta * domain.group_gen;
@@ -2123,7 +2117,7 @@ struct ExpandProofParams<'a> {
     zk_rows: u64,
 }
 
-fn expand_proof(params: ExpandProofParams) -> Result<ExpandedProof, InvalidBigInt> {
+fn expand_proof(params: ExpandProofParams) -> anyhow::Result<ExpandedProof> {
     let ExpandProofParams {
         dlog_vk,
         dlog_plonk_index,
@@ -2233,7 +2227,7 @@ fn expand_proof(params: ExpandProofParams) -> Result<ExpandedProof, InvalidBigIn
                     y.to_field()?,
                 )))
             })
-            .collect::<Result<_, _>>()?,
+            .collect::<Result<_, InvalidBigInt>>()?,
         old_bulletproof_challenges: old_bulletproof_challenges.clone(),
     }
     .hash();
@@ -2379,7 +2373,7 @@ fn expand_proof(params: ExpandProofParams) -> Result<ExpandedProof, InvalidBigIn
                 .challenge_polynomial_commitments
                 .iter()
                 .map(|(x, y)| Ok(make_group::<Fp>(x.to_field()?, y.to_field()?)))
-                .collect::<Result<Vec<_>, _>>()?;
+                .collect::<Result<Vec<_>, InvalidBigInt>>()?;
 
             while challenge_polynomial_commitments.len() < 2 {
                 challenge_polynomial_commitments.insert(0, dummy_ipa_wrap_sg());
@@ -2652,17 +2646,18 @@ impl Check<Fp> for PerProofWitness {
 
 pub fn extract_recursion_challenges<const N: usize>(
     proofs: &[&v2::PicklesProofProofsVerified2ReprStableV2; N],
-) -> Result<Vec<RecursionChallenge<GroupAffine<Fq>>>, InvalidBigInt> {
+) -> anyhow::Result<Vec<RecursionChallenge<GroupAffine<Fq>>>> {
     use poly_commitment::PolyComm;
 
-    let comms: [(Fq, Fq); N] = crate::try_array_into_with(proofs, |proof| {
-        let (a, b) = &proof
-            .statement
-            .proof_state
-            .messages_for_next_wrap_proof
-            .challenge_polynomial_commitment;
-        Ok((a.to_field::<Fq>()?, b.to_field::<Fq>()?))
-    })?;
+    let comms: [(Fq, Fq); N] =
+        crate::try_array_into_with(proofs, |proof| -> Result<_, InvalidBigInt> {
+            let (a, b) = &proof
+                .statement
+                .proof_state
+                .messages_for_next_wrap_proof
+                .challenge_polynomial_commitment;
+            Ok((a.to_field::<Fq>()?, b.to_field::<Fq>()?))
+        })?;
 
     let challs = proofs
         .iter()
@@ -2720,7 +2715,7 @@ pub struct StepProof {
 pub fn step<C: ProofConstants, const N_PREVIOUS: usize>(
     params: StepParams<N_PREVIOUS>,
     w: &mut Witness<Fp>,
-) -> Result<StepProof, ProofError> {
+) -> anyhow::Result<StepProof> {
     let StepParams {
         app_state,
         rule,
@@ -2759,7 +2754,8 @@ pub fn step<C: ProofConstants, const N_PREVIOUS: usize>(
                 zk_rows: data.zk_rows,
             })
         })
-        .collect::<Result<Vec<_>, _>>()?
+        .collect::<Result<Vec<_>, _>>()
+        .context("expand_proof")?
         .try_into()
         .unwrap();
 
@@ -2854,7 +2850,8 @@ pub fn step<C: ProofConstants, const N_PREVIOUS: usize>(
                 Ok(chals.try_into().unwrap()) // Never fail, we know it's 16
             },
         )
-        .collect::<Result<Vec<[Fp; 16]>, InvalidBigInt>>()?;
+        .collect::<Result<Vec<[Fp; 16]>, anyhow::Error>>()
+        .context("verify_one")?;
 
     std::mem::drop(srs);
 
@@ -2897,7 +2894,8 @@ pub fn step<C: ProofConstants, const N_PREVIOUS: usize>(
             only_verify_constraints,
         },
         w,
-    )?;
+    )
+    .context("create_proof")?;
 
     let proofs: [&v2::PicklesProofProofsVerified2ReprStableV2; N_PREVIOUS] = rule
         .previous_proof_statements
@@ -2920,7 +2918,8 @@ pub fn step<C: ProofConstants, const N_PREVIOUS: usize>(
                 },
             })
         })
-        .collect::<Result<Vec<_>, InvalidBigInt>>()?;
+        .collect::<anyhow::Result<Vec<_>>>()
+        .context("prev_evals")?;
 
     let challenge_polynomial_commitments = expanded_proofs
         .iter()
@@ -2940,7 +2939,8 @@ pub fn step<C: ProofConstants, const N_PREVIOUS: usize>(
                 messages_for_next_wrap_proof,
             ))
         })
-        .collect::<Result<Vec<_>, InvalidBigInt>>()? // TODO: Refactor when `try_unzip` is stable
+        .collect::<Result<Vec<_>, InvalidBigInt>>() // TODO: Refactor when `try_unzip` is stable
+        .context("unzip proof state")?
         .into_iter()
         .unzip();
 

--- a/ledger/src/proofs/unfinalized.rs
+++ b/ledger/src/proofs/unfinalized.rs
@@ -177,7 +177,7 @@ impl<F: FieldWitness> TryFrom<&v2::PicklesProofProofsVerified2ReprStableV2PrevEv
 /// Equivalent of `to_kimchi` in OCaml
 pub fn evals_from_p2p<F: FieldWitness>(
     e: &v2::PicklesWrapWireProofEvaluationsStableV1,
-) -> Result<ProofEvaluations<PointEvaluations<Vec<F>>>, InvalidBigInt> {
+) -> anyhow::Result<ProofEvaluations<PointEvaluations<Vec<F>>>> {
     let v2::PicklesWrapWireProofEvaluationsStableV1 {
         w,
         coefficients,
@@ -193,12 +193,13 @@ pub fn evals_from_p2p<F: FieldWitness>(
 
     use mina_p2p_messages::bigint::BigInt;
 
-    let of = |(zeta, zeta_omega): &(BigInt, BigInt)| -> Result<PointEvaluations<Vec<F>>, _> {
-        Ok(PointEvaluations {
-            zeta: vec![zeta.to_field()?],
-            zeta_omega: vec![zeta_omega.to_field()?],
-        })
-    };
+    let of =
+        |(zeta, zeta_omega): &(BigInt, BigInt)| -> Result<PointEvaluations<Vec<F>>, InvalidBigInt> {
+            Ok(PointEvaluations {
+                zeta: vec![zeta.to_field()?],
+                zeta_omega: vec![zeta_omega.to_field()?],
+            })
+        };
 
     use std::array;
     Ok(ProofEvaluations {

--- a/ledger/src/proofs/verification.rs
+++ b/ledger/src/proofs/verification.rs
@@ -673,7 +673,7 @@ fn run_checks(
 
 fn compute_deferred_values(
     proof: &PicklesProofProofsVerified2ReprStableV2,
-) -> Result<DeferredValues<Fp>, InvalidBigInt> {
+) -> anyhow::Result<DeferredValues<Fp>> {
     let bulletproof_challenges: Vec<Fp> = proof
         .statement
         .proof_state
@@ -837,7 +837,7 @@ fn verify_impl<AppState>(
     app_state: &AppState,
     proof: &PicklesProofProofsVerified2ReprStableV2,
     vk: &VK,
-) -> Result<bool, InvalidBigInt>
+) -> anyhow::Result<bool>
 where
     AppState: ToFieldElements<Fp>,
 {
@@ -875,7 +875,7 @@ where
 
 fn batch_verify_impl<AppState>(
     proofs: &[(&AppState, &PicklesProofProofsVerified2ReprStableV2, &VK)],
-) -> Result<bool, InvalidBigInt>
+) -> anyhow::Result<bool>
 where
     AppState: ToFieldElements<Fp>,
 {

--- a/ledger/src/proofs/wrap.rs
+++ b/ledger/src/proofs/wrap.rs
@@ -48,7 +48,7 @@ use super::{
     step::{step_verifier::PlonkDomain, FeatureFlags},
     to_field_elements::{ToFieldElements, ToFieldElementsDebug},
     transaction::{
-        plonk_curve_ops::scale_fast, Check, PlonkVerificationKeyEvals, ProofError, Prover,
+        plonk_curve_ops::scale_fast, Check, PlonkVerificationKeyEvals, Prover,
         ReducedMessagesForNextStepProof, StepProofState, StepStatement,
     },
     unfinalized::{AllEvals, EvalsWithPublicInput},
@@ -540,7 +540,7 @@ fn exists_prev_statement(
     step_statement: &StepStatement,
     messages_for_next_step_proof_hash: [u64; 4],
     w: &mut Witness<Fq>,
-) -> Result<(), InvalidBigInt> {
+) -> anyhow::Result<()> {
     for unfinalized in &step_statement.proof_state.unfinalized_proofs {
         w.exists_no_check(unfinalized);
     }
@@ -593,7 +593,7 @@ pub struct WrapParams<'a> {
 pub fn wrap<C: ProofConstants + ForWrapData>(
     params: WrapParams,
     w: &mut Witness<Fq>,
-) -> Result<WrapProof, ProofError> {
+) -> anyhow::Result<WrapProof> {
     use crate::proofs::public_input::scalar_challenge::ScalarChallenge;
 
     let WrapParams {
@@ -2653,7 +2653,7 @@ fn pack_statement(
     statement: &StepStatementWithHash,
     messages_for_next_step_proof_hash: &[u64; 4],
     w: &mut Witness<Fq>,
-) -> Result<Vec<Packed<Boolean>>, InvalidBigInt> {
+) -> anyhow::Result<Vec<Packed<Boolean>>> {
     let StepStatementWithHash {
         proof_state:
             StepProofState {
@@ -2788,7 +2788,7 @@ struct WrapMainParams<'a> {
     step_prover_index: &'a ProverIndex<Fp>,
 }
 
-fn wrap_main(params: WrapMainParams, w: &mut Witness<Fq>) -> Result<(), InvalidBigInt> {
+fn wrap_main(params: WrapMainParams, w: &mut Witness<Fq>) -> anyhow::Result<()> {
     let WrapMainParams {
         step_statement,
         next_statement,

--- a/ledger/src/proofs/zkapp.rs
+++ b/ledger/src/proofs/zkapp.rs
@@ -68,7 +68,7 @@ use super::{
     },
     provers::devnet_circuit_directory,
     to_field_elements::ToFieldElements,
-    transaction::{dummy_constraints, Check, ProofError, Prover},
+    transaction::{dummy_constraints, Check, Prover},
     witness::Witness,
     wrap::WrapProof,
 };
@@ -1310,7 +1310,7 @@ fn of_zkapp_command_segment_exn<StepConstants, WrapConstants>(
     tx_wrap_prover: &Prover<Fq>,
     fps_path: Option<String>,
     fqs_path: Option<String>,
-) -> Result<LedgerProof, ProofError>
+) -> anyhow::Result<LedgerProof>
 where
     StepConstants: ProofConstants,
     WrapConstants: ProofConstants + ForWrapData,
@@ -1659,7 +1659,7 @@ fn of_zkapp_command_segment(
     tx_wrap_prover: &Prover<Fq>,
     opt_signed_path: Option<&str>,
     proved_path: Option<&str>,
-) -> Result<LedgerProof, ProofError> {
+) -> anyhow::Result<LedgerProof> {
     let (step_prover, step_path, wrap_path) = match spec {
         SegmentBasic::OptSignedOptSigned => (step_opt_signed_opt_signed_prover, None, None),
         SegmentBasic::OptSigned => {
@@ -1697,7 +1697,7 @@ fn of_zkapp_command_segment(
     )
 }
 
-pub fn generate_zkapp_proof(params: ZkappParams) -> Result<LedgerProof, ProofError> {
+pub fn generate_zkapp_proof(params: ZkappParams) -> anyhow::Result<LedgerProof> {
     let ZkappParams {
         statement,
         tx_witness,
@@ -1792,7 +1792,7 @@ fn merge_zkapp_proofs(
     message: &SokMessage,
     merge_step_prover: &Prover<Fp>,
     tx_wrap_prover: &Prover<Fq>,
-) -> Result<LedgerProof, ProofError> {
+) -> anyhow::Result<LedgerProof> {
     let merged_statement = prev
         .statement
         .clone()

--- a/node/common/Cargo.toml
+++ b/node/common/Cargo.toml
@@ -22,6 +22,7 @@ ark-ff = { workspace = true }
 binprot = { git = "https://github.com/openmina/binprot-rs", rev = "400b52c" }
 binprot_derive = { git = "https://github.com/openmina/binprot-rs", rev = "400b52c" }
 bitflags = "2.8.0"
+anyhow = "1"
 
 node = { path = "../../node", features = ["replay"] }
 openmina-core = { path = "../../core" }

--- a/node/testing/src/service/mod.rs
+++ b/node/testing/src/service/mod.rs
@@ -539,7 +539,12 @@ impl BlockProducerService for NodeTestingService {
                     &keypair,
                     true,
                 ) {
-                    Err(ProofError::ConstraintsOk) => {
+                    Err(e)
+                        if matches!(
+                            e.downcast_ref::<ProofError>(),
+                            Some(ProofError::ConstraintsOk)
+                        ) =>
+                    {
                         let _ = self.real.event_sender().send(dummy_proof_event(block_hash));
                     }
                     Err(err) => panic!("unexpected block proof generation error: {err:?}"),


### PR DESCRIPTION
To debug block proof generation