### PR TITLE
fix(ci): When building the docker image, fetch the current tag 

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -33,6 +33,11 @@ jobs:
 
       - name: Git checkout
         uses: actions/checkout@v3
+      
+      # This is needed so that we can get the current version with vergen
+      - name: Fetch tag for current commit
+        run: |
+          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3


### PR DESCRIPTION
Needed to produce a version from git tag when building the docker images.