### PR TITLE
Fix WebNode: tokio channels sometimes panic when used in wasm main browser context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2719,12 +2719,13 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
+ "nanorand",
  "spin 0.9.8",
 ]
 
@@ -5237,6 +5238,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5802,6 +5812,7 @@ dependencies = [
  "binprot_derive",
  "bs58 0.4.0",
  "crypto_secretbox",
+ "flume",
  "graphannis-malloc_size_of",
  "graphannis-malloc_size_of_derive",
  "hex",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,6 +17,7 @@ binprot_derive = { git = "https://github.com/openmina/binprot-rs", rev = "400b52
 rand = "0.8.0"
 redux = { workspace = true }
 tokio = { version = "1.26", features = ["sync"] }
+flume = { version = "0.11.1", features = ["async", "spin"] }
 time = { version = "0.3", features = ["formatting", "macros", "parsing"] }
 md5 = "0.7.0"
 multihash = { version = "0.18.1", features = ["blake2b"] }

--- a/node/testing/src/cluster/p2p_task_spawner.rs
+++ b/node/testing/src/cluster/p2p_task_spawner.rs
@@ -1,14 +1,14 @@
-use node::core::channels::mpsc;
 use node::core::thread;
 use node::p2p::service_impl::TaskSpawner;
+use openmina_core::channels::Aborted;
 
 #[derive(Clone)]
 pub struct P2pTaskSpawner {
-    shutdown: mpsc::Sender<()>,
+    shutdown: Aborted,
 }
 
 impl P2pTaskSpawner {
-    pub fn new(shutdown: mpsc::Sender<()>) -> Self {
+    pub fn new(shutdown: Aborted) -> Self {
         Self { shutdown }
     }
 }
@@ -28,7 +28,7 @@ impl TaskSpawner for P2pTaskSpawner {
             .spawn(move || {
                 let fut = async {
                     tokio::select! {
-                        _ = shutdown.closed() => {}
+                        _ = shutdown.wait() => {}
                         _ = fut => {}
                     }
                 };

--- a/node/testing/src/service/mod.rs
+++ b/node/testing/src/service/mod.rs
@@ -53,6 +53,7 @@ use node::{
     },
 };
 use node::{ActionWithMeta, State};
+use openmina_core::channels::Aborter;
 use openmina_node_native::NodeService;
 use redux::Instant;
 
@@ -141,7 +142,7 @@ pub struct NodeTestingService {
 
     cluster_invariants_state: Arc<StdMutex<InvariantsState>>,
     /// Once dropped, it will cause all threads associated to shutdown.
-    _shutdown: mpsc::Receiver<()>,
+    _shutdown: Aborter,
 }
 
 impl NodeTestingService {
@@ -149,7 +150,7 @@ impl NodeTestingService {
         real: NodeService,
         id: ClusterNodeId,
         cluster_invariants_state: Arc<StdMutex<InvariantsState>>,
-        _shutdown: mpsc::Receiver<()>,
+        _shutdown: Aborter,
     ) -> Self {
         Self {
             real,

--- a/p2p/testing/src/rust_node.rs
+++ b/p2p/testing/src/rust_node.rs
@@ -73,14 +73,14 @@ impl RustNodeConfig {
 
 pub struct RustNode {
     store: Store,
-    event_receiver: mpsc::UnboundedReceiver<P2pEvent>,
+    event_receiver: mpsc::RecvStream<P2pEvent>,
 }
 
 impl RustNode {
     pub(super) fn new(store: Store, event_receiver: mpsc::UnboundedReceiver<P2pEvent>) -> Self {
         RustNode {
             store,
-            event_receiver,
+            event_receiver: event_receiver.stream(),
         }
     }
 
@@ -109,7 +109,7 @@ impl RustNode {
     }
 
     fn poll_event_receiver(&mut self, cx: &mut Context<'_>) -> Poll<Option<RustNodeEvent>> {
-        let event = ready!(Pin::new(&mut self.event_receiver).poll_recv(cx));
+        let event = ready!(Pin::new(&mut self.event_receiver).poll_next(cx));
         Poll::Ready(event.map(|event| {
             self.dispatch_event(event.clone());
             RustNodeEvent::P2p { event }


### PR DESCRIPTION
fixes: #1116 

Replaces `tokio::sync::mpsc` with [flume](https://github.com/zesterer/flume/).