### PR TITLE
fix(vrf-evaluator): Fix interruption of won slots search at epoch boundaries

### DIFF
--- a/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_actions.rs
+++ b/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_actions.rs
@@ -105,6 +105,7 @@ pub enum BlockProducerVrfEvaluatorAction {
     /// Epoch evaluation finished.
     #[action_event(level = info, fields(epoch_number, latest_evaluated_global_slot))]
     FinishEpochEvaluation {
+        /// The evaluated epoch number.
         epoch_number: u32,
         latest_evaluated_global_slot: u32,
     },

--- a/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_reducer.rs
+++ b/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_reducer.rs
@@ -424,7 +424,7 @@ impl BlockProducerVrfEvaluatorState {
                     time: meta.time(),
                     epoch_number: *epoch_number,
                 };
-                state.set_last_evaluated_epoch();
+                state.set_last_evaluated_epoch(*epoch_number);
             }
             BlockProducerVrfEvaluatorAction::WaitForNextEvaluation => {
                 state.status =

--- a/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_state.rs
+++ b/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_state.rs
@@ -277,18 +277,8 @@ impl BlockProducerVrfEvaluatorState {
 
     pub fn initialize_evaluator(&mut self, _epoch: u32, _last_height: u32) {}
 
-    pub fn set_last_evaluated_epoch(&mut self) {
-        if let BlockProducerVrfEvaluatorStatus::EpochEvaluationSuccess { epoch_number, .. } =
-            &self.status
-        {
-            match self.epoch_context {
-                EpochContext::Current(_) => self.last_evaluated_epoch = Some(*epoch_number),
-                EpochContext::Next(_) => {
-                    self.last_evaluated_epoch = Some(epoch_number.checked_add(1).expect("overflow"))
-                }
-                EpochContext::Waiting => {}
-            }
-        }
+    pub fn set_last_evaluated_epoch(&mut self, epoch_number: u32) {
+        self.last_evaluated_epoch = Some(epoch_number);
     }
 
     pub fn initial_slot(&self) -> Option<u32> {


### PR DESCRIPTION
This caused the epoch evaluation readiness check to incorrectly assume that the next epoch had already been evaluating, preventing won slot search from running.