### PR TITLE
fix(p2p): Do not fail when an initial peer address cannot be resolved

### DIFF
--- a/node/testing/src/hosts.rs
+++ b/node/testing/src/hosts.rs
@@ -23,6 +23,7 @@ pub fn devnet() -> Vec<ListenerNode> {
         .split_whitespace()
         .map(P2pConnectionOutgoingInitOpts::from_str)
         .filter_map(Result::ok)
+        .filter_map(|p| p.with_host_resolved())
         .map(Into::into)
         .collect()
 }


### PR DESCRIPTION
Don't perform DNS resolution during parsing, instead perform all name resolutions when building the list, and skip peers for which the address cannot be resolved.