### PR TITLE
CI: remove usage of ubuntu arm64

### DIFF
--- a/.github/workflows/docker-heartbeats-processor.yaml
+++ b/.github/workflows/docker-heartbeats-processor.yaml
@@ -18,7 +18,7 @@ jobs:
           - platform: linux/amd64
             runs-on: ubuntu-latest
           - platform: linux/arm64
-            runs-on: ubuntu-arm64
+            runs-on: ubuntu-24.04-arm
     runs-on: ${{ matrix.arch.runs-on }}
     steps:
       - name: Prepare

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Git checkout
         uses: actions/checkout@v3
-      
+
       # This is needed so that we can get the current version with vergen
       - name: Fetch tag for current commit
         run: |

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -23,7 +23,7 @@ jobs:
           - platform: linux/amd64
             runs-on: ubuntu-latest
           - platform: linux/arm64
-            runs-on: ubuntu-arm64
+            runs-on: ubuntu-24.04-arm
     runs-on: ${{ matrix.arch.runs-on }}
     steps:
       - name: Prepare
@@ -125,7 +125,7 @@ jobs:
           - platform: linux/amd64
             runs-on: ubuntu-latest
           - platform: linux/arm64
-            runs-on: ubuntu-arm64
+            runs-on: ubuntu-24.04-arm
         configuration:
           - build_configuration: production
     runs-on: ${{ matrix.arch.runs-on }}


### PR DESCRIPTION
Runners called ubuntu-24.04-arm is now available for free, instead of ubuntu-arm64, which might have a cost, see
![image](https://github.com/user-attachments/assets/943afc70-8fe3-4197-902b-b48ca1f70fe0)
and the cost in GH team.