### PR TITLE
Update lint.yml actions to latest versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,30 +10,20 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup build dependencies
         run: |
           sudo apt update
           sudo apt install -y protobuf-compiler
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.84
           components: rustfmt, clippy
-          default: true
-      - uses: actions-rs/cargo@v1
-        name: rustfmt
-        with:
-          command: fmt
-          args: --all -- --check
-      - uses: actions-rs/cargo@v1
-        name: check
-        with:
-          command: check
-          args: --all-targets
+      - name: rustfmt
+        run: cargo fmt --all -- --check
+      - name: check
+        run: cargo check --all-targets
         env:
           RUSTFLAGS: -D warnings
-      - uses: actions-rs/clippy-check@v1
-        name: clippy
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-targets -- -D warnings --allow clippy::mutable_key_type
+      - name: clippy
+        run: cargo clippy --all-targets -- -D warnings --allow clippy::mutable_key_type


### PR DESCRIPTION
- Update actions/checkout@v2 to v4
- Replace deprecated actions-rs/toolchain@v1 with dtolnay/rust-toolchain@stable
- Replace actions-rs/cargo@v1 with direct cargo commands
- Replace actions-rs/clippy-check@v1 with direct clippy command