### PR TITLE
CI/Docker: remove login in + push to Dockerhub related steps

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -34,13 +34,6 @@ jobs:
         run: |
           git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        if: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/')) && github.event_name == 'push' }}
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -53,15 +46,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           outputs: type=image,name=${{ env.REGISTRY_NODE_IMAGE }},push-by-digest=true,name-canonical=true,push=false
-
-      - name: Push Docker image by digest
-        if: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/')) && github.event_name == 'push' }}
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: ${{ matrix.arch.platform }}
-          cache-from: type=gha
-          outputs: type=image,name=${{ env.REGISTRY_NODE_IMAGE }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
         run: |
@@ -77,53 +61,7 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  merge-openmina-node-image:
-    runs-on: ubuntu-latest
-    if: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/')) && github.event_name == 'push' }}
-    needs:
-      - build-openmina-node-image
-    steps:
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/digests
-          pattern: node-digests-*
-          merge-multiple: true
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY_NODE_IMAGE }}
-          # generate Docker tags based on the following events/attributes
-          tags: |
-            type=ref,event=branch
-            type=sha,format=short
-            type=semver,pattern={{version}},event=tag
-            type=ref,event=tag
-            type=raw,value=latest,enable=${{ github.ref_name == 'main' }}
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
-      - name: Create manifest list and push
-        working-directory: /tmp/digests
-        run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY_NODE_IMAGE }}@sha256:%s ' *)
-
-      - name: Inspect image
-        run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY_NODE_IMAGE }}:${{ steps.meta.outputs.version }}
-
   # Frontend
-
   build-openmina-frontend-image:
     strategy:
       matrix:
@@ -144,13 +82,6 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v4
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        if: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/')) && github.event_name == 'push' }}
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -166,17 +97,6 @@ jobs:
           cache-to: type=gha,mode=max
           outputs: type=image,name=${{ env.REGISTRY_FRONTEND_IMAGE }},push-by-digest=true,name-canonical=true,push=false
 
-      - name: Push Docker image by digest
-        if: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/')) && github.event_name == 'push' }}
-        uses: docker/build-push-action@v6
-        with:
-          context: ./frontend
-          platforms: ${{ matrix.arch.platform }}
-          build-args: |
-            BUILD_CONFIGURATION=${{ matrix.configuration.build_configuration }}
-          cache-from: type=gha
-          outputs: type=image,name=${{ env.REGISTRY_FRONTEND_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-
       - name: Export digest
         run: |
           mkdir -p /tmp/digests
@@ -190,52 +110,3 @@ jobs:
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
-
-  merge-openmina-frontend-image:
-    strategy:
-      matrix:
-        configuration:
-          - build_configuration: production
-    runs-on: ubuntu-latest
-    if: ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/')) && github.event_name == 'push' }}
-    needs:
-      - build-openmina-frontend-image
-    steps:
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/digests
-          pattern: frontend-${{ matrix.configuration.build_configuration }}-digests-*
-          merge-multiple: true
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY_FRONTEND_IMAGE }}
-          tags: |
-            type=ref,event=branch
-            type=sha,format=short
-            type=semver,pattern={{version}},event=tag
-            type=ref,event=tag
-            type=raw,value=latest,enable=${{ github.ref_name == 'main' }}
-            type=raw,value=staging,enable=${{ github.ref_name == 'develop' }}
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
-      - name: Create manifest list and push
-        working-directory: /tmp/digests
-        run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY_FRONTEND_IMAGE }}@sha256:%s ' *)
-
-      - name: Inspect image
-        run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY_FRONTEND_IMAGE }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
We did remove the Dockerhub credentials, and we will reintroduce the steps when #1186, #1205, #1204, https://github.com/o1-labs/openmina/issues/1192 will have been decided/done.

We only build the docker images for now, for each commit. We don't want to push anywhere, even if deactivated. I prefer to remove the steps and reintroduce it later, with @dkijania and Luis taste.