### PR TITLE
Fix build script to avoid unnecessary action_kind.rs regeneration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,3 +130,12 @@ Each component directory contains a `summary.md` file documenting:
 - `docs/handover/` - Comprehensive architecture documentation
 - `ARCHITECTURE.md` - Migration guide for old vs new style
 - Component-specific `summary.md` files throughout the codebase
+
+## Commit Guidelines
+
+**IMPORTANT**: When creating commits, NEVER include AI tool generation messages such as:
+- "Generated with [Claude Code]"
+- "Co-Authored-By: Claude"
+- Any other AI tool attribution
+
+Always review commit messages before pushing to ensure they contain only project-relevant information.

--- a/node/build.rs
+++ b/node/build.rs
@@ -106,6 +106,11 @@ fn main() -> Result<(), Box<dyn Error>> {
         .all_rustc()
         .emit_and_set()?;
 
+    // Tell cargo when to rerun this build script
+    println!("cargo:rerun-if-changed=build.rs");
+    // Rerun if any action files change (they end with *_actions.rs or action.rs)
+    println!("cargo:rerun-if-changed=src");
+
     let crate_dir_name = std::env::var("CARGO_MANIFEST_DIR")?;
     let crate_dir = PathBuf::from(crate_dir_name);
     let node_dir = {


### PR DESCRIPTION
Add cargo:rerun-if-changed directives to node/build.rs to tell Cargo when the build script needs to run. This prevents regenerating action_kind.rs on every build, significantly improving build times.