### PR TITLE
CI/scenario-tests: increase timeouts to 45min

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -321,7 +321,7 @@ jobs:
         if: ${{ always() }}
 
   scenario-tests:
-    timeout-minutes: 30
+    timeout-minutes: 45
     needs:
       - build-tests
       - build-tests-webrtc


### PR DESCRIPTION
On develop, it took more than 30 min.

See https://github.com/o1-labs/mina-rust/actions/runs/17209456261/job/48819327466