### PR TITLE
CI: separate build workflows per OS for individual badges

### DIFF
--- a/.github/workflows/build-macos-13.yaml
+++ b/.github/workflows/build-macos-13.yaml
@@ -1,0 +1,20 @@
+name: Build macOS 13
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    paths-ignore: ["frontend"]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: ./.github/workflows/build-reusable.yaml
+    with:
+      os: macos-13
+      cache-prefix: macos-13-
+      build-wasm: true

--- a/.github/workflows/build-macos-14.yaml
+++ b/.github/workflows/build-macos-14.yaml
@@ -1,0 +1,20 @@
+name: Build macOS 14
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    paths-ignore: ["frontend"]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: ./.github/workflows/build-reusable.yaml
+    with:
+      os: macos-14
+      cache-prefix: macos-14-
+      build-wasm: true

--- a/.github/workflows/build-macos-15.yaml
+++ b/.github/workflows/build-macos-15.yaml
@@ -1,0 +1,20 @@
+name: Build macOS 15
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    paths-ignore: ["frontend"]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: ./.github/workflows/build-reusable.yaml
+    with:
+      os: macos-15
+      cache-prefix: macos-15-
+      build-wasm: true

--- a/.github/workflows/build-macos-latest.yaml
+++ b/.github/workflows/build-macos-latest.yaml
@@ -1,0 +1,20 @@
+name: Build macOS Latest
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    paths-ignore: ["frontend"]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: ./.github/workflows/build-reusable.yaml
+    with:
+      os: macos-latest
+      cache-prefix: macos-latest-
+      build-wasm: true

--- a/.github/workflows/build-reusable.yaml
+++ b/.github/workflows/build-reusable.yaml
@@ -1,0 +1,147 @@
+name: Reusable Build Workflow
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+        description: "Operating system to build on"
+      ocaml_version:
+        required: false
+        type: string
+        default: "4.14.2"
+        description: "OCaml version to use"
+      cache-prefix:
+        required: false
+        type: string
+        default: ""
+        description: "Cache prefix for the build"
+      build-wasm:
+        required: false
+        type: boolean
+        default: false
+        description: "Whether to build WASM targets"
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: full
+  MINA_PANIC_ON_BUG: true
+  CARGO_INCREMENTAL: 1
+  RUSTFLAGS: "-C overflow-checks=off -C debug-assertions=off -C link-args=-Wl,-undefined,dynamic_lookup"
+
+jobs:
+  build:
+    timeout-minutes: 60
+    runs-on: ${{ inputs.os }}
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v5
+
+      - name: Setup build dependencies
+        uses: ./.github/actions/setup-build-deps
+
+      - name: Use shared OCaml setting up steps
+        uses: ./.github/actions/setup-ocaml
+        with:
+          ocaml_version: ${{ inputs.ocaml_version }}
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          toolchain: 1.84
+          cache-prefix: build-${{ inputs.os }}-${{ inputs.cache-prefix }}v0
+
+      - name: Release build
+        run: make build-release
+
+      - name: Verify build-info command
+        run: |
+          echo "Testing build-info command..."
+          ./target/release/mina build-info
+
+          # Verify required fields are present
+          ./target/release/mina build-info | grep -E "Version:|Build time:|Commit SHA:|Commit branch:|Rustc version:"
+
+          # Verify version format (should be a short commit hash)
+          VERSION=$(./target/release/mina build-info | grep "Version:" | awk '{print $2}')
+          if [[ ! "$VERSION" =~ ^[0-9a-f]{7}$ ]]; then
+            echo "Error: Version should be a 7-character commit hash, got: $VERSION"
+            exit 1
+          fi
+
+          echo "Build info verification passed!"
+
+  build-tests:
+    timeout-minutes: 60
+    runs-on: ${{ inputs.os }}
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v5
+
+      - name: Setup build dependencies
+        uses: ./.github/actions/setup-build-deps
+
+      - name: Use shared OCaml setting up steps
+        uses: ./.github/actions/setup-ocaml
+        with:
+          ocaml_version: ${{ inputs.ocaml_version }}
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          toolchain: 1.84
+          cache-prefix: build-tests-${{ inputs.os }}-${{ inputs.cache-prefix }}v0
+
+      - name: Build tests
+        run: make build-tests
+
+  build-tests-webrtc:
+    timeout-minutes: 60
+    runs-on: ${{ inputs.os }}
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v5
+
+      - name: Setup build dependencies
+        uses: ./.github/actions/setup-build-deps
+
+      - name: Use shared OCaml setting up steps
+        uses: ./.github/actions/setup-ocaml
+        with:
+          ocaml_version: ${{ inputs.ocaml_version }}
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          toolchain: 1.84
+          cache-prefix: build-tests-webrtc-${{ inputs.os }}-${{ inputs.cache-prefix }}v0
+
+      - name: Build tests
+        run: make build-tests-webrtc
+
+  build-wasm:
+    if: ${{ inputs.build-wasm }}
+    timeout-minutes: 60
+    runs-on: ${{ inputs.os }}
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v5
+
+      - name: Setup build dependencies
+        uses: ./.github/actions/setup-build-deps
+
+      - name: Use shared OCaml setting up steps
+        uses: ./.github/actions/setup-ocaml
+        with:
+          ocaml_version: ${{ inputs.ocaml_version }}
+
+      - name: Setup WebAssembly environment
+        uses: ./.github/actions/setup-wasm
+        with:
+          cache-prefix: wasm-${{ inputs.os }}-${{ inputs.cache-prefix }}v0
+
+      - name: Release build
+        run: make build-wasm
+        env:
+          RUSTFLAGS: ""

--- a/.github/workflows/build-ubuntu-22-04.yaml
+++ b/.github/workflows/build-ubuntu-22-04.yaml
@@ -1,0 +1,20 @@
+name: Build Ubuntu 22.04
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    paths-ignore: ["frontend"]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: ./.github/workflows/build-reusable.yaml
+    with:
+      os: ubuntu-22.04
+      cache-prefix: ubuntu-22-04-
+      build-wasm: true

--- a/.github/workflows/build-ubuntu-24-04-arm.yaml
+++ b/.github/workflows/build-ubuntu-24-04-arm.yaml
@@ -1,0 +1,20 @@
+name: Build Ubuntu 24.04 ARM
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    paths-ignore: ["frontend"]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: ./.github/workflows/build-reusable.yaml
+    with:
+      os: ubuntu-24.04-arm
+      cache-prefix: ubuntu-24-04-arm-
+      build-wasm: true

--- a/.github/workflows/build-ubuntu-24-04.yaml
+++ b/.github/workflows/build-ubuntu-24-04.yaml
@@ -1,0 +1,20 @@
+name: Build Ubuntu 24.04
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    paths-ignore: ["frontend"]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: ./.github/workflows/build-reusable.yaml
+    with:
+      os: ubuntu-24.04
+      cache-prefix: ubuntu-24-04-
+      build-wasm: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,4 +1,4 @@
-name: Mina CI
+name: Tests
 on:
   push:
     branches: [main, develop]
@@ -175,7 +175,7 @@ jobs:
         run: make test-p2p
 
   # Fast builds specifically for test artifacts - no cross-platform matrix
-  build-for-tests:
+  build:
     timeout-minutes: 60
     runs-on: ubuntu-22.04
     steps:
@@ -194,7 +194,7 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           toolchain: 1.84
-          cache-prefix: build-for-tests-v0
+          cache-prefix: build-v0
 
       - name: Release build
         run: make build-release
@@ -223,7 +223,7 @@ jobs:
           path: target/release/mina
           retention-days: 7
 
-  build-tests-for-tests:
+  build-tests:
     timeout-minutes: 60
     runs-on: ubuntu-22.04
     steps:
@@ -242,7 +242,7 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           toolchain: 1.84
-          cache-prefix: build-tests-for-tests-v0
+          cache-prefix: build-tests-v0
 
       - name: Build tests
         run: make build-tests
@@ -254,7 +254,7 @@ jobs:
           path: target/release/tests
           retention-days: 7
 
-  build-tests-webrtc-for-tests:
+  build-tests-webrtc:
     timeout-minutes: 60
     runs-on: ubuntu-22.04
     steps:
@@ -273,7 +273,7 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           toolchain: 1.84
-          cache-prefix: build-tests-webrtc-for-tests-v0
+          cache-prefix: build-tests-webrtc-v0
 
       - name: Build tests
         run: make build-tests-webrtc
@@ -285,154 +285,9 @@ jobs:
           path: target/release/tests
           retention-days: 7
 
-  build:
-    if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main'
-    timeout-minutes: 60
-    # NOTE: If you add or remove platforms from this matrix, make sure to update
-    # the documentation at website/docs/developers/getting-started.mdx
-    strategy:
-      fail-fast: false # Allow other platforms to continue if one fails
-      matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm, macos-13, macos-14, macos-15, macos-latest]
-        ocaml_version: [4.14.2]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Git checkout
-        uses: actions/checkout@v5
-
-      - name: Setup build dependencies
-        uses: ./.github/actions/setup-build-deps
-
-      - name: Use shared OCaml setting up steps
-        uses: ./.github/actions/setup-ocaml
-        with:
-          ocaml_version: ${{ matrix.ocaml_version }}
-
-      - name: Setup Rust
-        uses: ./.github/actions/setup-rust
-        with:
-          toolchain: 1.84
-          cache-prefix: build-${{ matrix.os }}-v0
-
-      - name: Release build
-        run: make build-release
-
-      - name: Verify build-info command
-        run: |
-          echo "Testing build-info command..."
-          ./target/release/mina build-info
-
-          # Verify required fields are present
-          ./target/release/mina build-info | grep -E "Version:|Build time:|Commit SHA:|Commit branch:|Rustc version:"
-
-          # Verify version format (should be a short commit hash)
-          VERSION=$(./target/release/mina build-info | grep "Version:" | awk '{print $2}')
-          if [[ ! "$VERSION" =~ ^[0-9a-f]{7}$ ]]; then
-            echo "Error: Version should be a 7-character commit hash, got: $VERSION"
-            exit 1
-          fi
-
-          echo "Build info verification passed!"
-
-  build-wasm:
-    if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main'
-    timeout-minutes: 60
-    # NOTE: If you add or remove platforms from this matrix, make sure to update
-    # the documentation at website/docs/developers/getting-started.mdx
-    strategy:
-      fail-fast: false # Allow other platforms to continue if one fails
-      matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm, macos-13, macos-14, macos-15, macos-latest]
-        ocaml_version: [4.14.2]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Git checkout
-        uses: actions/checkout@v5
-
-      - name: Setup build dependencies
-        uses: ./.github/actions/setup-build-deps
-
-      - name: Use shared OCaml setting up steps
-        uses: ./.github/actions/setup-ocaml
-        with:
-          ocaml_version: ${{ matrix.ocaml_version }}
-
-      - name: Setup WebAssembly environment
-        uses: ./.github/actions/setup-wasm
-        with:
-          cache-prefix: wasm-${{ matrix.os }}-v0
-
-      - name: Release build
-        run: make build-wasm
-        env:
-          RUSTFLAGS: ""
-
-  build-tests:
-    if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main'
-    timeout-minutes: 60
-    # NOTE: If you add or remove platforms from this matrix, make sure to update
-    # the documentation at website/docs/developers/getting-started.mdx
-    strategy:
-      fail-fast: false # Allow other platforms to continue if one fails
-      matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm, macos-13, macos-14, macos-15, macos-latest]
-        ocaml_version: [4.14.2]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Git checkout
-        uses: actions/checkout@v5
-
-      - name: Setup build dependencies
-        uses: ./.github/actions/setup-build-deps
-
-      - name: Use shared OCaml setting up steps
-        uses: ./.github/actions/setup-ocaml
-        with:
-          ocaml_version: ${{ matrix.ocaml_version }}
-
-      - name: Setup Rust
-        uses: ./.github/actions/setup-rust
-        with:
-          toolchain: 1.84
-          cache-prefix: build-tests-${{ matrix.os }}-v0
-
-      - name: Build tests
-        run: make build-tests
-
-  build-tests-webrtc:
-    if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main'
-    timeout-minutes: 60
-    # NOTE: If you add or remove platforms from this matrix, make sure to update
-    # the documentation at website/docs/developers/getting-started.mdx
-    strategy:
-      fail-fast: false # Allow other platforms to continue if one fails
-      matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm, macos-13, macos-14, macos-15, macos-latest]
-        ocaml_version: [4.14.2]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Git checkout
-        uses: actions/checkout@v5
-
-      - name: Setup build dependencies
-        uses: ./.github/actions/setup-build-deps
-
-      - name: Use shared OCaml setting up steps
-        uses: ./.github/actions/setup-ocaml
-        with:
-          ocaml_version: ${{ matrix.ocaml_version }}
-
-      - name: Setup Rust
-        uses: ./.github/actions/setup-rust
-        with:
-          toolchain: 1.84
-          cache-prefix: build-tests-webrtc-${{ matrix.os }}-v0
-
-      - name: Build tests
-        run: make build-tests-webrtc
 
   p2p-scenario-tests:
-    needs: [build-tests-for-tests, build-tests-webrtc-for-tests]
+    needs: [build-tests, build-tests-webrtc]
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     container:
@@ -503,8 +358,8 @@ jobs:
   scenario-tests:
     timeout-minutes: 60
     needs:
-      - build-tests-for-tests
-      - build-tests-webrtc-for-tests
+      - build-tests
+      - build-tests-webrtc
     runs-on: ubuntu-24.04
     container:
       image: gcr.io/o1labs-192920/mina-daemon:3.2.0-beta2-939b08d-noble-devnet
@@ -590,8 +445,8 @@ jobs:
   record-replay-tests:
     timeout-minutes: 30
     needs:
-      - build-tests-for-tests
-      - build-tests-webrtc-for-tests
+      - build-tests
+      - build-tests-webrtc
     runs-on: ubuntu-24.04
     container:
       image: gcr.io/o1labs-192920/mina-daemon:3.2.0-beta2-939b08d-noble-devnet
@@ -627,7 +482,7 @@ jobs:
 
   bootstrap-test:
     timeout-minutes: 10
-    needs: [build-for-tests, build-tests-for-tests]
+    needs: [build, build-tests]
     runs-on: ubuntu-24.04
     env:
       MINA_HOME: data

--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ This repository contains the complete Mina Rust Node implementation:
 <!-- Platform support badges -->
 
 [ci-badge]:
-  https://github.com/o1-labs/mina-rust/actions/workflows/ci.yaml/badge.svg?branch=develop
-[ci-link]: https://github.com/o1-labs/mina-rust/actions/workflows/ci.yaml
+  https://github.com/o1-labs/mina-rust/actions/workflows/tests.yaml/badge.svg?branch=develop
+[ci-link]: https://github.com/o1-labs/mina-rust/actions/workflows/tests.yaml
 [ubuntu-icon]:
   https://img.shields.io/badge/-Ubuntu-E95420?style=flat&logo=ubuntu&logoColor=white
 [macos-icon]:
@@ -134,33 +134,33 @@ This repository contains the complete Mina Rust Node implementation:
 <!-- Individual platform badges -->
 
 [ubuntu-22-badge]:
-  https://img.shields.io/badge/Ubuntu%2022.04%20x64-passing-brightgreen?style=flat&logo=ubuntu
+  https://github.com/o1-labs/mina-rust/actions/workflows/build-ubuntu-22-04.yaml/badge.svg?branch=develop
 [ubuntu-24-badge]:
-  https://img.shields.io/badge/Ubuntu%2024.04%20x64-passing-brightgreen?style=flat&logo=ubuntu
+  https://github.com/o1-labs/mina-rust/actions/workflows/build-ubuntu-24-04.yaml/badge.svg?branch=develop
 [ubuntu-24-arm-badge]:
-  https://img.shields.io/badge/Ubuntu%2024.04%20ARM64-passing-brightgreen?style=flat&logo=ubuntu
+  https://github.com/o1-labs/mina-rust/actions/workflows/build-ubuntu-24-04-arm.yaml/badge.svg?branch=develop
 [macos-13-badge]:
-  https://img.shields.io/badge/macOS%2013%20Intel-passing-brightgreen?style=flat&logo=apple
+  https://github.com/o1-labs/mina-rust/actions/workflows/build-macos-13.yaml/badge.svg?branch=develop
 [macos-14-badge]:
-  https://img.shields.io/badge/macOS%2014%20M1%2FM2-passing-brightgreen?style=flat&logo=apple
+  https://github.com/o1-labs/mina-rust/actions/workflows/build-macos-14.yaml/badge.svg?branch=develop
 [macos-15-badge]:
-  https://img.shields.io/badge/macOS%2015%20M1%2FM2%2FM3-passing-brightgreen?style=flat&logo=apple
+  https://github.com/o1-labs/mina-rust/actions/workflows/build-macos-15.yaml/badge.svg?branch=develop
 [macos-latest-badge]:
-  https://img.shields.io/badge/macOS%20Latest-passing-brightgreen?style=flat&logo=apple
+  https://github.com/o1-labs/mina-rust/actions/workflows/build-macos-latest.yaml/badge.svg?branch=develop
 
 <!-- Platform-specific build links -->
 
 [ubuntu-22-link]:
-  https://github.com/o1-labs/mina-rust/actions/workflows/ci.yaml?query=branch%3Adevelop+is%3Acompleted+job%3A%22build+%28ubuntu-22.04%2C+4.14.2%29%22
+  https://github.com/o1-labs/mina-rust/actions/workflows/build-ubuntu-22-04.yaml
 [ubuntu-24-link]:
-  https://github.com/o1-labs/mina-rust/actions/workflows/ci.yaml?query=branch%3Adevelop+is%3Acompleted+job%3A%22build+%28ubuntu-24.04%2C+4.14.2%29%22
+  https://github.com/o1-labs/mina-rust/actions/workflows/build-ubuntu-24-04.yaml
 [ubuntu-24-arm-link]:
-  https://github.com/o1-labs/mina-rust/actions/workflows/ci.yaml?query=branch%3Adevelop+is%3Acompleted+job%3A%22build+%28ubuntu-24.04-arm%2C+4.14.2%29%22
+  https://github.com/o1-labs/mina-rust/actions/workflows/build-ubuntu-24-04-arm.yaml
 [macos-13-link]:
-  https://github.com/o1-labs/mina-rust/actions/workflows/ci.yaml?query=branch%3Adevelop+is%3Acompleted+job%3A%22build+%28macos-13%2C+4.14.2%29%22
+  https://github.com/o1-labs/mina-rust/actions/workflows/build-macos-13.yaml
 [macos-14-link]:
-  https://github.com/o1-labs/mina-rust/actions/workflows/ci.yaml?query=branch%3Adevelop+is%3Acompleted+job%3A%22build+%28macos-14%2C+4.14.2%29%22
+  https://github.com/o1-labs/mina-rust/actions/workflows/build-macos-14.yaml
 [macos-15-link]:
-  https://github.com/o1-labs/mina-rust/actions/workflows/ci.yaml?query=branch%3Adevelop+is%3Acompleted+job%3A%22build+%28macos-15%2C+4.14.2%29%22
+  https://github.com/o1-labs/mina-rust/actions/workflows/build-macos-15.yaml
 [macos-latest-link]:
-  https://github.com/o1-labs/mina-rust/actions/workflows/ci.yaml?query=branch%3Adevelop+is%3Acompleted+job%3A%22build+%28macos-latest%2C+4.14.2%29%22
+  https://github.com/o1-labs/mina-rust/actions/workflows/build-macos-latest.yaml


### PR DESCRIPTION
- Create reusable build workflow to consolidate build logic
- Rename ci.yaml to tests.yaml focusing on test execution
- Add individual workflow files for each supported platform:
  - Ubuntu 22.04, 24.04, and 24.04 ARM
  - macOS 13, 14, 15, and latest
- Update README badges to use new workflow-specific URLs
- Optimize test dependencies to use only ubuntu-22.04 builds
- Clean up job names by removing redundant "-for-tests" suffixes

This enables individual GitHub Actions badges per OS platform while maintaining code reuse through the reusable workflow pattern.