### PR TITLE
CI: stop building for each platform at each PR

### DIFF
--- a/.github/workflows/build-macos-13.yaml
+++ b/.github/workflows/build-macos-13.yaml
@@ -3,8 +3,6 @@ name: Build macOS 13
 on:
   push:
     branches: [main, develop]
-  pull_request:
-    paths-ignore: ["frontend"]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/build-macos-14.yaml
+++ b/.github/workflows/build-macos-14.yaml
@@ -3,8 +3,6 @@ name: Build macOS 14
 on:
   push:
     branches: [main, develop]
-  pull_request:
-    paths-ignore: ["frontend"]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/build-macos-15.yaml
+++ b/.github/workflows/build-macos-15.yaml
@@ -3,8 +3,6 @@ name: Build macOS 15
 on:
   push:
     branches: [main, develop]
-  pull_request:
-    paths-ignore: ["frontend"]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/build-macos-latest.yaml
+++ b/.github/workflows/build-macos-latest.yaml
@@ -3,8 +3,6 @@ name: Build macOS Latest
 on:
   push:
     branches: [main, develop]
-  pull_request:
-    paths-ignore: ["frontend"]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/build-ubuntu-22-04.yaml
+++ b/.github/workflows/build-ubuntu-22-04.yaml
@@ -3,8 +3,6 @@ name: Build Ubuntu 22.04
 on:
   push:
     branches: [main, develop]
-  pull_request:
-    paths-ignore: ["frontend"]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/build-ubuntu-24-04-arm.yaml
+++ b/.github/workflows/build-ubuntu-24-04-arm.yaml
@@ -3,8 +3,6 @@ name: Build Ubuntu 24.04 ARM
 on:
   push:
     branches: [main, develop]
-  pull_request:
-    paths-ignore: ["frontend"]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/build-ubuntu-24-04.yaml
+++ b/.github/workflows/build-ubuntu-24-04.yaml
@@ -3,8 +3,6 @@ name: Build Ubuntu 24.04
 on:
   push:
     branches: [main, develop]
-  pull_request:
-    paths-ignore: ["frontend"]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
We only want to test on develop and main. Otherwise, it takes too much resources.

This has been introduced in https://github.com/o1-labs/mina-rust/pull/1436