### PR TITLE
CI/Makefile: setup-wasm installs wasm-bindgen-cli

### DIFF
--- a/.github/actions/setup-wasm/action.yml
+++ b/.github/actions/setup-wasm/action.yml
@@ -5,10 +5,6 @@ inputs:
     description: 'Rust toolchain version'
     required: false
     default: 'nightly'
-  wasm-bindgen-version:
-    description: 'wasm-bindgen-cli version'
-    required: false
-    default: '0.2.99'
   cache-prefix:
     description: 'Cache prefix key'
     required: false
@@ -20,13 +16,11 @@ runs:
       uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: ${{ inputs.toolchain }}
-        components: rustfmt, rust-src
 
-    - name: Install wasm32 target and wasm-bindgen-cli
+    - name: Setup WASM toolchain using Makefile
       shell: bash
       run: |
-        rustup target add wasm32-unknown-unknown
-        cargo install -f wasm-bindgen-cli --version ${{ inputs.wasm-bindgen-version }}
+        make setup-wasm
 
     - name: Setup Rust Cache
       uses: Swatinem/rust-cache@v2

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@
 # - ./github/workflows/lint.yaml
 NIGHTLY_RUST_VERSION = "nightly"
 
+# WebAssembly
+WASM_BINDGEN_CLI_VERSION = "0.2.99"
+
 # Docker
 DOCKER_ORG ?= o1labs
 
@@ -240,8 +243,8 @@ lint-dockerfiles: ## Check all Dockerfiles using hadolint
 		fi; \
 	fi
 
-.PHONY: setup-wasm-toolchain
-setup-wasm-toolchain: ## Setup the WebAssembly toolchain, using nightly
+.PHONY: setup-wasm
+setup-wasm: ## Setup the WebAssembly toolchain, using nightly
 		@ARCH=$$(uname -m); \
 		OS=$$(uname -s | tr A-Z a-z); \
 		case $$OS in \
@@ -256,8 +259,11 @@ setup-wasm-toolchain: ## Setup the WebAssembly toolchain, using nightly
 			*) echo "Unsupported architecture: $$ARCH" && exit 1 ;; \
 		esac; \
 		TARGET="$$ARCH_PART-$$OS_PART"; \
-		echo "Installing rust-src and rustfmt for ${NIGHTLY_RUST_VERSION}-$$TARGET with wasm32 target"; \
-		rustup target add wasm32-unknown-unknown --toolchain ${NIGHTLY_RUST_VERSION}-$$TARGET
+		echo "Installing components for ${NIGHTLY_RUST_VERSION}-$$TARGET with wasm32 target"; \
+		rustup component add rust-src --toolchain ${NIGHTLY_RUST_VERSION}-$$TARGET; \
+		rustup component add rustfmt --toolchain ${NIGHTLY_RUST_VERSION}-$$TARGET; \
+		rustup target add wasm32-unknown-unknown --toolchain ${NIGHTLY_RUST_VERSION}-$$TARGET; \
+		cargo install wasm-bindgen-cli --version ${WASM_BINDGEN_CLI_VERSION}
 
 .PHONY: test
 test: ## Run tests


### PR DESCRIPTION
Cherry-picked from https://github.com/o1-labs/mina-rust/pull/1420/.

This will be used when building the Docker image for the frontend.