### PR TITLE
Prepare v0.18.0 release: Fix Docker builds and update versions

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/cli/replay_dynamic_effects/Cargo.toml
+++ b/cli/replay_dynamic_effects/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "replay_dynamic_effects"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mina-core"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/fuzzer/Cargo.toml
+++ b/fuzzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mina-fuzzer"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mina-tree"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mina-macros"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Alexander Koptelov <alexandre.koptelov@gmail.com>"]

--- a/mina-p2p-messages/Cargo.toml
+++ b/mina-p2p-messages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mina-p2p-messages"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/node/account/Cargo.toml
+++ b/node/account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mina-node-account"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Account management for Mina nodes, including key generation, encryption, and address handling"

--- a/node/common/Cargo.toml
+++ b/node/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mina-node-common"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/node/invariants/Cargo.toml
+++ b/node/invariants/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mina-node-invariants"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/node/native/Cargo.toml
+++ b/node/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mina-node-native"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/node/testing/Cargo.toml
+++ b/node/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mina-node-testing"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/node/web/Cargo.toml
+++ b/node/web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mina-node-web"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p2p"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/p2p/libp2p-rpc-behaviour/Cargo.toml
+++ b/p2p/libp2p-rpc-behaviour/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-rpc-behaviour"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/p2p/testing/Cargo.toml
+++ b/p2p/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p2p-testing"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/poseidon/Cargo.toml
+++ b/poseidon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poseidon"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 
 [lints]

--- a/snark/Cargo.toml
+++ b/snark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snark"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/tools/archive-breadcrumb-compare/Cargo.toml
+++ b/tools/archive-breadcrumb-compare/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mina-archive-breadcrumb-compare"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 
 [dependencies]

--- a/tools/bootstrap-sandbox/Cargo.toml
+++ b/tools/bootstrap-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mina-bootstrap-sandbox"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 
 [dependencies]

--- a/tools/fuzzing/Cargo.toml
+++ b/tools/fuzzing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transaction_fuzzer"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 
 [dependencies]

--- a/tools/gossipsub-sandbox/Cargo.toml
+++ b/tools/gossipsub-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mina-gossipsub-sandbox"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 
 [dependencies]

--- a/tools/hash-tool/Cargo.toml
+++ b/tools/hash-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hash-tool"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 
 [dependencies]

--- a/tools/ledger-tool/Cargo.toml
+++ b/tools/ledger-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ledger-tool"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 
 [dependencies]

--- a/tools/transport/Cargo.toml
+++ b/tools/transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mina-transport"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 
 [dependencies]

--- a/tools/webrtc-sniffer/Cargo.toml
+++ b/tools/webrtc-sniffer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrtc-sniffer"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 
 [dependencies]

--- a/vendor/salsa-simple/Cargo.toml
+++ b/vendor/salsa-simple/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "salsa-simple"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 
 [dev-dependencies]

--- a/vrf/Cargo.toml
+++ b/vrf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vrf"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/website/docs/appendix/release-process.mdx
+++ b/website/docs/appendix/release-process.mdx
@@ -142,7 +142,39 @@ _Updates will be posted in this thread_
 
 ## Release Steps
 
-### 1. Create Release Branch (for major/minor releases)
+### 1. Update Version Numbers
+
+```bash
+# Update all Cargo.toml version fields
+make release-update-version VERSION=1.5.0
+```
+
+<!-- prettier-ignore-start -->
+
+<details>
+<summary>Script contents (click to expand)</summary>
+
+<CodeBlock
+  language="bash"
+  title="website/docs/developers/scripts/release/update-version.sh"
+>
+  {UpdateVersionScript}
+</CodeBlock>
+
+</details>
+<!-- prettier-ignore-stop -->
+
+This automatically updates version references in:
+
+- All `Cargo.toml` files in the workspace
+- Excludes target directory files
+
+You may also need to manually update:
+
+- Documentation examples
+- Any hardcoded version references in other files
+
+### 2. Create Release Branch (for major/minor releases)
 
 <!-- prettier-ignore-start -->
 
@@ -207,38 +239,6 @@ docker run -p 8302:8302 o1labs/mina-rust:v1.5.0
 :::
 
 <!-- prettier-ignore-stop -->
-
-### 2. Update Version Numbers
-
-```bash
-# Update all Cargo.toml version fields
-make release-update-version VERSION=1.5.0
-```
-
-<!-- prettier-ignore-start -->
-
-<details>
-<summary>Script contents (click to expand)</summary>
-
-<CodeBlock
-  language="bash"
-  title="website/docs/developers/scripts/release/update-version.sh"
->
-  {UpdateVersionScript}
-</CodeBlock>
-
-</details>
-<!-- prettier-ignore-stop -->
-
-This automatically updates version references in:
-
-- All `Cargo.toml` files in the workspace
-- Excludes target directory files
-
-You may also need to manually update:
-
-- Documentation examples
-- Any hardcoded version references in other files
 
 ### 3. Create Release PR
 

--- a/website/docs/node-operators/archive-node.md
+++ b/website/docs/node-operators/archive-node.md
@@ -62,10 +62,10 @@ Ensure Docker and Docker Compose are installed on your system -
 
    # Download the archive node docker-compose file (choose one method)
    # Using wget:
-   wget https://raw.githubusercontent.com/o1-labs/mina-rust/v0.17.0/docker-compose.archive.devnet.yml
+   wget https://raw.githubusercontent.com/o1-labs/mina-rust/v0.18.0/docker-compose.archive.devnet.yml
 
    # Or using curl:
-   curl -O https://raw.githubusercontent.com/o1-labs/mina-rust/v0.17.0/docker-compose.archive.devnet.yml
+   curl -O https://raw.githubusercontent.com/o1-labs/mina-rust/v0.18.0/docker-compose.archive.devnet.yml
 
    # Create required .env file with PostgreSQL settings
    cat > .env << EOF
@@ -76,7 +76,7 @@ Ensure Docker and Docker Compose are installed on your system -
    EOF
    ```
 
-   For the latest development version, replace `v0.17.0` with `develop` in the
+   For the latest development version, replace `v0.18.0` with `develop` in the
    URL.
 
    <!-- prettier-ignore-start -->

--- a/website/docs/node-operators/block-producer.md
+++ b/website/docs/node-operators/block-producer.md
@@ -27,16 +27,16 @@ Ensure Docker and Docker Compose are installed on your system -
 
    # Download the block producer docker-compose file (choose one method)
    # Using wget:
-   wget https://raw.githubusercontent.com/o1-labs/mina-rust/v0.17.0/docker-compose.block-producer.yml
+   wget https://raw.githubusercontent.com/o1-labs/mina-rust/v0.18.0/docker-compose.block-producer.yml
 
    # Or using curl:
-   curl -O https://raw.githubusercontent.com/o1-labs/mina-rust/v0.17.0/docker-compose.block-producer.yml
+   curl -O https://raw.githubusercontent.com/o1-labs/mina-rust/v0.18.0/docker-compose.block-producer.yml
 
    # Create an empty .env file to avoid warnings (optional - has defaults)
    touch .env
    ```
 
-   For the latest development version, replace `v0.17.0` with `develop` in the
+   For the latest development version, replace `v0.18.0` with `develop` in the
    URL.
 
 2. **Verify Docker Image Version** (Optional but recommended)

--- a/website/docs/node-operators/docker-usage.md
+++ b/website/docs/node-operators/docker-usage.md
@@ -156,10 +156,10 @@ mkdir mina-rust-node && cd mina-rust-node
 
 # Download the docker-compose.yml file (choose one method)
 # Using wget:
-wget https://raw.githubusercontent.com/o1-labs/mina-rust/v0.17.0/docker-compose.yml
+wget https://raw.githubusercontent.com/o1-labs/mina-rust/v0.18.0/docker-compose.yml
 
 # Or using curl:
-curl -O https://raw.githubusercontent.com/o1-labs/mina-rust/v0.17.0/docker-compose.yml
+curl -O https://raw.githubusercontent.com/o1-labs/mina-rust/v0.18.0/docker-compose.yml
 
 # Create an empty .env file to avoid warnings (optional - has defaults)
 touch .env

--- a/website/docs/node-operators/node-management.md
+++ b/website/docs/node-operators/node-management.md
@@ -38,7 +38,7 @@ Rustc version: 1.84.1
 For a specific version:
 
 ```bash
-docker run --rm o1labs/mina-rust:v0.17.0 build-info
+docker run --rm o1labs/mina-rust:v0.18.0 build-info
 ```
 
 ### Using Native Binary


### PR DESCRIPTION
- Replacing version `0.17.0` with `0.18.0`
- Reordered steps for the release process