### PR TITLE
CI/docker: accept version tags in build-info validation

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -279,10 +279,10 @@ jobs:
           # Verify required fields are present
           docker run --rm ${{ env.REGISTRY_NODE_IMAGE }}:${{ env.DOCKER_TAG }} build-info | grep -E "Version:|Build time:|Commit SHA:|Commit branch:|Rustc version:"
 
-          # Verify version format
+          # Verify version format (commit hash or version tag)
           VERSION=$(docker run --rm ${{ env.REGISTRY_NODE_IMAGE }}:${{ env.DOCKER_TAG }} build-info | grep "Version:" | awk '{print $2}')
-          if [[ ! "$VERSION" =~ ^[0-9a-f]{7}$ ]]; then
-            echo "Error: Version should be a 7-character commit hash, got: $VERSION"
+          if [[ ! "$VERSION" =~ ^[0-9a-f]{7}$ ]] && [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "Error: Version should be either a 7-character commit hash or a version tag (vX.Y.Z), got: $VERSION"
             exit 1
           fi
 


### PR DESCRIPTION
The test-docker-build-info job was only accepting 7-character commit hashes, causing failures for tagged releases where the version is set to the tag name (e.g., `v0.18.0`). Update the validation regex to accept both commit hashes and semantic version tags (vX.Y.Z).