### PR TITLE
CI/lint: increase timeout to 15

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   lint:
-    timeout-minutes: 10
+    timeout-minutes: 15
     name: Lint - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
Handle the case when the deps have to be downloaded and compiled

Related to the failing jobs of https://github.com/o1-labs/mina-rust/pull/1622. It also happened a few times in the past.