### PR TITLE
CI/docs: remove path dependency for the job test-doc-commands

### DIFF
--- a/.github/workflows/doc-commands.yaml
+++ b/.github/workflows/doc-commands.yaml
@@ -4,11 +4,6 @@ on:
   push:
     branches: [ main, develop ]
   pull_request:
-    paths:
-      - 'Makefile'
-      - 'docs/**'
-      - 'CLAUDE.md'
-      - '.github/workflows/doc-commands.yml'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
The job is required on every branch. Therefore, we must ensure it is always run, otherwise the CI is blocked.