### PR TITLE
CI/E2E: commenting for now single_node/bootstrap_from_replayer

### DIFF
--- a/node/testing/tests/single_node.rs
+++ b/node/testing/tests/single_node.rs
@@ -29,6 +29,7 @@ scenario_test!(
 );
 
 scenario_test!(
+    #[ignore = "investigate failure, see 1591"]
     bootstrap_from_replayer,
     SoloNodeBootstrap,
     SoloNodeBootstrap


### PR DESCRIPTION
We are investigating it in https://github.com/o1-labs/mina-rust/issues/1591.

Ignoring the test for now to avoid requiring a force merge and blocking PR if @dannywillems is not available.