### PR TITLE
Fix frontend black screen issue in docker-compose setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Dashboard, documenting all endpoints and specific data fields used by the
   frontend ([#1566](https://github.com/o1-labs/mina-rust/issues/1566))
 
+### Fixed
+
+- **Docker Compose**: Fix frontend black screen issue by changing environment
+  from `compose` to `local` and exposing port 3000 for mina-node HTTP API
+  ([#1649](https://github.com/o1-labs/mina-rust/pull/1649))
+
 ## [0.18.0] - 2025-11-04
 
 ### OCaml node

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     volumes:
       - ./mina-workdir:/root/.mina:rw
     ports:
+      - "3000:3000"
       - "${MINA_LIBP2P_PORT:-8302}:${MINA_LIBP2P_PORT:-8302}"
     environment:
       MINA_LIBP2P_EXTERNAL_IP: "${MINA_LIBP2P_EXTERNAL_IP:-}"
@@ -20,6 +21,6 @@ services:
   frontend:
     image: o1labs/mina-rust-frontend:${MINA_FRONTEND_TAG:-latest}
     environment:
-      MINA_FRONTEND_ENVIRONMENT: compose
+      MINA_FRONTEND_ENVIRONMENT: local
     ports:
       - "8070:80"


### PR DESCRIPTION
## Summary

- Changed frontend environment from `compose` to `local` as `compose` is not a valid environment in the frontend startup script
- Exposed port 3000 for the mina-node HTTP API to allow frontend to connect to the backend

## Problem

The docker-compose setup was experiencing a black screen issue where the frontend failed to start. The root cause was that `MINA_FRONTEND_ENVIRONMENT: compose` was not recognized by the frontend startup script, which only accepts: `local`, `fuzzing`, `production`, `webnode`, or `staging`.

Additionally, the mina-node HTTP API (running on port 3000) was not exposed, preventing the frontend from connecting to the backend even if it had started successfully.

## Test plan

- [x] Run `docker-compose up -d`
- [x] Verify frontend starts without errors: `docker-compose logs frontend`
- [x] Access frontend at http://localhost:8070
- [x] Verify no black screen and frontend loads correctly
- [x] Verify frontend can connect to backend API at http://localhost:3000/status