### PR TITLE
Release v0.18.1 - Fix Docker Compose frontend black screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.18.1] - 2025-11-20
+
+### Fixed
+
+- **Docker Compose**: Fix frontend black screen issue by changing environment
+  from `compose` to `local` and exposing port 3000 for rust node HTTP API (hotfix `v0.18.1`)
+
 ## [0.18.0] - 2025-11-04
 
 ### OCaml node
@@ -680,7 +687,8 @@ First public release.
 - Alpha version of the node which can connect and syncup to the berkeleynet network, and keep applying new blocks to maintain consensus state and ledger up to date.
 - Web-based frontend for the node.
 
-[Unreleased]: https://github.com/openmina/openmina/compare/v0.18.0...develop
+[Unreleased]: https://github.com/openmina/openmina/compare/v0.18.1...develop
+[0.18.1]: https://github.com/openmina/openmina/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/openmina/openmina/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/openmina/openmina/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/openmina/openmina/compare/v0.15.0...v0.16.0

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/cli/replay_dynamic_effects/Cargo.toml
+++ b/cli/replay_dynamic_effects/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "replay_dynamic_effects"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mina-core"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     volumes:
       - ./mina-workdir:/root/.mina:rw
     ports:
+      - "3000:3000"
       - "${MINA_LIBP2P_PORT:-8302}:${MINA_LIBP2P_PORT:-8302}"
     environment:
       MINA_LIBP2P_EXTERNAL_IP: "${MINA_LIBP2P_EXTERNAL_IP:-}"
@@ -20,6 +21,6 @@ services:
   frontend:
     image: o1labs/mina-rust-frontend:${MINA_FRONTEND_TAG:-latest}
     environment:
-      MINA_FRONTEND_ENVIRONMENT: compose
+      MINA_FRONTEND_ENVIRONMENT: local
     ports:
       - "8070:80"

--- a/fuzzer/Cargo.toml
+++ b/fuzzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mina-fuzzer"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mina-tree"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mina-macros"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Alexander Koptelov <alexandre.koptelov@gmail.com>"]

--- a/mina-p2p-messages/Cargo.toml
+++ b/mina-p2p-messages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mina-p2p-messages"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/node/account/Cargo.toml
+++ b/node/account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mina-node-account"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Account management for Mina nodes, including key generation, encryption, and address handling"

--- a/node/common/Cargo.toml
+++ b/node/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mina-node-common"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/node/invariants/Cargo.toml
+++ b/node/invariants/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mina-node-invariants"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/node/native/Cargo.toml
+++ b/node/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mina-node-native"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/node/testing/Cargo.toml
+++ b/node/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mina-node-testing"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/node/web/Cargo.toml
+++ b/node/web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mina-node-web"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p2p"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/p2p/libp2p-rpc-behaviour/Cargo.toml
+++ b/p2p/libp2p-rpc-behaviour/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libp2p-rpc-behaviour"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/p2p/testing/Cargo.toml
+++ b/p2p/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p2p-testing"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/poseidon/Cargo.toml
+++ b/poseidon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "poseidon"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 
 [lints]

--- a/snark/Cargo.toml
+++ b/snark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snark"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/tools/archive-breadcrumb-compare/Cargo.toml
+++ b/tools/archive-breadcrumb-compare/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mina-archive-breadcrumb-compare"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 
 [dependencies]

--- a/tools/bootstrap-sandbox/Cargo.toml
+++ b/tools/bootstrap-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mina-bootstrap-sandbox"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 
 [dependencies]

--- a/tools/fuzzing/Cargo.toml
+++ b/tools/fuzzing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transaction_fuzzer"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 
 [dependencies]

--- a/tools/gossipsub-sandbox/Cargo.toml
+++ b/tools/gossipsub-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mina-gossipsub-sandbox"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 
 [dependencies]

--- a/tools/hash-tool/Cargo.toml
+++ b/tools/hash-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hash-tool"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 
 [dependencies]

--- a/tools/ledger-tool/Cargo.toml
+++ b/tools/ledger-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ledger-tool"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 
 [dependencies]

--- a/tools/transport/Cargo.toml
+++ b/tools/transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mina-transport"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 
 [dependencies]

--- a/tools/webrtc-sniffer/Cargo.toml
+++ b/tools/webrtc-sniffer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webrtc-sniffer"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 
 [dependencies]

--- a/vendor/salsa-simple/Cargo.toml
+++ b/vendor/salsa-simple/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "salsa-simple"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 
 [dev-dependencies]

--- a/vrf/Cargo.toml
+++ b/vrf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vrf"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION
Hotfix release `v0.18.1`

## Changes
- **Docker Compose**: Fix frontend black screen issue by changing environment from 'compose' to 'local' and exposing port 3000 for rust node HTTP API
- Update version to 0.18.1 in all Cargo.toml files
- Add CHANGELOG entry for v0.18.1

## Issue
The frontend was showing a black screen when running with docker compose due to incorrect environment configuration.

## Testing
- [x] Verify docker compose starts successfully
- [x] Confirm frontend loads properly at http://localhost:8070
- [x] Verify rust node HTTP API is accessible at http://localhost:3000