### PR TITLE
Deps: install taplo using nightly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,7 +296,7 @@ setup-taplo: ## Install taplo TOML formatter
 	@if taplo --version 2>/dev/null | grep -q ${TAPLO_CLI_VERSION}; then \
 		echo "taplo ${TAPLO_CLI_VERSION} already installed"; \
 	else \
-		cargo install taplo-cli --version ${TAPLO_CLI_VERSION} --force; \
+		cargo +nightly install taplo-cli --version ${TAPLO_CLI_VERSION} --force; \
 	fi
 
 .PHONY: setup


### PR DESCRIPTION
We're getting:
```
error: failed to compile `taplo-cli v0.9.3`, intermediate artifacts can be found at `/tmp/cargo-installcKWfPA`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.

Caused by:
  failed to parse manifest at `/home/fok/.cargo/registry/src/index.crates.io-6f17d22bba15001f/globset-0.4.18/Cargo.toml`

Caused by:
  feature `edition2024` is required

  The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.84.1 (66221abde 2024-11-19)).
  Consider trying a newer version of Cargo (this may require the nightly release).
  See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.
```
otherwise.