### PR TITLE
Deps: use tag for proof-systems instead of rev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changes
+
+- **Dependency**: use tag instead of references of o1-labs/proof-systems, fix
+  [[#1674](https://github.com/o1-labs/mina-rust/issues/1674)]
+  ([#1673](https://github.com/o1-labs/mina-rust/pull/1673))
+
 ## [0.18.1] - 2025-11-20
+
 ### Added
 
 - **Documentation**: Add comprehensive API endpoints reference for the Node

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,7 +1688,7 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "cli"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -3282,7 +3282,7 @@ dependencies = [
 [[package]]
 name = "groupmap"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=282faf5#282faf58a97a0397304ca02010de7e43d3d3ec20"
+source = "git+https://github.com/o1-labs/proof-systems?tag=0.2.0#e8e02799802b42caf727d69c2dba7fce9548cb5b"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -3340,7 +3340,7 @@ dependencies = [
 
 [[package]]
 name = "hash-tool"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "bs58 0.4.0",
  "hex",
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "internal-tracing"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=282faf5#282faf58a97a0397304ca02010de7e43d3d3ec20"
+source = "git+https://github.com/o1-labs/proof-systems?tag=0.2.0#e8e02799802b42caf727d69c2dba7fce9548cb5b"
 
 [[package]]
 name = "io-lifetimes"
@@ -4184,7 +4184,7 @@ dependencies = [
 [[package]]
 name = "kimchi"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=282faf5#282faf58a97a0397304ca02010de7e43d3d3ec20"
+source = "git+https://github.com/o1-labs/proof-systems?tag=0.2.0#e8e02799802b42caf727d69c2dba7fce9548cb5b"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -4247,7 +4247,7 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "ledger-tool"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "mina-curves",
@@ -4583,7 +4583,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-rpc-behaviour"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "libp2p",
  "log",
@@ -4868,7 +4868,7 @@ dependencies = [
 
 [[package]]
 name = "mina-archive-breadcrumb-compare"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "binprot",
@@ -4883,7 +4883,7 @@ dependencies = [
 
 [[package]]
 name = "mina-bootstrap-sandbox"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "base64 0.22.1",
  "binprot",
@@ -4908,7 +4908,7 @@ dependencies = [
 
 [[package]]
 name = "mina-core"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "argon2",
  "ark-ff",
@@ -4952,7 +4952,7 @@ dependencies = [
 [[package]]
 name = "mina-curves"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=282faf5#282faf58a97a0397304ca02010de7e43d3d3ec20"
+source = "git+https://github.com/o1-labs/proof-systems?tag=0.2.0#e8e02799802b42caf727d69c2dba7fce9548cb5b"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -4962,7 +4962,7 @@ dependencies = [
 
 [[package]]
 name = "mina-fuzzer"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "lazy_static",
  "rand",
@@ -4973,7 +4973,7 @@ dependencies = [
 
 [[package]]
 name = "mina-gossipsub-sandbox"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "bs58 0.4.0",
  "env_logger",
@@ -4988,7 +4988,7 @@ dependencies = [
 [[package]]
 name = "mina-hasher"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=282faf5#282faf58a97a0397304ca02010de7e43d3d3ec20"
+source = "git+https://github.com/o1-labs/proof-systems?tag=0.2.0#e8e02799802b42caf727d69c2dba7fce9548cb5b"
 dependencies = [
  "ark-ff",
  "bitvec",
@@ -5000,7 +5000,7 @@ dependencies = [
 
 [[package]]
 name = "mina-macros"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "mina-core",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "mina-node-account"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "bs58 0.4.0",
@@ -5031,7 +5031,7 @@ dependencies = [
 
 [[package]]
 name = "mina-node-common"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5073,7 +5073,7 @@ dependencies = [
 
 [[package]]
 name = "mina-node-invariants"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "documented",
  "lazy_static",
@@ -5087,7 +5087,7 @@ dependencies = [
 
 [[package]]
 name = "mina-node-native"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "bs58 0.4.0",
@@ -5127,7 +5127,7 @@ dependencies = [
 
 [[package]]
 name = "mina-node-testing"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -5173,7 +5173,7 @@ dependencies = [
 
 [[package]]
 name = "mina-node-web"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "mina-p2p-messages"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "alloc-test",
  "anyhow",
@@ -5245,7 +5245,7 @@ dependencies = [
 [[package]]
 name = "mina-poseidon"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=282faf5#282faf58a97a0397304ca02010de7e43d3d3ec20"
+source = "git+https://github.com/o1-labs/proof-systems?tag=0.2.0#e8e02799802b42caf727d69c2dba7fce9548cb5b"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -5263,7 +5263,7 @@ dependencies = [
 [[package]]
 name = "mina-signer"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=282faf5#282faf58a97a0397304ca02010de7e43d3d3ec20"
+source = "git+https://github.com/o1-labs/proof-systems?tag=0.2.0#e8e02799802b42caf727d69c2dba7fce9548cb5b"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "mina-transport"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "blake2",
  "hex",
@@ -5293,7 +5293,7 @@ dependencies = [
 
 [[package]]
 name = "mina-tree"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "node"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5907,7 +5907,7 @@ dependencies = [
 [[package]]
 name = "o1-utils"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=282faf5#282faf58a97a0397304ca02010de7e43d3d3ec20"
+source = "git+https://github.com/o1-labs/proof-systems?tag=0.2.0#e8e02799802b42caf727d69c2dba7fce9548cb5b"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -6128,7 +6128,7 @@ dependencies = [
 
 [[package]]
 name = "p2p"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "aes-gcm 0.10.3",
  "anyhow",
@@ -6197,7 +6197,7 @@ dependencies = [
 
 [[package]]
 name = "p2p-testing"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "derive_more",
  "futures",
@@ -6596,7 +6596,7 @@ dependencies = [
 [[package]]
 name = "poly-commitment"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=282faf5#282faf58a97a0397304ca02010de7e43d3d3ec20"
+source = "git+https://github.com/o1-labs/proof-systems?tag=0.2.0#e8e02799802b42caf727d69c2dba7fce9548cb5b"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -6674,7 +6674,7 @@ checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 
 [[package]]
 name = "poseidon"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -7205,7 +7205,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "replay_dynamic_effects"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "mina-node-invariants",
  "mina-node-native",
@@ -7634,7 +7634,7 @@ checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "salsa-simple"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "generic-array",
  "hex",
@@ -8079,7 +8079,7 @@ dependencies = [
 
 [[package]]
 name = "snark"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -8928,7 +8928,7 @@ dependencies = [
 
 [[package]]
 name = "transaction_fuzzer"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -9063,7 +9063,7 @@ dependencies = [
 [[package]]
 name = "turshi"
 version = "0.1.0"
-source = "git+https://github.com/o1-labs/proof-systems?rev=282faf5#282faf58a97a0397304ca02010de7e43d3d3ec20"
+source = "git+https://github.com/o1-labs/proof-systems?tag=0.2.0#e8e02799802b42caf727d69c2dba7fce9548cb5b"
 dependencies = [
  "ark-ff",
  "hex",
@@ -9302,7 +9302,7 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "vrf"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -9715,7 +9715,7 @@ dependencies = [
 
 [[package]]
 name = "webrtc-sniffer"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm 0.10.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ js-sys = "0.3.64"
 jsonpath-rust = "0.5.0"
 juniper = { version = "0.16" }
 juniper_warp = "0.8.0"
-kimchi = { git = "https://github.com/o1-labs/proof-systems", rev = "282faf5" }
+kimchi = { git = "https://github.com/o1-labs/proof-systems", tag = "0.2.0" }
 lazy_static = "1.4.0"
 leb128 = "0.2.1"
 ledger = { path = "ledger", package = "mina-tree" }
@@ -134,9 +134,9 @@ log = "0.4.25"
 md5 = "0.7.0"
 mina-bootstrap-sandbox = { path = "tools/bootstrap-sandbox" }
 mina-core = { path = "core" }
-mina-curves = { git = "https://github.com/o1-labs/proof-systems", rev = "282faf5" }
+mina-curves = { git = "https://github.com/o1-labs/proof-systems", tag = "0.2.0" }
 mina-fuzzer = { path = "fuzzer" }
-mina-hasher = { git = "https://github.com/o1-labs/proof-systems", rev = "282faf5" }
+mina-hasher = { git = "https://github.com/o1-labs/proof-systems", tag = "0.2.0" }
 mina-macros = { path = "macros" }
 mina-node-account = { path = "node/account" }
 mina-node-common = { path = "node/common" }
@@ -144,8 +144,8 @@ mina-node-invariants = { path = "node/invariants" }
 mina-node-native = { path = "node/native" }
 mina-node-testing = { path = "node/testing" }
 mina-p2p-messages = { path = "mina-p2p-messages" }
-mina-poseidon = { git = "https://github.com/o1-labs/proof-systems", rev = "282faf5" }
-mina-signer = { git = "https://github.com/o1-labs/proof-systems", rev = "282faf5" }
+mina-poseidon = { git = "https://github.com/o1-labs/proof-systems", tag = "0.2.0" }
+mina-signer = { git = "https://github.com/o1-labs/proof-systems", tag = "0.2.0" }
 mina-transport = { path = "tools/transport" }
 mio = { version = "1.0.4", features = ["os-poll", "net"] }
 multiaddr = "0.18.1"
@@ -158,7 +158,7 @@ num-bigint = { git = "https://github.com/openmina/num-bigint", branch = "rebase-
 num-traits = "0.2"
 num_cpus = "1.0"
 num_enum = "0.5.7"
-o1-utils = { git = "https://github.com/o1-labs/proof-systems", rev = "282faf5" }
+o1-utils = { git = "https://github.com/o1-labs/proof-systems", tag = "0.2.0" }
 object = "0.37.1"
 ocaml-interop = { git = "https://github.com/sebastiencs/ocaml-interop.git", branch = "closure-values" }
 once_cell = "1"
@@ -166,7 +166,7 @@ p256 = { version = "0.13", features = ["default", "ecdh", "ecdsa"] }
 p384 = "0.13"
 pcap = "2.3"
 pin-project-lite = "0.2.10"
-poly-commitment = { git = "https://github.com/o1-labs/proof-systems", rev = "282faf5" }
+poly-commitment = { git = "https://github.com/o1-labs/proof-systems", tag = "0.2.0" }
 poseidon = { path = "poseidon" }
 postcard = { version = "1.0.9", features = ["use-std"] }
 proc-macro2 = "1.0.95"


### PR DESCRIPTION
We start enforcing the Caml and Rust node to use the same reference, and in particular we want to enforce releases only

Fix https://github.com/o1-labs/mina-rust/issues/1674