### PR TITLE
CI: VRF unit tests run as part of unit-tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -150,36 +150,6 @@ jobs:
   #     - name: Run ledger tests
   #       run: make test-ledger
 
-  vrf-tests:
-    timeout-minutes: 20
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Git checkout
-        uses: actions/checkout@v6
-
-      - name: Load versions
-        uses: ./.github/actions/load-versions
-
-      - name: Setup build dependencies
-        uses: ./.github/actions/setup-build-deps
-
-      - name: Use shared OCaml setting up steps
-        uses: ./.github/actions/setup-ocaml
-        with:
-          ocaml_version: ${{ env.OCAML_VERSION }}
-
-      - name: Setup Rust
-        uses: ./.github/actions/setup-rust
-        with:
-          toolchain: ${{ env.RUST_NIGHTLY_VERSION }}
-          cache-prefix: vrf-${{ env.CACHE_VERSION }}
-
-      - name: Build vrf tests
-        run: make build-vrf
-
-      - name: Run vrf tests
-        run: make test-vrf
-
   p2p-tests:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
@@ -302,7 +272,6 @@ jobs:
               --exclude libp2p-rpc-behaviour \
               --exclude node \
               --exclude mina-node-account \
-              --exclude vrf \
               --exclude mina-node-common \
               --exclude mina-node-native \
               --exclude mina-node-web \
@@ -319,6 +288,7 @@ jobs:
               --exclude mina-archive-breadcrumb-compare \
               --exclude webrtc-sniffer
               # --exclude mina-tree
+              # --exclude vrf
 
   account-tests:
     timeout-minutes: 20

--- a/Makefile
+++ b/Makefile
@@ -117,10 +117,6 @@ build-tests-webrtc: ## Build tests for WebRTC
 		cp -a $$FILE target/release/tests/webrtc_$$NAME; \
 	done < tests.tsv
 
-.PHONY: build-vrf
-build-vrf: ## Build the VRF package
-	@cd vrf && cargo +$(NIGHTLY_RUST_VERSION) build --release --tests
-
 .PHONY: build-wasm
 build-wasm: ## Build WebAssembly node
 	@cd node/web && cargo +${NIGHTLY_RUST_VERSION} build \
@@ -318,11 +314,6 @@ test-p2p: ## Run P2P tests
 test-release: ## Run tests in release mode
 	cargo test --release
 
-.PHONY: test-vrf
-test-vrf: ## Run VRF tests, requires nightly Rust
-	@cd vrf && cargo +$(NIGHTLY_RUST_VERSION) test --release -- \
-		-Z unstable-options --report-time
-
 .PHONY: test-account
 test-account: ## Run account tests
 	@cargo test -p mina-node-account
@@ -359,10 +350,6 @@ nextest-p2p: ## Run P2P tests with cargo-nextest
 .PHONY: nextest-ledger
 nextest-ledger: build-ledger ## Run ledger tests with cargo-nextest, requires nightly Rust
 	@cd ledger && cargo +$(NIGHTLY_RUST_VERSION) nextest run --release
-
-.PHONY: nextest-vrf
-nextest-vrf: ## Run VRF tests with cargo-nextest, requires nightly Rust
-	@cd vrf && cargo +$(NIGHTLY_RUST_VERSION) nextest run --release
 
 # Docker build targets
 


### PR DESCRIPTION
There are no integrations tests (following the Rust naming convention described [here](https://doc.rust-lang.org/book/ch11-03-test-organization.html)), only unit tests.