### PR TITLE
docs: add zkApp signing RFC page

### DIFF
--- a/website/docs/researchers/zkapp-signing.md
+++ b/website/docs/researchers/zkapp-signing.md
@@ -1,0 +1,31 @@
+---
+sidebar_position: 2
+title: How are zkApp transactions signed
+description: zkApp transaction signing process
+slug: /researchers/zkapp-signing
+---
+
+# How are zkApp transactions signed
+
+This document describes the signing process for zkApp transactions in the Mina
+Protocol.
+
+## Overview
+
+_This RFC is under development._
+
+## Related resources
+
+- **Transaction SNARK specification**:
+  [#1756](https://github.com/o1-labs/mina-rust/issues/1756) - Documents how the
+  Transaction SNARK verifies signatures against transaction commitments.
+- **Transaction types crate**: A standalone `no_std` crate containing zkApp
+  transaction types is being developed
+  ([#1665](https://github.com/o1-labs/mina-rust/issues/1665)). Documentation
+  link will be added once published.
+- **Ledger App test vectors**:
+  [#1409](https://github.com/o1-labs/mina-rust/issues/1409) - Providing test
+  vectors for signing zkApp on hardware wallets (Zondax/Ledger).
+- **OCaml test vectors PR**:
+  [MinaProtocol/mina#18203](https://github.com/MinaProtocol/mina/pull/18203) -
+  zkApp signature test vectors in OCaml codebase.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -189,6 +189,7 @@ const sidebars: SidebarsConfig = {
       label: 'Cryptography',
       items: [
         'researchers/snark-work',
+        'researchers/zkapp-signing',
       ],
     },
   ],


### PR DESCRIPTION
## Summary

- Add initial RFC page for documenting how zkApp transactions are signed in the
  Mina Protocol
- Add page to sidebar under Researchers > Cryptography section

This page will serve as the specification for external implementers (e.g.,
hardware wallet teams like Ledger/Zondax).

This will also be important to verify that we are actually signing zkApp correctly in the Rust codebase.

## Related issues

- Start #1748 (zkApp signing documentation)
- Related: #1756 (Transaction SNARK specification)
- Related: #1757 (Blockchain SNARK specification)
- Related: #1665 (Transaction types crate)
- Related: #1409 (Ledger App test vectors)
- Related: MinaProtocol/mina#18203 (OCaml test vectors)

## Test plan

- [ ] Verify the page renders correctly on the documentation website
- [ ] Verify sidebar navigation works