### PR TITLE
Add cross-references between API endpoints and sidecar service docs

### DIFF
--- a/website/docs/developers/frontend/api-endpoints.mdx
+++ b/website/docs/developers/frontend/api-endpoints.mdx
@@ -35,6 +35,30 @@ The frontend connects to multiple services with configurable endpoints:
 - **GraphQL endpoint**: External MinaScan API (e.g.
   `https://api.minascan.io/node/devnet/v1/graphql`)
 
+<!-- prettier-ignore-start -->
+
+:::caution Memory profiler and debugger are separate sidecar services
+
+The memory profiler and network debugger are **not part of the main node
+binary**. They are separate sidecar services that must be run alongside your
+node to enable these features in the dashboard.
+
+To use these features:
+
+- **Memory profiler**: See the
+  [memory profiler setup guide](/docs/node-operators/infrastructure/memory-profiler)
+  for instructions on running the memory profiler sidecar.
+- **Network debugger**: See the
+  [network debugger setup guide](/docs/node-operators/infrastructure/network-debugger)
+  for instructions on running the network debugger sidecar.
+
+Without these sidecars running, the corresponding dashboard features will not be
+available.
+
+:::
+
+<!-- prettier-ignore-stop -->
+
 #### Further, let's examine the used endpoints
 
 ### Node status and information

--- a/website/docs/node-operators/infrastructure/memory-profiler.mdx
+++ b/website/docs/node-operators/infrastructure/memory-profiler.mdx
@@ -7,7 +7,29 @@ sidebar_position: 6
 # Memory Profiler
 
 This section is still a work in progress. It will cover nodes running with a
-memory profiler for performance analysis and optimization. The memory profiler
-data is used by the node dashboard for debugging purposes.
+memory profiler for performance analysis and optimization.
+
+<!-- prettier-ignore-start -->
+
+:::info Memory profiler usage in the dashboard
+
+The memory profiler is a **separate sidecar service** that runs alongside your
+node. It provides memory allocation analysis data that the
+[Node Dashboard](/docs/developers/frontend/api-endpoints) uses for performance
+debugging.
+
+The dashboard consumes the memory profiler's API to visualize:
+
+- Hierarchical memory resource allocation (treemap visualization)
+- Memory usage by function and executable
+- Memory allocation call stacks
+
+For API details, see the
+[Memory profiler API endpoints](/docs/developers/frontend/api-endpoints#memory-profiler)
+section in the API reference.
+
+:::
+
+<!-- prettier-ignore-stop -->
 
 Track progress: [Issue #1207](https://github.com/o1-labs/mina-rust/issues/1207)

--- a/website/docs/node-operators/infrastructure/network-debugger.mdx
+++ b/website/docs/node-operators/infrastructure/network-debugger.mdx
@@ -7,7 +7,31 @@ sidebar_position: 7
 # Network Debugger
 
 This section is still a work in progress. It will cover nodes running with the
-network debugger for network analysis and troubleshooting. The network debugger
-data is used by the node dashboard for debugging purposes.
+network debugger for network analysis and troubleshooting.
+
+<!-- prettier-ignore-start -->
+
+:::info Network debugger usage in the dashboard
+
+The network debugger is a **separate sidecar service** that runs alongside your
+node. It captures and stores detailed network traffic data that the
+[Node Dashboard](/docs/developers/frontend/api-endpoints) uses for network
+analysis and troubleshooting.
+
+The dashboard consumes the network debugger's API to visualize:
+
+- Block propagation messages and timing analysis
+- Network message inspection with filtering
+- Connection management and monitoring
+- Message decryption statistics
+- Low-level protocol debugging (hex dumps)
+
+For API details, see the
+[Debugger API endpoints](/docs/developers/frontend/api-endpoints#debugger-api-endpoints)
+section in the API reference.
+
+:::
+
+<!-- prettier-ignore-stop -->
 
 Track progress: [Issue #1365](https://github.com/o1-labs/mina-rust/issues/1365)


### PR DESCRIPTION
## Summary

This PR adds cross-references between the API endpoints documentation and the
memory profiler and network debugger documentation pages to clarify that these
are separate sidecar services.

## Changes

### API Endpoints Page

- Added a caution box in the Optional services section explaining that the
  memory profiler and network debugger are separate sidecar services that must
  be run alongside the node
- Provided links to the memory profiler and network debugger setup guides
- Clarified that without these sidecars running, the corresponding dashboard
  features will not be available

### Memory Profiler Page

- Added an info box explaining the memory profiler is a separate sidecar
  service
- Listed what the dashboard visualizes using the memory profiler API
  (hierarchical memory allocation, function usage, call stacks)
- Linked to the API endpoints page and specifically the memory profiler API
  section

### Network Debugger Page

- Added an info box explaining the network debugger is a separate sidecar
  service
- Listed what the dashboard visualizes using the network debugger API (block
  propagation, message inspection, connection monitoring, etc.)
- Linked to the API endpoints page and specifically the debugger API endpoints
  section
