### PR TITLE
Vendor: move redux-rs into mina-rust monorepo

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -294,6 +294,7 @@ jobs:
               --exclude mina-archive-breadcrumb-compare \
               --exclude webrtc-sniffer
               # --exclude mina-tree
+              # --exclude redux-rs
               # --exclude vrf
 
   account-tests:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- **Dependencies**: vendor redux-rs into `vendor/redux` to centralize all code
+  in the monorepo ([#1814](https://github.com/o1-labs/mina-rust/pull/1814))
 - **Dependency**: use tag instead of references of o1-labs/proof-systems, fix
   [[#1674](https://github.com/o1-labs/mina-rust/issues/1674)]
   ([#1673](https://github.com/o1-labs/mina-rust/pull/1673))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
   "tools/ledger-tool",
   "tools/transport",
   "tools/webrtc-sniffer",
+  "vendor/redux",
   "vendor/salsa-simple",
   "vrf",
 ]
@@ -179,9 +180,7 @@ rand_pcg = "0.3"
 rand_seeder = "0.2"
 rayon = "1.5"
 rcgen = { version = "0.13", features = ["pem", "x509-parser"] }
-redux = { git = "https://github.com/o1-labs/redux-rs.git", rev = "06c8366", features = [
-  "serde",
-] }
+redux = { path = "vendor/redux", features = ["serde"] }
 regex = "1"
 reqwest = { version = "0.12.8", features = ["blocking", "json"] }
 ring_buffer = "2.0.2"

--- a/vendor/redux/Cargo.toml
+++ b/vendor/redux/Cargo.toml
@@ -5,11 +5,11 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"], optional = true }
-fuzzcheck = { git = "https://github.com/openmina/fuzzcheck-rs.git", optional = true }
 enum_dispatch = "0.3.7"
+fuzzcheck = { git = "https://github.com/openmina/fuzzcheck-rs.git", optional = true }
 linkme = { version = "0.3.22", optional = true }
 paste = "1.0.14"
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-timer = { git = "https://github.com/openmina/wasm-timer" }

--- a/vendor/redux/Cargo.toml
+++ b/vendor/redux/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "redux"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"], optional = true }
+fuzzcheck = { git = "https://github.com/openmina/fuzzcheck-rs.git", optional = true }
+enum_dispatch = "0.3.7"
+linkme = { version = "0.3.22", optional = true }
+paste = "1.0.14"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-timer = { git = "https://github.com/openmina/wasm-timer" }
+
+[features]
+default = ["serde"]
+fuzzing = ["fuzzcheck"]
+serializable_callbacks = ["linkme"]

--- a/vendor/redux/LICENSE
+++ b/vendor/redux/LICENSE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/vendor/redux/src/action/action_id.rs
+++ b/vendor/redux/src/action/action_id.rs
@@ -1,0 +1,56 @@
+use std::time::Duration;
+
+use crate::Timestamp;
+
+/// Time in nanoseconds from [std::time::UNIX_EPOCH].
+///
+/// Each action will have unique id. If two actions happen at the same time,
+/// id must be increased by 1 for second action, to ensure uniqueness of id.
+///
+/// u64 is enough to contain time in nanoseconds at most 584 years
+/// after `UNIX_EPOCH` (1970-01-01 00:00:00 UTC).
+///
+/// ```
+/// //           nano     micro  milli  sec    min  hour day  year
+/// assert_eq!(u64::MAX / 1000 / 1000 / 1000 / 60 / 60 / 24 / 365, 584);
+/// ```
+#[cfg_attr(feature = "fuzzing", derive(fuzzcheck::DefaultMutator))]
+#[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ActionId(Timestamp);
+
+impl ActionId {
+    pub const ZERO: Self = Self(Timestamp::ZERO);
+
+    /// Caller must make sure such action actually exists!
+    #[inline(always)]
+    pub fn new_unchecked(value: u64) -> Self {
+        Self(Timestamp::new(value))
+    }
+
+    #[allow(unused)]
+    #[inline(always)]
+    pub(crate) fn next(&self, time_passed: u64) -> Self {
+        Self(self.0 + time_passed.max(1))
+    }
+
+    pub fn duration_since(&self, other: ActionId) -> Duration {
+        let d = self.0.checked_sub(other.0);
+        debug_assert!(d.is_some());
+        d.unwrap_or(Duration::ZERO)
+    }
+}
+
+impl From<ActionId> for Timestamp {
+    #[inline(always)]
+    fn from(id: ActionId) -> Self {
+        id.0
+    }
+}
+
+impl From<ActionId> for u64 {
+    #[inline(always)]
+    fn from(id: ActionId) -> Self {
+        id.0.into()
+    }
+}

--- a/vendor/redux/src/action/action_meta.rs
+++ b/vendor/redux/src/action/action_meta.rs
@@ -1,0 +1,87 @@
+use std::time::Duration;
+
+use crate::{SystemTime, Timestamp};
+
+use super::{ActionId, ActionWithMeta};
+
+pub type RecursionDepth = u32;
+
+/// Action with additional metadata like: id.
+#[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ActionMeta {
+    id: ActionId,
+    /// Previously applied action.
+    prev: ActionId,
+    /// Recursion depth of a given action.
+    depth: RecursionDepth,
+}
+
+impl ActionMeta {
+    pub const ZERO: Self = Self {
+        id: ActionId::ZERO,
+        prev: ActionId::ZERO,
+        depth: 0,
+    };
+
+    #[inline(always)]
+    pub(crate) fn new(id: ActionId, prev: ActionId, depth: RecursionDepth) -> Self {
+        Self { id, prev, depth }
+    }
+
+    #[inline(always)]
+    pub fn zero_custom(time: Timestamp) -> Self {
+        Self {
+            id: ActionId::new_unchecked(time.into()),
+            prev: ActionId::new_unchecked(time.into()),
+            depth: 0,
+        }
+    }
+
+    #[inline(always)]
+    pub fn id(&self) -> ActionId {
+        self.id
+    }
+
+    /// Recursion depth of a given action.
+    #[inline(always)]
+    pub fn depth(&self) -> RecursionDepth {
+        self.depth
+    }
+
+    /// Time of previously applied action.
+    #[inline(always)]
+    pub fn prev_time(&self) -> Timestamp {
+        self.prev.into()
+    }
+
+    #[inline(always)]
+    pub fn time(&self) -> Timestamp {
+        self.id.into()
+    }
+
+    #[inline(always)]
+    pub fn sys_time(&self) -> SystemTime {
+        SystemTime::UNIX_EPOCH + self.duration_since_epoch()
+    }
+
+    #[inline(always)]
+    pub fn time_as_nanos(&self) -> u64 {
+        self.id.into()
+    }
+
+    #[inline(always)]
+    pub fn duration_since_epoch(&self) -> Duration {
+        Duration::from_nanos(self.time_as_nanos())
+    }
+
+    #[inline(always)]
+    pub fn duration_since(&self, other: &ActionMeta) -> Duration {
+        self.id.duration_since(other.id)
+    }
+
+    #[inline(always)]
+    pub fn with_action<T>(self, action: T) -> ActionWithMeta<T> {
+        ActionWithMeta { meta: self, action }
+    }
+}

--- a/vendor/redux/src/action/action_with_meta.rs
+++ b/vendor/redux/src/action/action_with_meta.rs
@@ -1,0 +1,67 @@
+use std::time::Duration;
+
+use crate::{SystemTime, Timestamp};
+
+use super::{ActionId, ActionMeta, RecursionDepth};
+
+/// Action with additional metadata like: id.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ActionWithMeta<Action> {
+    pub(super) meta: ActionMeta,
+
+    #[cfg_attr(feature = "serde", serde(flatten))]
+    pub(super) action: Action,
+}
+
+impl<Action> ActionWithMeta<Action> {
+    pub fn meta(&self) -> &ActionMeta {
+        &self.meta
+    }
+
+    pub fn action(&self) -> &Action {
+        &self.action
+    }
+
+    #[inline(always)]
+    pub fn id(&self) -> ActionId {
+        self.meta.id()
+    }
+
+    /// Recursion depth of a given action.
+    #[inline(always)]
+    pub fn depth(&self) -> RecursionDepth {
+        self.meta.depth()
+    }
+
+    #[inline(always)]
+    pub fn time(&self) -> Timestamp {
+        self.meta.time()
+    }
+
+    #[inline(always)]
+    pub fn sys_time(&self) -> SystemTime {
+        self.meta.sys_time()
+    }
+
+    #[inline(always)]
+    pub fn time_as_nanos(&self) -> u64 {
+        self.meta.time_as_nanos()
+    }
+
+    #[inline(always)]
+    pub fn duration_since_epoch(&self) -> Duration {
+        self.meta.duration_since_epoch()
+    }
+
+    #[inline(always)]
+    pub fn duration_since(&self, other: &ActionWithMeta<Action>) -> Duration {
+        self.meta.duration_since(&other.meta)
+    }
+
+    /// Splits the struct into a tuple of action and it's metadata.
+    #[inline(always)]
+    pub fn split(self) -> (Action, ActionMeta) {
+        (self.action, self.meta)
+    }
+}

--- a/vendor/redux/src/action/enabling_condition.rs
+++ b/vendor/redux/src/action/enabling_condition.rs
@@ -1,0 +1,9 @@
+#[allow(unused_variables)]
+pub trait EnablingCondition<State> {
+    /// Enabling condition for the Action.
+    ///
+    /// Checks if the given action is enabled for a given state and timestamp.
+    fn is_enabled(&self, state: &State, time: crate::Timestamp) -> bool {
+        true
+    }
+}

--- a/vendor/redux/src/action/mod.rs
+++ b/vendor/redux/src/action/mod.rs
@@ -1,0 +1,11 @@
+mod enabling_condition;
+pub use enabling_condition::EnablingCondition;
+
+mod action_id;
+pub use action_id::ActionId;
+
+mod action_meta;
+pub use action_meta::{ActionMeta, RecursionDepth};
+
+mod action_with_meta;
+pub use action_with_meta::ActionWithMeta;

--- a/vendor/redux/src/callback.rs
+++ b/vendor/redux/src/callback.rs
@@ -1,0 +1,120 @@
+#[cfg(feature = "serializable_callbacks")]
+use linkme::distributed_slice;
+
+pub use paste;
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+
+pub struct AnyAction(pub Box<dyn std::any::Any>);
+
+#[cfg(feature = "serializable_callbacks")]
+#[distributed_slice]
+pub static CALLBACKS: [(&str, fn(&str, Box<dyn std::any::Any>) -> AnyAction)];
+
+#[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
+pub struct Callback<T> {
+    #[serde(skip, default = "default_fun_ptr")]
+    fun_ptr: Option<fn(T) -> AnyAction>,
+    pub fun_name: Cow<'static, str>,
+}
+
+fn default_fun_ptr<T>() -> Option<fn(T) -> AnyAction> {
+    None
+}
+
+impl<T: 'static> Callback<T> {
+    pub fn new(name: &'static str, fun_ptr: fn(T) -> AnyAction) -> Self {
+        Self {
+            fun_ptr: Some(fun_ptr),
+            fun_name: Cow::Borrowed(name),
+        }
+    }
+
+    pub fn call<Action>(&self, args: T) -> Action
+    where
+        Action: From<AnyAction>,
+    {
+        if let Some(fun) = self.fun_ptr {
+            return fun(args).into();
+        }
+
+        #[cfg(not(feature = "serializable_callbacks"))]
+        unimplemented!();
+
+        #[cfg(feature = "serializable_callbacks")]
+        {
+            // We reach this point only when the callback was deserialized
+            for (name, fun) in CALLBACKS {
+                if name == &self.fun_name {
+                    return fun(std::any::type_name::<T>(), Box::new(args)).into();
+                }
+            }
+
+            panic!("callback function {} not found", self.fun_name)
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! _callback {
+    ($callback_name:ident, $action_ty:ty, $arg:tt, $arg_type:ty, $body:expr) => {{
+        use $crate::{AnyAction, Callback};
+
+        #[cfg(feature = "serializable_callbacks")]
+        use {$crate::CALLBACKS, linkme::distributed_slice};
+
+        redux::paste::paste! {
+            #[allow(unused)] // $arg is marked as unused, but it's used in `$body`
+            fn convert_impl($arg: $arg_type) -> AnyAction {
+                let action: $action_ty = ($body).into();
+                AnyAction(Box::new(action))
+            }
+
+            fn $callback_name(call_type: &str, args: Box<dyn std::any::Any>) -> AnyAction {
+                #[cfg(feature = "serializable_callbacks")]
+                {
+                    #[distributed_slice(CALLBACKS)]
+                    static CALLBACK_DESERIALIZE: (&str, fn(&str, Box<dyn std::any::Any>) -> AnyAction) = (
+                        stringify!($callback_name),
+                        $callback_name,
+                    );
+                }
+
+                let $arg = *args.downcast::<$arg_type>()
+                    .expect(&format!(
+                        "Invalid argument type: {}, expected: {}",
+                        call_type,
+                        stringify!($arg_type)));
+
+                convert_impl($arg)
+            }
+        }
+
+        Callback::new(stringify!($callback_name), convert_impl)
+    }};
+}
+
+/// Creates a callback instance. Must accept a single argument, so `()`
+/// should be used when no arguments are needed and tuples where
+/// more than one value need to be passed.
+///
+/// # Example
+///
+/// ```ignore
+/// callback!(task_done_callback(result: String) -> Action {
+///     SomeAction { result }
+/// })
+///
+/// callback!(multiple_arguments_callback((arg1: u64, arg2: u64)) -> Action {
+///     MultipleArgumentsAction { value: arg1 + arg2 }
+/// })
+/// ```
+#[macro_export]
+macro_rules! callback {
+    ($callback_name:ident(($($var:ident : $typ:ty),+)) -> $action_ty:ty $body:block) => {
+        $crate::_callback!($callback_name, $action_ty, ($($var),+), ($($typ),+), $body)
+    };
+    ($callback_name:ident($var:ident : $typ:ty) -> $action_ty:ty $body:block) => {
+        $crate::_callback!($callback_name, $action_ty, $var, $typ, $body)
+    };
+}

--- a/vendor/redux/src/dispatcher.rs
+++ b/vendor/redux/src/dispatcher.rs
@@ -1,0 +1,61 @@
+use std::{collections::VecDeque, marker::PhantomData};
+
+use crate::{AnyAction, Callback, EnablingCondition};
+
+pub struct Dispatcher<Action, State> {
+    queue: VecDeque<Action>,
+    _marker: PhantomData<State>,
+}
+
+impl<Action, State> Default for Dispatcher<Action, State>
+where
+    Action: crate::EnablingCondition<State>,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<Action, State> Dispatcher<Action, State>
+where
+    Action: crate::EnablingCondition<State>,
+{
+    pub fn new() -> Self {
+        Self {
+            queue: VecDeque::new(),
+            _marker: Default::default(),
+        }
+    }
+
+    pub fn push<T>(&mut self, action: T)
+    where
+        T: Into<Action>,
+    {
+        self.queue.push_back(action.into());
+    }
+
+    pub fn push_if_enabled<T>(&mut self, action: T, state: &State, time: crate::Timestamp) -> bool
+    where
+        T: Into<Action> + EnablingCondition<State>,
+    {
+        if action.is_enabled(state, time) {
+            self.queue.push_back(action.into());
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn push_callback<T>(&mut self, callback: Callback<T>, args: T)
+    where
+        T: 'static,
+        Action: From<AnyAction>,
+    {
+        let action: Action = callback.call(args);
+        self.queue.push_back(action);
+    }
+
+    pub(crate) fn pop(&mut self) -> Option<Action> {
+        self.queue.pop_front()
+    }
+}

--- a/vendor/redux/src/effects.rs
+++ b/vendor/redux/src/effects.rs
@@ -1,0 +1,4 @@
+use crate::{ActionWithMeta, Store};
+
+pub type Effects<State, Service, Action> =
+    fn(&mut Store<State, Service, Action>, ActionWithMeta<Action>);

--- a/vendor/redux/src/instant.rs
+++ b/vendor/redux/src/instant.rs
@@ -1,0 +1,146 @@
+use std::{
+    cell::RefCell,
+    cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd},
+    ops::{Add, AddAssign, Sub, SubAssign},
+    time::Duration,
+};
+
+use crate::SystemTime;
+
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::Instant as InnerInstant;
+
+#[cfg(target_arch = "wasm32")]
+use wasm_timer::Instant as InnerInstant;
+
+#[derive(Copy, Clone)]
+pub struct Instant {
+    inner: InnerInstant,
+}
+
+impl PartialEq for Instant {
+    fn eq(&self, other: &Instant) -> bool {
+        self.inner == other.inner
+    }
+}
+
+impl Eq for Instant {}
+
+impl PartialOrd for Instant {
+    fn partial_cmp(&self, other: &Instant) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Instant {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.inner.partial_cmp(&other.inner).unwrap()
+    }
+}
+
+thread_local! {
+    static INITIAL_AND_DRIFT: RefCell<Option<(SystemTime, InnerInstant, Duration)>> = const { RefCell::new(None) };
+}
+
+impl Instant {
+    pub fn now() -> Instant {
+        let inner = INITIAL_AND_DRIFT.with_borrow_mut(|initial_and_drift| {
+            let (initial_sys_time, initial_monotonic, drift) = initial_and_drift
+                .get_or_insert_with(|| (SystemTime::now(), InnerInstant::now(), Duration::ZERO));
+
+            let sys_time_passed = SystemTime::now()
+                .duration_since(*initial_sys_time)
+                .unwrap_or_default();
+            let monotonic_now = InnerInstant::now();
+            let monotonic_passed = monotonic_now.duration_since(*initial_monotonic);
+
+            if sys_time_passed > monotonic_passed + *drift {
+                // handling for system suspension/browser tab suspension.
+                *drift = sys_time_passed - monotonic_passed;
+            }
+
+            monotonic_now + *drift
+        });
+
+        Self { inner }
+    }
+
+    pub fn duration_since(&self, earlier: Instant) -> Duration {
+        *self - earlier
+    }
+
+    pub fn elapsed(&self) -> Duration {
+        Instant::now() - *self
+    }
+
+    pub fn checked_duration_since(&self, earlier: Instant) -> Option<Duration> {
+        match self.cmp(&earlier) {
+            Ordering::Less => None,
+            _ => Some(self.duration_since(earlier)),
+        }
+    }
+
+    pub fn saturating_duration_since(&self, earlier: Instant) -> Duration {
+        self.checked_duration_since(earlier).unwrap_or_default()
+    }
+
+    pub fn checked_add(&self, duration: Duration) -> Option<Instant> {
+        Some(*self + duration)
+    }
+
+    pub fn checked_sub(&self, duration: Duration) -> Option<Instant> {
+        Some(*self - duration)
+    }
+}
+
+impl From<InnerInstant> for Instant {
+    fn from(inner: InnerInstant) -> Self {
+        Self { inner }
+    }
+}
+
+impl Add<Duration> for Instant {
+    type Output = Instant;
+
+    fn add(self, other: Duration) -> Instant {
+        Instant {
+            inner: self.inner + other,
+        }
+    }
+}
+
+impl Sub<Duration> for Instant {
+    type Output = Instant;
+
+    fn sub(self, other: Duration) -> Instant {
+        Instant {
+            inner: self.inner - other,
+        }
+    }
+}
+
+impl Sub<Instant> for Instant {
+    type Output = Duration;
+
+    fn sub(self, other: Instant) -> Duration {
+        self.inner - other.inner
+    }
+}
+
+impl AddAssign<Duration> for Instant {
+    fn add_assign(&mut self, other: Duration) {
+        *self = *self + other;
+    }
+}
+
+impl SubAssign<Duration> for Instant {
+    fn sub_assign(&mut self, other: Duration) {
+        *self = *self - other;
+    }
+}
+
+impl std::fmt::Debug for Instant {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.inner.fmt(f)
+    }
+}

--- a/vendor/redux/src/lib.rs
+++ b/vendor/redux/src/lib.rs
@@ -1,0 +1,33 @@
+#![cfg_attr(feature = "fuzzing", feature(no_coverage))]
+
+mod instant;
+
+mod timestamp;
+pub use timestamp::{Instant, SystemTime, Timestamp};
+
+mod action;
+pub use action::*;
+
+mod reducer;
+pub use reducer::Reducer;
+
+mod effects;
+pub use effects::Effects;
+
+mod service;
+pub use service::{Service, TimeService};
+
+mod callback;
+#[cfg(feature = "serializable_callbacks")]
+pub use callback::CALLBACKS;
+pub use callback::{paste, AnyAction, Callback};
+
+mod store;
+pub(crate) use store::monotonic_to_time;
+pub use store::Store;
+
+mod sub_store;
+pub use sub_store::SubStore;
+
+mod dispatcher;
+pub use dispatcher::Dispatcher;

--- a/vendor/redux/src/reducer.rs
+++ b/vendor/redux/src/reducer.rs
@@ -1,0 +1,5 @@
+use crate::{ActionWithMeta, Dispatcher};
+
+/// Function signature for a reducer.
+pub type Reducer<State, Action> =
+    fn(&mut State, &ActionWithMeta<Action>, &mut Dispatcher<Action, State>);

--- a/vendor/redux/src/service.rs
+++ b/vendor/redux/src/service.rs
@@ -1,0 +1,10 @@
+use crate::Instant;
+
+pub trait Service: TimeService {}
+
+/// Time service.
+pub trait TimeService {
+    fn monotonic_time(&mut self) -> Instant {
+        Instant::now()
+    }
+}

--- a/vendor/redux/src/store.rs
+++ b/vendor/redux/src/store.rs
@@ -1,0 +1,263 @@
+use std::sync::OnceLock;
+
+use crate::{
+    ActionId, ActionMeta, ActionWithMeta, AnyAction, Callback, Dispatcher, Effects,
+    EnablingCondition, Instant, Reducer, SubStore, SystemTime, TimeService, Timestamp,
+};
+
+/// Wraps around State and allows only immutable borrow,
+/// Through `StateWrapper::get` method.
+///
+/// Mutable borrow of state can only happen in reducer.
+pub struct StateWrapper<State> {
+    inner: State,
+}
+
+impl<State> StateWrapper<State> {
+    /// Get immutable reference to State.
+    #[inline(always)]
+    pub fn get(&self) -> &State {
+        &self.inner
+    }
+
+    /// Get mutable reference to State.
+    ///
+    /// Only should be used in the reducer and it's not `pub`,
+    /// so it can't be accessed from lib users.
+    #[inline(always)]
+    fn get_mut(&mut self) -> &mut State {
+        &mut self.inner
+    }
+}
+
+impl<T: Clone> Clone for StateWrapper<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+/// Monotonic and system time reference points.
+static INITIAL_TIME: OnceLock<(Instant, SystemTime)> = OnceLock::new();
+
+/// Converts monotonic time to nanoseconds since Unix epoch.
+///
+/// If `None` passed, returns result for current time.
+pub fn monotonic_to_time(time: Option<Instant>) -> u64 {
+    let (monotonic, system) = INITIAL_TIME.get_or_init(|| (Instant::now(), SystemTime::now()));
+    let time_passed = time.unwrap_or_else(Instant::now).duration_since(*monotonic);
+    system
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|x| x + time_passed)
+        .map(|x| x.as_nanos())
+        .unwrap_or(0) as u64
+}
+
+/// Main struct for the state machine.
+///
+/// Exposes a [`Store::dispatch`] method, using
+/// which actions can be dispatched, which triggers a
+/// 1. [`Reducer`] - to update the state.
+/// 2. [`Effects`] - to trigger side-effects of the action.
+pub struct Store<State, Service, Action> {
+    reducer: Reducer<State, Action>,
+    effects: Effects<State, Service, Action>,
+
+    /// Current State.
+    ///
+    /// Immutable access can be gained using `store.state.get()`.
+    /// Mutation can only happen inside reducer.
+    pub state: StateWrapper<State>,
+    pub service: Service,
+
+    initial_monotonic_time: Instant,
+    initial_time: Timestamp,
+
+    /// Current recursion depth of dispatch.
+    recursion_depth: u32,
+
+    last_action_id: ActionId,
+}
+
+impl<State, Service, Action> Store<State, Service, Action>
+where
+    Service: TimeService,
+    Action: EnablingCondition<State>,
+{
+    /// Creates a new store.
+    pub fn new(
+        reducer: Reducer<State, Action>,
+        effects: Effects<State, Service, Action>,
+        mut service: Service,
+        initial_time: SystemTime,
+        initial_state: State,
+    ) -> Self {
+        let initial_monotonic_time = service.monotonic_time();
+        let initial_time_nanos = initial_time
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map(|x| x.as_nanos())
+            .unwrap_or(0);
+
+        INITIAL_TIME.get_or_init(move || (initial_monotonic_time, initial_time));
+
+        Self {
+            reducer,
+            effects,
+            service,
+            state: StateWrapper {
+                inner: initial_state,
+            },
+
+            initial_monotonic_time,
+            initial_time: Timestamp::new(initial_time_nanos as u64),
+
+            recursion_depth: 0,
+            last_action_id: ActionId::new_unchecked(initial_time_nanos as u64),
+        }
+    }
+
+    /// Returns the current state.
+    #[inline(always)]
+    pub fn state(&self) -> &State {
+        self.state.get()
+    }
+
+    #[inline(always)]
+    pub fn service(&mut self) -> &mut Service {
+        &mut self.service
+    }
+
+    /// Convert monotonic time to system clock in nanoseconds from epoch.
+    pub fn monotonic_to_time(&self, monotonic_time: Instant) -> u64 {
+        monotonic_to_time(Some(monotonic_time))
+    }
+
+    /// Dispatch an Action.
+    ///
+    /// Returns `true` if the action was enabled, hence if it was dispatched
+    /// to reducer and then effects.
+    ///
+    /// If action is not enabled, we return false and do nothing.
+    pub fn dispatch<T>(&mut self, action: T) -> bool
+    where
+        T: Into<Action> + EnablingCondition<State>,
+    {
+        if !action.is_enabled(self.state(), self.last_action_id.into()) {
+            return false;
+        }
+        self.dispatch_enabled(action.into());
+
+        true
+    }
+
+    pub fn dispatch_callback<T>(&mut self, callback: Callback<T>, args: T) -> bool
+    where
+        T: 'static,
+        Action: From<AnyAction> + EnablingCondition<State>,
+    {
+        let action: Action = callback.call(args);
+        self.dispatch(action)
+    }
+
+    /// Dispatch an Action (For `SubStore`).
+    ///
+    /// Returns `true` if the action was enabled, hence if it was dispatched
+    /// to reducer and then effects.
+    ///
+    /// If action is not enabled, we return false and do nothing.
+    pub fn sub_dispatch<A, S>(&mut self, action: A) -> bool
+    where
+        A: Into<<Self as SubStore<State, S>>::SubAction> + EnablingCondition<S>,
+        <Self as SubStore<State, S>>::SubAction: Into<Action>,
+        Self: SubStore<State, S>,
+    {
+        if !action.is_enabled(
+            <Self as SubStore<State, S>>::state(self),
+            self.last_action_id.into(),
+        ) {
+            return false;
+        }
+        self.dispatch_enabled(action.into().into());
+
+        true
+    }
+
+    fn update_action_id(&mut self) -> ActionId {
+        let prev_action_id = self.last_action_id;
+        let now = self.initial_time
+            + self
+                .service
+                .monotonic_time()
+                .duration_since(self.initial_monotonic_time);
+
+        let t = (Timestamp::from(prev_action_id) + 1).max(now);
+        self.last_action_id = ActionId::new_unchecked(t.into());
+        prev_action_id
+    }
+
+    /// Dispatches action without checking the enabling condition.
+    fn dispatch_enabled(&mut self, action: Action) {
+        let prev = self.update_action_id();
+        self.recursion_depth += 1;
+
+        let action_with_meta =
+            ActionMeta::new(self.last_action_id, prev, self.recursion_depth).with_action(action);
+
+        let mut dispatcher = Dispatcher::new();
+        self.dispatch_reducer(&action_with_meta, &mut dispatcher);
+        self.dispatch_effects(action_with_meta, dispatcher);
+
+        self.recursion_depth -= 1;
+    }
+
+    /// Runs the reducer.
+    #[inline(always)]
+    fn dispatch_reducer(
+        &mut self,
+        action_with_id: &ActionWithMeta<Action>,
+        dispatcher: &mut Dispatcher<Action, State>,
+    ) {
+        (self.reducer)(self.state.get_mut(), action_with_id, dispatcher);
+    }
+
+    /// Runs the effects.
+    #[inline(always)]
+    fn dispatch_effects(
+        &mut self,
+        action_with_id: ActionWithMeta<Action>,
+        mut queued: Dispatcher<Action, State>,
+    ) {
+        // First the effects for this specific action must be handled
+        (self.effects)(self, action_with_id);
+
+        // Then dispatch all actions enqueued by the reducer
+        while let Some(action) = queued.pop() {
+            if action.is_enabled(self.state(), self.last_action_id.into()) {
+                self.dispatch_enabled(action);
+            }
+        }
+    }
+}
+
+impl<State, Service, Action> Clone for Store<State, Service, Action>
+where
+    State: Clone,
+    Service: Clone,
+    Action: Clone + EnablingCondition<State>,
+{
+    fn clone(&self) -> Self {
+        Self {
+            reducer: self.reducer,
+            effects: self.effects,
+            service: self.service.clone(),
+            state: self.state.clone(),
+
+            initial_monotonic_time: self.initial_monotonic_time,
+            initial_time: self.initial_time,
+
+            recursion_depth: self.recursion_depth,
+            last_action_id: self.last_action_id,
+        }
+    }
+}

--- a/vendor/redux/src/sub_store.rs
+++ b/vendor/redux/src/sub_store.rs
@@ -1,0 +1,19 @@
+/// Useful when state machine is split into multiple crates. Using this
+/// trait we can pass `Store<GlobalState, Service, GlobalAction>`
+/// almost as if it were `Store<SubState, Service, SubAction>`.
+pub trait SubStore<GlobalState, SubState> {
+    type SubAction;
+    type Service;
+
+    fn state(&self) -> &SubState;
+    fn service(&mut self) -> &mut Self::Service;
+    fn state_and_service(&mut self) -> (&SubState, &mut Self::Service);
+    fn dispatch<A>(&mut self, action: A) -> bool
+    where
+        A: Into<Self::SubAction> + crate::EnablingCondition<SubState>;
+
+    fn dispatch_callback<T>(&mut self, callback: crate::Callback<T>, args: T) -> bool
+    where
+        T: 'static,
+        Self::SubAction: From<crate::AnyAction> + crate::EnablingCondition<SubState>;
+}

--- a/vendor/redux/src/timestamp.rs
+++ b/vendor/redux/src/timestamp.rs
@@ -1,0 +1,84 @@
+pub use crate::instant::Instant;
+use std::time::Duration;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use std::time::SystemTime;
+
+#[cfg(target_arch = "wasm32")]
+pub use wasm_timer::SystemTime;
+
+/// Time in nanoseconds from [std::time::UNIX_EPOCH].
+///
+/// Used as an ID+Timestamp for an Action`.
+/// Each action will have an unique id. If two actions happen at the same time,
+/// id must be increased by 1 for second action, to ensure uniqueness of id.
+///
+/// u64 is enough to contain time in nanoseconds at most 584 years
+/// after `UNIX_EPOCH` (1970-01-01 00:00:00 UTC).
+///
+/// ```
+/// //           nano     micro  milli  sec    min  hour day  year
+/// assert_eq!(u64::MAX / 1000 / 1000 / 1000 / 60 / 60 / 24 / 365, 584);
+/// ```
+#[cfg_attr(feature = "fuzzing", derive(fuzzcheck::DefaultMutator))]
+#[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Timestamp(u64);
+
+impl Timestamp {
+    pub const ZERO: Self = Self(0);
+
+    #[inline(always)]
+    pub fn new(nanos_from_unix_epoch: u64) -> Self {
+        Self(nanos_from_unix_epoch)
+    }
+
+    #[inline(always)]
+    pub fn global_now() -> Self {
+        Self::new(crate::monotonic_to_time(None))
+    }
+
+    pub fn checked_sub(self, rhs: Timestamp) -> Option<Duration> {
+        self.0.checked_sub(rhs.0).map(Duration::from_nanos)
+    }
+
+    pub fn checked_add(self, other: u64) -> Option<Timestamp> {
+        self.0.checked_add(other).map(Timestamp)
+    }
+}
+
+impl From<Timestamp> for u64 {
+    fn from(t: Timestamp) -> Self {
+        t.0
+    }
+}
+
+impl From<Timestamp> for SystemTime {
+    fn from(value: Timestamp) -> Self {
+        Self::UNIX_EPOCH + Duration::from_nanos(value.into())
+    }
+}
+
+impl std::ops::Add for Timestamp {
+    type Output = Timestamp;
+    #[inline]
+    fn add(self, other: Timestamp) -> Timestamp {
+        Timestamp(self.0 + other.0)
+    }
+}
+
+impl std::ops::Add<u64> for Timestamp {
+    type Output = Timestamp;
+    #[inline]
+    fn add(self, other: u64) -> Timestamp {
+        Timestamp(self.0 + other)
+    }
+}
+
+impl std::ops::Add<Duration> for Timestamp {
+    type Output = Timestamp;
+    #[inline]
+    fn add(self, other: Duration) -> Timestamp {
+        Timestamp(self.0 + other.as_nanos() as u64)
+    }
+}


### PR DESCRIPTION
## Summary

- Add redux-rs library to `vendor/redux` directory to centralize all code in
  the monorepo
- Update workspace to include the vendored crate
- Add CI workflow for testing vendored crates

Source: https://github.com/o1-labs/redux-rs
Commit: 06c8366

## Test plan

- [x] `cargo check -p redux` passes
- [x] `cargo check -p node` passes
- [x] `make lint` passes
- [x] CI workflow added in `tests-vendor.yaml`

Fixes #1804