### PR TITLE
CI: Tweak docker workflow to push additional tags for versioned releases

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -135,7 +135,7 @@ jobs:
   # Push frontend multi-arch manifest
   push-frontend-image:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/release')
+    if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
     needs:
       - build-mina-frontend-image
     steps:
@@ -151,13 +151,19 @@ jobs:
             echo "GIT_COMMIT=${GITHUB_SHA:0:8}" >> $GITHUB_ENV
             echo "ADDITIONAL_TAGS=latest" >> $GITHUB_ENV
           elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
-            echo "GIT_COMMIT=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-            echo "ADDITIONAL_TAGS=" >> $GITHUB_ENV
-          elif [[ "${{ github.ref }}" == refs/heads/release/* ]]; then
-            BRANCH_NAME="${GITHUB_REF#refs/heads/}"
-            VERSION="${BRANCH_NAME#release/}"
-            echo "GIT_COMMIT=${VERSION}" >> $GITHUB_ENV
-            echo "ADDITIONAL_TAGS=" >> $GITHUB_ENV
+            FULL_TAG=${GITHUB_REF#refs/tags/}
+            MAJOR_MINOR=$(echo $FULL_TAG | sed -E 's/(v[0-9]+\.[0-9]+)\.[0-9]+/\1/')
+
+            echo "Will push Docker image with tag \"${FULL_TAG}\""
+            echo "GIT_COMMIT=${FULL_TAG}" >> $GITHUB_ENV
+
+            if [[ "$FULL_TAG" =~ [+-] ]]; then
+              echo "Found pre-release or build ID in version, will __NOT__ update Docker tag \"${MAJOR_MINOR}\""
+              echo "ADDITIONAL_TAGS=" >> $GITHUB_ENV
+            else
+              echo "Will additionally push Docker image with tag \"${MAJOR_MINOR}\""
+              echo "ADDITIONAL_TAGS=${MAJOR_MINOR}" >> $GITHUB_ENV
+            fi
           fi
 
       - name: Push frontend multi-arch manifest
@@ -173,7 +179,7 @@ jobs:
   # Push node multi-arch manifest (after node build completes)
   push-node-image:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/release')
+    if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
     needs:
       - build-mina-node-image
     steps:
@@ -189,13 +195,19 @@ jobs:
             echo "GIT_COMMIT=${GITHUB_SHA:0:8}" >> $GITHUB_ENV
             echo "ADDITIONAL_TAGS=latest" >> $GITHUB_ENV
           elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
-            echo "GIT_COMMIT=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-            echo "ADDITIONAL_TAGS=" >> $GITHUB_ENV
-          elif [[ "${{ github.ref }}" == refs/heads/release/* ]]; then
-            BRANCH_NAME="${GITHUB_REF#refs/heads/}"
-            VERSION="${BRANCH_NAME#release/}"
-            echo "GIT_COMMIT=${VERSION}" >> $GITHUB_ENV
-            echo "ADDITIONAL_TAGS=" >> $GITHUB_ENV
+            FULL_TAG=${GITHUB_REF#refs/tags/}
+            MAJOR_MINOR=$(echo $FULL_TAG | sed -E 's/(v[0-9]+\.[0-9]+)\.[0-9]+/\1/')
+
+            echo "Will push Docker image with tag \"${FULL_TAG}\""
+            echo "GIT_COMMIT=${FULL_TAG}" >> $GITHUB_ENV
+
+            if [[ "$FULL_TAG" =~ [+-] ]]; then
+              echo "Found pre-release or build ID in version, will __NOT__ update Docker tag \"${MAJOR_MINOR}\""
+              echo "ADDITIONAL_TAGS=" >> $GITHUB_ENV
+            else
+              echo "Will additionally push Docker image with tag \"${MAJOR_MINOR}\""
+              echo "ADDITIONAL_TAGS=${MAJOR_MINOR}" >> $GITHUB_ENV
+            fi
           fi
 
       - name: Push node multi-arch manifest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Node**: add top-level documentation for the crate `node`
   ([#1736](https://github.com/o1-labs/mina-rust/pull/1736))
 - **CI**: automatically push Docker images for `vX.Y.Z` and `vX.Y` when tag `vX.Y.Z` is created
-  ([#TODO](https://github.com/o1-labs/mina-rust/pull/TODO))
+  ([#1838](https://github.com/o1-labs/mina-rust/pull/1838))
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Node**: add top-level documentation for the crate `node`
   ([#1736](https://github.com/o1-labs/mina-rust/pull/1736))
+- **CI**: automatically push Docker images for `vX.Y.Z` and `vX.Y` when tag `vX.Y.Z` is created
+  ([#TODO](https://github.com/o1-labs/mina-rust/pull/TODO))
 
 ### Changes
 

--- a/website/docs/appendix/release-process.mdx
+++ b/website/docs/appendix/release-process.mdx
@@ -354,8 +354,9 @@ After pushing the tag, verify:
 1. **Docker images are built and pushed**
 
    ```bash
-   # Verify multi-arch images are available
+   # Verify multi-arch images are available for both vMAJOR.MINOR.PATCH and vMAJOR.MINOR
    make release-docker-verify TAG=v1.5.0
+   make release-docker-verify TAG=v1.5
    ```
 
    <!-- prettier-ignore-start -->
@@ -633,6 +634,15 @@ git tag -d v1.5.0
 git push origin :refs/tags/v1.5.0
 # Then recreate tag
 ```
+
+:::important Verify `vMAJOR.MINOR` Docker tags
+
+If tag is recreated that looks like a valid semver, it will trigger a rebuild
+and push of the Docker images for that tag. For example, recreating tag `v1.5.0`
+will initiate a Docker build that will be pushed to Dockerhub as both `v1.5.0`
+and `v1.5`. As long as historical tags aren't recreated this shouldn't be a
+problem, but if the need arises to recreate tags, it's worth verifying that
+related images aren't adversely affected.
 
 ### CI Pipeline Issues
 


### PR DESCRIPTION
### Description

Modifies the Docker GitHub Actions workflow to additionally push a build tagged as `vX.Y` when the tag `vX.Y.Z` is created in GitHub.

### Related Issue(s)

* Closes #1688

### Type of Change

- [x] This change requires a (mild) documentation update
- [x] Build-related changes

### Testing

The only real way to test this is to merge it into main and create a release tag on GitHub. We can then validate that the `Push Docker` workflows created and pushed the additional desired tags

### Changelog Entry

**Added** - CI: automatically push Docker images for `vX.Y.Z` and `vX.Y` when tag `vX.Y.Z` is created ([#1838](https://github.com/o1-labs/mina-rust/pull/1838))

