### PR TITLE
Makefile: enforce GNU sed on macOS

### DIFF
--- a/.github/workflows/whitespace-check.yaml
+++ b/.github/workflows/whitespace-check.yaml
@@ -16,3 +16,37 @@ jobs:
 
       - name: Check for trailing whitespaces
         run: make check-trailing-whitespace
+
+  test-fix-whitespace:
+    timeout-minutes: 5
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install GNU sed (macOS)
+        if: runner.os == 'macOS'
+        run: ./website/docs/developers/scripts/setup/install-gnu-sed-macos.sh
+
+      - name: Create test file with trailing whitespace
+        run: printf 'line with trailing spaces   \nclean line\n' > test-whitespace.md
+
+      - name: Run fix-trailing-whitespace
+        run: make fix-trailing-whitespace
+
+      - name: Verify trailing whitespace was removed
+        run: |
+          if grep -q '[[:space:]]$' test-whitespace.md; then
+            echo "ERROR: Trailing whitespace was not removed"
+            cat -vet test-whitespace.md
+            exit 1
+          else
+            echo "Trailing whitespace successfully removed"
+            cat -vet test-whitespace.md
+          fi
+
+      - name: Clean up test file
+        run: rm -f test-whitespace.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Dependencies**: vendor redux-rs into `vendor/redux` to centralize all code
   in the monorepo ([#1814](https://github.com/o1-labs/mina-rust/pull/1814))
+- **Build System**: enforce GNU sed on macOS, require `brew install gnu-sed`
+  for `make fix-trailing-whitespace`, add CI test for cross-platform support,
+  fix [#1864](https://github.com/o1-labs/mina-rust/issues/1864)
+  ([#1872](https://github.com/o1-labs/mina-rust/pull/1872))
 - **Dependency**: use tag instead of references of o1-labs/proof-systems, fix
   [[#1674](https://github.com/o1-labs/mina-rust/issues/1674)]
   ([#1673](https://github.com/o1-labs/mina-rust/pull/1673))

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -424,10 +424,5 @@ When modifying CI workflows, especially for performance improvements:
 - **MANDATORY**: Run `make fix-trailing-whitespace` before every commit
 - **MANDATORY**: Run `make check-trailing-whitespace` to verify no trailing
   whitespaces remain
-- **macOS only**: After running `make fix-trailing-whitespace` or
-  `make format-md`, run these commands to clean up backup files created by sed:
-  ```bash
-  git clean -f -- '*-e' && git clean -f -- '**/*-e'
-  ```
 - This applies to ALL file modifications, regardless of file type
 - Trailing whitespaces are strictly prohibited in the codebase

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,17 @@ CIRCUITS_REPO ?= https://github.com/o1-labs/circuit-blobs.git
 CIRCUITS_REV ?= main
 CIRCUITS_NETWORKS ?= 3.0.0mainnet berkeley-devnet
 
+# Detect GNU sed (macOS requires gsed from Homebrew gnu-sed)
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+    SED := $(shell command -v gsed 2>/dev/null)
+    ifeq ($(SED),)
+        $(error GNU sed (gsed) not found on macOS. Install with: brew install gnu-sed)
+    endif
+else
+    SED := sed
+endif
+
 # Documentation server port
 DOCS_PORT ?= 3000
 
@@ -186,7 +197,7 @@ fix-trailing-whitespace: ## Remove trailing whitespaces from all files
 		-not -path "./website/static/api-docs/*" \
 		-not -path "./website/.docusaurus/*" \
 		-not -path "./.git/*" \
-		-exec sh -c 'echo "Processing: $$1"; sed -i'\'''\'' -e "s/[[:space:]]*$$//" "$$1"' _ {} \; && \
+		-exec sh -c 'echo "Processing: $$1"; $(SED) -i -e "s/[[:space:]]*$$//" "$$1"' _ {} \; && \
 		echo "Trailing whitespaces removed."
 
 .PHONY: check-trailing-whitespace

--- a/Makefile
+++ b/Makefile
@@ -190,8 +190,10 @@ fix-trailing-whitespace: ## Remove trailing whitespaces from all files
 		-o -name "*.js" -o -name "*.jsx" -o -name "*.sh" \) \
 		-not -path "./target/*" \
 		-not -path "./node_modules/*" \
+		-not -path "./frontend/.angular/*" \
 		-not -path "./frontend/node_modules/*" \
 		-not -path "./frontend/dist/*" \
+		-not -path "./pkg/*" \
 		-not -path "./website/node_modules/*" \
 		-not -path "./website/build/*" \
 		-not -path "./website/static/api-docs/*" \
@@ -209,8 +211,10 @@ check-trailing-whitespace: ## Check for trailing whitespaces in source files
 		-o -name "*.js" -o -name "*.jsx" -o -name "*.sh" \) \
 		-not -path "./target/*" \
 		-not -path "./node_modules/*" \
+		-not -path "./frontend/.angular/*" \
 		-not -path "./frontend/node_modules/*" \
 		-not -path "./frontend/dist/*" \
+		-not -path "./pkg/*" \
 		-not -path "./website/node_modules/*" \
 		-not -path "./website/build/*" \
 		-not -path "./website/static/api-docs/*" \

--- a/website/docs/developers/getting-started.mdx
+++ b/website/docs/developers/getting-started.mdx
@@ -10,6 +10,7 @@ import TabItem from "@theme/TabItem";
 import InstallRustSh from "!!raw-loader!./scripts/setup/install-rust.sh";
 import InstallSystemDepsSh from "!!raw-loader!./scripts/setup/install-system-deps.sh";
 import InstallSystemDepsMacOSSh from "!!raw-loader!./scripts/setup/install-system-deps-macos.sh";
+import InstallGnuSedMacOSSh from "!!raw-loader!./scripts/setup/install-gnu-sed-macos.sh";
 
 import InstallDockerSh from "!!raw-loader!./scripts/setup/install-docker.sh";
 import InstallDockerMacOSSh from "!!raw-loader!./scripts/setup/install-docker-macos.sh";
@@ -141,6 +142,21 @@ environment.
 The Mina Rust Node maintains strict code quality standards:
 
 <CodeBlock language="bash">{FormatAndLintSh}</CodeBlock>
+
+<!-- prettier-ignore-start -->
+
+:::note macOS users
+
+The `make fix-trailing-whitespace` command requires GNU sed. Install it with
+Homebrew:
+
+<CodeBlock language="bash">{InstallGnuSedMacOSSh}</CodeBlock>
+
+The Makefile will automatically use `gsed` on macOS when available.
+
+:::
+
+<!-- prettier-ignore-stop -->
 
 ### Working with Makefiles
 

--- a/website/docs/developers/scripts/setup/install-gnu-sed-macos.sh
+++ b/website/docs/developers/scripts/setup/install-gnu-sed-macos.sh
@@ -1,0 +1,1 @@
+brew install gnu-sed


### PR DESCRIPTION
## Summary

- Enforce GNU sed (gsed) on macOS instead of BSD sed workaround
- Makefile now fails with a clear error if gsed is not installed on macOS
- Add CI job to test `fix-trailing-whitespace` on both Ubuntu and macOS
- Add installation script and documentation for macOS users
- Remove obsolete sed backup file cleanup instructions from CLAUDE.md

Closes #1864

## Test plan

- [ ] Verify `make fix-trailing-whitespace` works on macOS with gsed installed
- [ ] Verify `make fix-trailing-whitespace` fails with clear error on macOS without gsed
- [ ] Verify CI job passes on both ubuntu-latest and macos-latest