### PR TITLE
CI: add beta channel lint workflow

### DIFF
--- a/.github/actions/load-versions/action.yml
+++ b/.github/actions/load-versions/action.yml
@@ -5,6 +5,9 @@ outputs:
   rust-stable:
     description: "Rust stable version"
     value: ${{ steps.load.outputs.rust-stable }}
+  rust-beta:
+    description: "Rust beta version"
+    value: ${{ steps.load.outputs.rust-beta }}
   rust-nightly:
     description: "Rust nightly version"
     value: ${{ steps.load.outputs.rust-nightly }}
@@ -26,6 +29,7 @@ runs:
 
         # Read versions from YAML file using yq
         RUST_STABLE=$(yq eval '.rust.stable' "$VERSIONS_FILE")
+        RUST_BETA=$(yq eval '.rust.beta' "$VERSIONS_FILE")
         RUST_NIGHTLY=$(yq eval '.rust.nightly' "$VERSIONS_FILE")
         OCAML_VERSION=$(yq eval '.ocaml.version' "$VERSIONS_FILE")
         NODE_VERSION_YAML=$(yq eval '.node.version' "$VERSIONS_FILE")
@@ -43,18 +47,21 @@ runs:
 
         # Set outputs
         echo "rust-stable=$RUST_STABLE" >> $GITHUB_OUTPUT
+        echo "rust-beta=$RUST_BETA" >> $GITHUB_OUTPUT
         echo "rust-nightly=$RUST_NIGHTLY" >> $GITHUB_OUTPUT
         echo "ocaml-version=$OCAML_VERSION" >> $GITHUB_OUTPUT
         echo "node-version=$NODE_VERSION_YAML" >> $GITHUB_OUTPUT
 
         # Also set as environment variables for convenience
         echo "RUST_STABLE_VERSION=$RUST_STABLE" >> $GITHUB_ENV
+        echo "RUST_BETA_VERSION=$RUST_BETA" >> $GITHUB_ENV
         echo "RUST_NIGHTLY_VERSION=$RUST_NIGHTLY" >> $GITHUB_ENV
         echo "OCAML_VERSION=$OCAML_VERSION" >> $GITHUB_ENV
         echo "NODE_VERSION=$NODE_VERSION_YAML" >> $GITHUB_ENV
 
         echo "Loaded versions:"
         echo "  Rust stable: $RUST_STABLE"
+        echo "  Rust beta: $RUST_BETA"
         echo "  Rust nightly: $RUST_NIGHTLY"
         echo "  OCaml: $OCAML_VERSION"
         echo "  Node.js: $NODE_VERSION_YAML"

--- a/.github/config/versions.yaml
+++ b/.github/config/versions.yaml
@@ -11,6 +11,7 @@
 
 rust:
   stable: "1.84"
+  beta: "beta"
   nightly: "nightly"
 
 ocaml:

--- a/.github/workflows/lint-beta.yaml
+++ b/.github/workflows/lint-beta.yaml
@@ -1,0 +1,47 @@
+name: Lint (Beta Channel)
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+  schedule:
+    # Run weekly on Mondays at 00:00 UTC
+    - cron: '0 0 * * 1'
+
+jobs:
+  lint-beta:
+    timeout-minutes: 15
+    name: Lint (Beta) - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    # Allow this job to fail without failing the entire workflow
+    continue-on-error: true
+    strategy:
+      matrix:
+        os: [ubuntu-24.04]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Load versions
+        uses: ./.github/actions/load-versions
+
+      - name: Setup build dependencies
+        uses: ./.github/actions/setup-build-deps
+
+      - name: Use shared OCaml setting up steps
+        uses: ./.github/actions/setup-ocaml
+        with:
+          ocaml_version: ${{ env.OCAML_VERSION }}
+
+      - name: Setup Rust (Beta)
+        uses: ./.github/actions/setup-rust
+        with:
+          toolchain: ${{ env.RUST_BETA_VERSION }}
+          components: clippy, rustfmt
+          cache-prefix: lint-beta-${{ env.RUST_BETA_VERSION }}-v0
+
+      - name: Run make check-beta
+        run: make check-beta
+
+      - name: Run make lint-beta
+        run: make lint-beta
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1838](https://github.com/o1-labs/mina-rust/pull/1838))
 - **Web Node**: fix webnode build, add quality-of-life improvements when running
   webnode in Docker. ([#1778](https://github.com/o1-labs/mina-rust/pull/1778))
+- **CI**: add beta channel lint workflow to catch build issues early
+  ([#1875](https://github.com/o1-labs/mina-rust/pull/1875))
 
 ### Changes
 

--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,10 @@ bench-database: ## Run ledger database benchmark
 check: ## Check code for compilation errors
 	cargo check --all-targets
 
+.PHONY: check-beta
+check-beta: ## Check code for compilation errors using beta Rust
+	cargo +beta check --all-targets
+
 .PHONY: check-tx-fuzzing
 check-tx-fuzzing: ## Check the transaction fuzzing tools, requires nightly Rust
 	@cd tools/fuzzing && cargo +$(NIGHTLY_RUST_VERSION) check
@@ -243,6 +247,10 @@ format-md: ## Format all markdown and MDX files to wrap at 80 characters
 .PHONY: lint
 lint: ## Run linter (clippy)
 	cargo clippy --all-targets -- -D warnings --allow clippy::mutable_key_type
+
+.PHONY: lint-beta
+lint-beta: ## Run linter (clippy) using beta Rust
+	cargo +beta clippy --all-targets -- -D warnings --allow clippy::mutable_key_type
 
 .PHONY: lint-bash
 lint-bash: ## Check all shell scripts using shellcheck


### PR DESCRIPTION
### Description

Add a new CI workflow to check compilation and linting with the Rust beta
channel. This helps catch build issues early before they appear in stable releases.

The make targets explicitly use `cargo +beta` to override `rust-toolchain.toml`,
ensuring the beta toolchain is used for checking and linting.

### Related Issue(s)

Closes #1777

### Type of Change

- [x] Build-related changes

### Testing

The workflow will run automatically on this PR to verify it works correctly.

- [x] Added make targets `check-beta` and `lint-beta`
- [x] Workflow configured with `continue-on-error: true`
- [x] Workflow runs successfully in CI (will verify on this PR)
See... the workflow failed, but that's actually a success! :)
<img width="881" height="542" alt="image" src="https://github.com/user-attachments/assets/adf4b823-6054-4502-9f05-184b246ed4b8" />


### Changelog Entry

**Changelog Summary:** CI: add beta channel lint workflow to catch
build issues early