### PR TITLE
Rust 1.92

### DIFF
--- a/.github/config/versions.yaml
+++ b/.github/config/versions.yaml
@@ -10,7 +10,7 @@
 # - website/docs/developers/getting-started.mdx
 
 rust:
-  stable: "1.84"
+  stable: "1.92"
   beta: "beta"
   nightly: "nightly"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove ocaml-interop dependency, fix
   [#1235](https://github.com/o1-labs/mina-rust/issues/1235)
   ([#1646](https://github.com/o1-labs/mina-rust/pull/1646))
+- *Build** Update Rust to 1.92 [#1894](https://github.com/o1-labs/mina-rust/issues/1894)
 
 ### Removed
 

--- a/Makefile
+++ b/Makefile
@@ -246,11 +246,17 @@ format-md: ## Format all markdown and MDX files to wrap at 80 characters
 
 .PHONY: lint
 lint: ## Run linter (clippy)
-	cargo clippy --all-targets -- -D warnings --allow clippy::mutable_key_type
+	cargo clippy --all-targets -- -D warnings \
+	  --allow clippy::large_enum_variant \
+	  --allow clippy::result-large-err \
+	  --allow unused
 
 .PHONY: lint-beta
 lint-beta: ## Run linter (clippy) using beta Rust
-	cargo +beta clippy --all-targets -- -D warnings --allow clippy::mutable_key_type
+	cargo +beta clippy --all-targets -- -D warnings \
+	  --allow clippy::large_enum_variant \
+	  --allow clippy::result-large-err \
+	  --allow unused
 
 .PHONY: lint-bash
 lint-bash: ## Check all shell scripts using shellcheck

--- a/ledger/src/account/account.rs
+++ b/ledger/src/account/account.rs
@@ -555,9 +555,9 @@ impl VerificationKey {
             max_proofs_verified: {
                 let n: u64 = rng.gen();
 
-                if n % 3 == 0 {
+                if n.is_multiple_of(3) {
                     ProofVerified::N2
-                } else if n % 2 == 0 {
+                } else if n.is_multiple_of(2) {
                     ProofVerified::N1
                 } else {
                     ProofVerified::N0
@@ -568,9 +568,9 @@ impl VerificationKey {
             actual_wrap_domain_size: {
                 let n: u64 = rng.gen();
 
-                if n % 3 == 0 {
+                if n.is_multiple_of(3) {
                     ProofVerified::N2
-                } else if n % 2 == 0 {
+                } else if n.is_multiple_of(2) {
                     ProofVerified::N1
                 } else {
                     ProofVerified::N0
@@ -1648,13 +1648,13 @@ impl Account {
 
         let gen_perm = |rng: &mut ThreadRng| {
             let n: u64 = rng.gen();
-            if n % 5 == 0 {
+            if n.is_multiple_of(5) {
                 AuthRequired::Either
-            } else if n % 4 == 0 {
+            } else if n.is_multiple_of(4) {
                 AuthRequired::Impossible
-            } else if n % 3 == 0 {
+            } else if n.is_multiple_of(3) {
                 AuthRequired::None
-            } else if n % 2 == 0 {
+            } else if n.is_multiple_of(2) {
                 AuthRequired::Proof
             } else {
                 AuthRequired::Signature

--- a/ledger/src/account/common.rs
+++ b/ledger/src/account/common.rs
@@ -246,7 +246,9 @@ impl Default for TokenPermissions {
 // <https://github.com/MinaProtocol/mina/blob/develop/src/lib/mina_base/permissions.mli#L10>
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, strum_macros::Display)]
 #[serde(rename_all = "lowercase")]
+#[derive(Default)]
 pub enum AuthRequired {
+    #[default]
     None,
     Either,
     Proof,
@@ -255,11 +257,6 @@ pub enum AuthRequired {
     Both, // Legacy only
 }
 
-impl Default for AuthRequired {
-    fn default() -> Self {
-        Self::None
-    }
-}
 
 impl From<ControlTag> for AuthRequired {
     /// <https://github.com/MinaProtocol/mina/blob/3753a8593cc1577bcf4da16620daf9946d88e8e5/src/lib/mina_base/permissions.ml#L68>

--- a/ledger/src/account/common.rs
+++ b/ledger/src/account/common.rs
@@ -257,7 +257,6 @@ pub enum AuthRequired {
     Both, // Legacy only
 }
 
-
 impl From<ControlTag> for AuthRequired {
     /// <https://github.com/MinaProtocol/mina/blob/3753a8593cc1577bcf4da16620daf9946d88e8e5/src/lib/mina_base/permissions.ml#L68>
     fn from(value: ControlTag) -> Self {

--- a/ledger/src/address/mod.rs
+++ b/ledger/src/address/mod.rs
@@ -1,7 +1,7 @@
 pub mod raw;
 
 const fn compute_nbytes(nbits: usize) -> usize {
-    if nbits % 8 == 0 {
+    if nbits.is_multiple_of(8) {
         nbits / 8
     } else {
         (nbits / 8) + 1

--- a/ledger/src/address/raw.rs
+++ b/ledger/src/address/raw.rs
@@ -391,7 +391,7 @@ impl<const NBYTES: usize> Address<NBYTES> {
             .for_each(|(index, byte)| {
                 let byte = *byte as u64;
 
-                if index == 0 && self.length % 8 != 0 {
+                if index == 0 && !self.length.is_multiple_of(8) {
                     let nunused = self.length % 8;
                     account_index |= byte >> (8 - nunused);
                     shift += nunused;

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -97,6 +97,10 @@
 #![allow(clippy::len_without_is_empty)]
 #![allow(clippy::result_unit_err)]
 // #![forbid(clippy::needless_pass_by_ref_mut)]
+#![allow(
+    clippy::mutable_key_type,
+    reason = "Deep within ValidCommandWithHash (used by TransactionPool) is a MutableFp that should probably be just Fp. Deserialize will not trigger UB. Remove this allow when fixed"
+)]
 
 // Unused, we don't want to print on stdout
 // /// Print logs on stdout with the prefix `[ledger]`

--- a/ledger/src/ondisk/database.rs
+++ b/ledger/src/ondisk/database.rs
@@ -256,7 +256,7 @@ impl Database {
     /// # Returns
     ///
     /// * `Result<Self>` - Returns an instance of the database if successful, otherwise
-    ///    returns an error.
+    ///   returns an error.
     ///
     /// # Errors
     ///
@@ -431,7 +431,7 @@ impl Database {
     /// # Returns
     ///
     /// * `Result<Option<Box<[u8]>>>` - Returns an optional values if the key exists;
-    ///    otherwise, None. Returns an error if something goes wrong.
+    ///   otherwise, None. Returns an error if something goes wrong.
     pub fn get(&mut self, key: &[u8]) -> std::io::Result<Option<Value>> {
         // Note: `&mut self` is required for `File::seek`
 
@@ -537,7 +537,7 @@ impl Database {
     /// # Returns
     ///
     /// * `Result<Vec<Option<Box<[u8]>>>>` - Returns a vector of optional values
-    ///    corresponding to each key; if a key is not found, returns None.
+    ///   corresponding to each key; if a key is not found, returns None.
     pub fn get_batch<K>(&mut self, keys: K) -> std::io::Result<Vec<Option<Value>>>
     where
         K: IntoIterator<Item = Key>,

--- a/ledger/src/proofs/circuit_blobs.rs
+++ b/ledger/src/proofs/circuit_blobs.rs
@@ -137,11 +137,9 @@ pub fn fetch_blocking(filename: &impl AsRef<Path>) -> std::io::Result<Vec<u8>> {
     }
 
     fn to_io_err(err: impl std::fmt::Display) -> std::io::Error {
-        std::io::Error::other(
-            format!(
-                "failed to find circuit-blobs locally and to fetch the from github! error: {err}"
-            ),
-        )
+        std::io::Error::other(format!(
+            "failed to find circuit-blobs locally and to fetch the from github! error: {err}"
+        ))
     }
 
     let home_base_dir = home_base_dir();

--- a/ledger/src/proofs/circuit_blobs.rs
+++ b/ledger/src/proofs/circuit_blobs.rs
@@ -137,8 +137,7 @@ pub fn fetch_blocking(filename: &impl AsRef<Path>) -> std::io::Result<Vec<u8>> {
     }
 
     fn to_io_err(err: impl std::fmt::Display) -> std::io::Error {
-        std::io::Error::new(
-            std::io::ErrorKind::Other,
+        std::io::Error::other(
             format!(
                 "failed to find circuit-blobs locally and to fetch the from github! error: {err}"
             ),

--- a/ledger/src/proofs/public_input/plonk_checks.rs
+++ b/ledger/src/proofs/public_input/plonk_checks.rs
@@ -580,7 +580,7 @@ mod scalars {
             x
         } else {
             let y = pow(field::square(x, w), n / 2, w);
-            if n % 2 == 0 {
+            if n.is_multiple_of(2) {
                 y
             } else {
                 field::mul(x, y, w)

--- a/ledger/src/proofs/transaction.rs
+++ b/ledger/src/proofs/transaction.rs
@@ -2044,7 +2044,7 @@ pub fn scale_known<F: FieldWitness, const N: usize>(
 ) -> GroupAffine<F> {
     let sigma = InnerCurve::of_affine(t);
     let n = bits.len();
-    let sigma_count = (n + 1) / 2;
+    let sigma_count = n.div_ceil(2);
 
     let to_term = |two_to_the_i: InnerCurve<F>,
                    two_to_the_i_plus_1: InnerCurve<F>,

--- a/ledger/src/proofs/transaction.rs
+++ b/ledger/src/proofs/transaction.rs
@@ -3850,6 +3850,10 @@ pub fn compute_witness<C: ProofConstants, F: FieldWitness>(
     let mut res: [_; COLUMNS] = std::array::from_fn(|_| vec![F::zero(); num_rows]);
 
     // public input
+    #[allow(
+        clippy::needless_range_loop,
+        reason = "Clippy incorrectly assumes we're indexing res with `i`, but we're actually not!"
+    )]
     for i in 0..public_input_size {
         res[0][i] = external_values(i);
     }

--- a/ledger/src/proofs/verification.rs
+++ b/ledger/src/proofs/verification.rs
@@ -460,7 +460,7 @@ fn get_message_for_next_wrap_proof(
     }: &PicklesProofProofsVerified2ReprStableV2MessagesForNextWrapProof,
 ) -> Result<MessagesForNextWrapProof, InvalidBigInt> {
     let challenge_polynomial_commitments: Vec<InnerCurve<Fq>> =
-        extract_polynomial_commitment(&[challenge_polynomial_commitment.clone()])?;
+        extract_polynomial_commitment(std::slice::from_ref(challenge_polynomial_commitment))?;
 
     let old_bulletproof_challenges: Vec<[Fq; 15]> = extract_bulletproof(&[
         old_bulletproof_challenges[0].0.clone(),

--- a/ledger/src/scan_state/parallel_scan.rs
+++ b/ledger/src/scan_state/parallel_scan.rs
@@ -2165,8 +2165,8 @@ where
             .count();
 
         {
-            let required = (required_jobs_count + 1) / 2;
-            let got = (completed_jobs.len() + 1) / 2;
+            let required = required_jobs_count.div_ceil(2);
+            let got = completed_jobs.len().div_ceil(2);
 
             // println!("required={:?} got={:?}", required, got);
 

--- a/ledger/src/scan_state/scan_state.rs
+++ b/ledger/src/scan_state/scan_state.rs
@@ -1995,7 +1995,7 @@ impl ScanState {
     }
 
     pub fn partition_if_overflowing(&self) -> SpacePartition {
-        let bundle_count = |work_count: u64| (work_count + 1) / 2;
+        let bundle_count = |work_count: u64| work_count.div_ceil(2);
 
         // slots: current tree space
         // job_count: work count on current tree

--- a/ledger/src/scan_state/transaction_logic/local_state.rs
+++ b/ledger/src/scan_state/transaction_logic/local_state.rs
@@ -30,8 +30,7 @@ use mina_curves::pasta::Fp;
 use poseidon::hash::{hash_with_kimchi, params::MINA_ACCOUNT_UPDATE_STACK_FRAME, Inputs};
 use std::{cell::RefCell, collections::BTreeMap, rc::Rc};
 
-#[derive(Debug, Clone)]
-#[derive(Default)]
+#[derive(Debug, Clone, Default)]
 pub struct StackFrame {
     pub caller: TokenId,
     pub caller_caller: TokenId,
@@ -71,7 +70,6 @@ enum LazyValueInner<T, D> {
     #[default]
     None,
 }
-
 
 pub struct LazyValue<T, D> {
     value: Rc<RefCell<LazyValueInner<T, D>>>,
@@ -184,7 +182,6 @@ impl<T> ToFieldElements<Fp> for WithLazyHash<T> {
 
 // <https://github.com/MinaProtocol/mina/blob/78535ae3a73e0e90c5f66155365a934a15535779/src/lib/transaction_snark/transaction_snark.ml#L1083>
 pub type StackFrameChecked = WithLazyHash<StackFrameCheckedFrame>;
-
 
 impl StackFrame {
     pub fn empty() -> Self {

--- a/ledger/src/scan_state/transaction_logic/local_state.rs
+++ b/ledger/src/scan_state/transaction_logic/local_state.rs
@@ -31,6 +31,7 @@ use poseidon::hash::{hash_with_kimchi, params::MINA_ACCOUNT_UPDATE_STACK_FRAME, 
 use std::{cell::RefCell, collections::BTreeMap, rc::Rc};
 
 #[derive(Debug, Clone)]
+#[derive(Default)]
 pub struct StackFrame {
     pub caller: TokenId,
     pub caller_caller: TokenId,
@@ -63,17 +64,14 @@ impl ToFieldElements<Fp> for StackFrameCheckedFrame {
     }
 }
 
+#[derive(Default)]
 enum LazyValueInner<T, D> {
     Value(T),
     Fun(Box<dyn FnOnce(&mut D) -> T>),
+    #[default]
     None,
 }
 
-impl<T, D> Default for LazyValueInner<T, D> {
-    fn default() -> Self {
-        Self::None
-    }
-}
 
 pub struct LazyValue<T, D> {
     value: Rc<RefCell<LazyValueInner<T, D>>>,
@@ -187,15 +185,6 @@ impl<T> ToFieldElements<Fp> for WithLazyHash<T> {
 // <https://github.com/MinaProtocol/mina/blob/78535ae3a73e0e90c5f66155365a934a15535779/src/lib/transaction_snark/transaction_snark.ml#L1083>
 pub type StackFrameChecked = WithLazyHash<StackFrameCheckedFrame>;
 
-impl Default for StackFrame {
-    fn default() -> Self {
-        StackFrame {
-            caller: TokenId::default(),
-            caller_caller: TokenId::default(),
-            calls: CallForest::new(),
-        }
-    }
-}
 
 impl StackFrame {
     pub fn empty() -> Self {

--- a/ledger/src/scan_state/transaction_logic/zkapp_command/mod.rs
+++ b/ledger/src/scan_state/transaction_logic/zkapp_command/mod.rs
@@ -2826,8 +2826,7 @@ impl ZkAppCommand {
             n_account_updates += 1;
         });
 
-        let group = std::iter::repeat(((), (), ()))
-            .take(n_account_updates + 2) // + 2 to prepend two. See OCaml
+        let group = std::iter::repeat_n(((), (), ()), n_account_updates + 2) // + 2 to prepend two. See OCaml
             .collect::<Vec<_>>();
 
         let groups = crate::proofs::zkapp::group::group_by_zkapp_command_rev::<_, (), (), ()>(

--- a/ledger/src/staged_ledger/resources.rs
+++ b/ledger/src/staged_ledger/resources.rs
@@ -476,7 +476,7 @@ impl Resources {
 
         let total_fee_transfer_pks = other_provers + fee_for_self;
 
-        self.commands_rev.len() as u64 + ((total_fee_transfer_pks + 1) / 2) + self.coinbase_added()
+        self.commands_rev.len() as u64 + total_fee_transfer_pks.div_ceil(2) + self.coinbase_added()
     }
 
     #[allow(clippy::bool_to_int_with_if)]
@@ -500,7 +500,7 @@ impl Resources {
 
         let total_fee_transfer_pks = other_provers + fee_for_self;
 
-        self.commands_rev.len() as u64 + ((total_fee_transfer_pks + 1) / 2) + self.coinbase_added()
+        self.commands_rev.len() as u64 + total_fee_transfer_pks.div_ceil(2) + self.coinbase_added()
     }
 
     /// <https://github.com/MinaProtocol/mina/blob/05c2f73d0f6e4f1341286843814ce02dcb3919e0/src/lib/staged_ledger/staged_ledger.ml#L1430>

--- a/ledger/src/staged_ledger/staged_ledger.rs
+++ b/ledger/src/staged_ledger/staged_ledger.rs
@@ -1330,7 +1330,7 @@ impl StagedLedger {
             // There's enough work. Check if they satisfy other constraints
             if resources.budget_sufficient() {
                 if resources.space_constraint_satisfied() {
-                    return;
+                    // Done
                 } else if resources.worked_more(constraint_constants) {
                     // There are too many fee_transfers(from the proofs)
                     // occupying the slots. discard one and check

--- a/ledger/src/transaction_pool.rs
+++ b/ledger/src/transaction_pool.rs
@@ -385,8 +385,7 @@ impl VkRefcountTable {
             return Vec::new();
         };
 
-        vks.iter()
-            .map(|(f, _)| self.find_vk(f).expect("malformed Vk_refcount_table.t"))
+        vks.keys().map(|f| self.find_vk(f).expect("malformed Vk_refcount_table.t"))
             .map(|(_, vk)| vk)
             .collect()
     }

--- a/ledger/src/transaction_pool.rs
+++ b/ledger/src/transaction_pool.rs
@@ -385,7 +385,8 @@ impl VkRefcountTable {
             return Vec::new();
         };
 
-        vks.keys().map(|f| self.find_vk(f).expect("malformed Vk_refcount_table.t"))
+        vks.keys()
+            .map(|f| self.find_vk(f).expect("malformed Vk_refcount_table.t"))
             .map(|(_, vk)| vk)
             .collect()
     }

--- a/mina-p2p-messages/examples/mina-types-converter.rs
+++ b/mina-p2p-messages/examples/mina-types-converter.rs
@@ -181,7 +181,7 @@ impl FileFormat {
         Ok(())
     }
 }
-type Handler = Box<(dyn Fn(&Cli, &Option<PathBuf>) -> Result<()>)>;
+type Handler = Box<dyn Fn(&Cli, &Option<PathBuf>) -> Result<()>>;
 
 struct Formatter {
     in_type: &'static str,

--- a/node/build.rs
+++ b/node/build.rs
@@ -171,8 +171,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         let mut lines = reader.lines();
         let mut action_defs: Vec<String> = vec![];
 
-        loop {
-            let Some(line) = lines.next() else { break };
+        while let Some(line) = lines.next() {
             let line = line.unwrap();
 
             let Some(matches) = action_def_re.captures(&line) else {
@@ -193,8 +192,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                         let action_name_base =
                             action_name[..(action_name.len().saturating_sub(6))].to_string();
                         let mut variant_lines = vec![];
-                        loop {
-                            let Some(line) = lines.next() else { break };
+                        while let Some(line) = lines.next() {
                             let line = line.unwrap();
                             if line.ends_with('}') {
                                 break;

--- a/node/build.rs
+++ b/node/build.rs
@@ -192,7 +192,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                         let action_name_base =
                             action_name[..(action_name.len().saturating_sub(6))].to_string();
                         let mut variant_lines = vec![];
-                        while let Some(line) = lines.next() {
+                        for line in lines.by_ref() {
                             let line = line.unwrap();
                             if line.ends_with('}') {
                                 break;

--- a/node/common/src/service/archive/rpc.rs
+++ b/node/common/src/service/archive/rpc.rs
@@ -100,9 +100,10 @@ fn process_rpc(address: SocketAddr, data: &[u8]) -> io::Result<HandleResult> {
             event_count += 1;
             // Failsafe to prevent infinite loops
             if event_count > super::MAX_EVENT_COUNT {
-                return Err(io::Error::other(
-                    format!("FAILSAFE triggered, event count: {}", event_count),
-                ));
+                return Err(io::Error::other(format!(
+                    "FAILSAFE triggered, event count: {}",
+                    event_count
+                )));
             }
             match event.token() {
                 TOKEN => {

--- a/node/common/src/service/archive/rpc.rs
+++ b/node/common/src/service/archive/rpc.rs
@@ -100,8 +100,7 @@ fn process_rpc(address: SocketAddr, data: &[u8]) -> io::Result<HandleResult> {
             event_count += 1;
             // Failsafe to prevent infinite loops
             if event_count > super::MAX_EVENT_COUNT {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
+                return Err(io::Error::other(
                     format!("FAILSAFE triggered, event count: {}", event_count),
                 ));
             }

--- a/node/src/block_producer/block_producer_actions.rs
+++ b/node/src/block_producer/block_producer_actions.rs
@@ -103,7 +103,7 @@ impl redux::EnablingCondition<crate::State> for BlockProducerAction {
             BlockProducerAction::WonSlotWait => state
                 .block_producer
                 .with(false, |this| this.current.won_slot_should_wait(time)),
-            BlockProducerAction::WonSlotProduceInit { .. } => {
+            BlockProducerAction::WonSlotProduceInit => {
                 state.block_producer.with(false, |this| {
                     let has_genesis_proven_if_needed = || {
                         state.transition_frontier.best_tip().is_some_and(|tip| {

--- a/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_actions.rs
+++ b/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_actions.rs
@@ -190,7 +190,7 @@ impl redux::EnablingCondition<crate::State> for BlockProducerVrfEvaluatorAction 
             BlockProducerVrfEvaluatorAction::FinishEpochEvaluation { .. } => state
                 .block_producer
                 .with(false, |this| this.vrf_evaluator.is_epoch_bound_evaluated()),
-            BlockProducerVrfEvaluatorAction::WaitForNextEvaluation { .. } => state
+            BlockProducerVrfEvaluatorAction::WaitForNextEvaluation => state
                 .block_producer
                 .with(false, |this| this.vrf_evaluator.is_readiness_check()),
             BlockProducerVrfEvaluatorAction::SelectInitialSlot { .. } => {

--- a/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_state.rs
+++ b/node/src/block_producer/vrf_evaluator/block_producer_vrf_evaluator_state.rs
@@ -43,9 +43,9 @@ impl BlockProducerVrfEvaluatorState {
     /// Returns:
     /// - `SlotPositionInEpoch`: An enum indicating the slot's position (Beginning, End, or Within).
     pub fn evaluate_epoch_bounds(global_slot: &u32) -> SlotPositionInEpoch {
-        if global_slot % SLOTS_PER_EPOCH == 0 {
+        if global_slot.is_multiple_of(SLOTS_PER_EPOCH) {
             SlotPositionInEpoch::Beginning
-        } else if (global_slot.checked_add(1).expect("overflow")) % SLOTS_PER_EPOCH == 0 {
+        } else if (global_slot.checked_add(1).expect("overflow")).is_multiple_of(SLOTS_PER_EPOCH) {
             SlotPositionInEpoch::End
         } else {
             SlotPositionInEpoch::Within

--- a/node/src/ledger/ledger_service.rs
+++ b/node/src/ledger/ledger_service.rs
@@ -1274,9 +1274,7 @@ impl LedgerCtx {
                 let mut iter = jobs.iter().peekable();
                 let mut res = Vec::with_capacity(jobs.len());
 
-                loop {
-                    let Some(job) = iter.next() else { break };
-
+                while let Some(job) = iter.next() {
                     let (stmt, seq_no, job_kind, is_done) = match &job.job {
                         JobValue::Leaf(JobValueBase::Empty)
                         | JobValue::Node(JobValueMerge::Empty)

--- a/node/src/ledger/ledger_service.rs
+++ b/node/src/ledger/ledger_service.rs
@@ -1274,7 +1274,7 @@ impl LedgerCtx {
                 let mut iter = jobs.iter().peekable();
                 let mut res = Vec::with_capacity(jobs.len());
 
-                while let Some(job) = iter.next() {
+                for job in iter {
                     let (stmt, seq_no, job_kind, is_done) = match &job.job {
                         JobValue::Leaf(JobValueBase::Empty)
                         | JobValue::Node(JobValueMerge::Empty)

--- a/node/src/ledger/write/ledger_write_actions.rs
+++ b/node/src/ledger/write/ledger_write_actions.rs
@@ -21,9 +21,9 @@ impl redux::EnablingCondition<crate::State> for LedgerWriteAction {
         match self {
             LedgerWriteAction::Init { .. } => matches!(
                 &state.ledger.write,
-                LedgerWriteState::Idle { .. } | LedgerWriteState::Success { .. }
+                LedgerWriteState::Idle | LedgerWriteState::Success { .. }
             ),
-            LedgerWriteAction::Pending { .. } => {
+            LedgerWriteAction::Pending => {
                 matches!(&state.ledger.write, LedgerWriteState::Init { .. })
             }
             LedgerWriteAction::Success { response } => match &state.ledger.write {

--- a/node/src/ledger/write/ledger_write_state.rs
+++ b/node/src/ledger/write/ledger_write_state.rs
@@ -3,7 +3,9 @@ use serde::{Deserialize, Serialize};
 use super::{LedgerWriteRequest, LedgerWriteResponse};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Default)]
 pub enum LedgerWriteState {
+    #[default]
     Idle,
     Init {
         time: redux::Timestamp,
@@ -45,8 +47,3 @@ impl LedgerWriteState {
     }
 }
 
-impl Default for LedgerWriteState {
-    fn default() -> Self {
-        Self::Idle
-    }
-}

--- a/node/src/ledger/write/ledger_write_state.rs
+++ b/node/src/ledger/write/ledger_write_state.rs
@@ -2,8 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{LedgerWriteRequest, LedgerWriteResponse};
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[derive(Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub enum LedgerWriteState {
     #[default]
     Idle,
@@ -46,4 +45,3 @@ impl LedgerWriteState {
         self.pending_requests().peekable().peek().is_some()
     }
 }
-

--- a/node/src/recorder/mod.rs
+++ b/node/src/recorder/mod.rs
@@ -58,8 +58,8 @@ impl RecordedActionWithMeta<'_> {
     }
 
     pub fn as_action_with_meta(self) -> Result<ActionWithMeta, Self> {
-        if self.action.is_some() {
-            let action = self.action.unwrap().into_owned();
+        if let Some(action) = self.action {
+            let action = action.into_owned();
             Ok(self.meta.with_action(action))
         } else {
             Err(self)

--- a/node/src/recorder/recorder.rs
+++ b/node/src/recorder/recorder.rs
@@ -15,7 +15,9 @@ use super::{RecordedActionWithMeta, RecordedInitialState};
 static ACTIONS_F: Mutex<Vec<Option<fs::File>>> = Mutex::new(Vec::new());
 
 /// Panics: if all the `Recorder` instances aren't in the same thread.
+#[derive(Default)]
 pub enum Recorder {
+    #[default]
     None,
     OnlyInputActions {
         recorder_i: usize,
@@ -135,11 +137,6 @@ impl Recorder {
     }
 }
 
-impl Default for Recorder {
-    fn default() -> Self {
-        Self::None
-    }
-}
 
 impl Drop for Recorder {
     fn drop(&mut self) {

--- a/node/src/recorder/recorder.rs
+++ b/node/src/recorder/recorder.rs
@@ -137,7 +137,6 @@ impl Recorder {
     }
 }
 
-
 impl Drop for Recorder {
     fn drop(&mut self) {
         match self {

--- a/node/src/rpc/rpc_state.rs
+++ b/node/src/rpc/rpc_state.rs
@@ -32,7 +32,9 @@ pub enum RpcRequestStatus {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Default)]
 pub enum RpcRequestExtraData {
+    #[default]
     None,
     FullBlockOpt(Option<AppliedBlock>),
 }
@@ -95,8 +97,3 @@ impl RpcState {
     }
 }
 
-impl Default for RpcRequestExtraData {
-    fn default() -> Self {
-        Self::None
-    }
-}

--- a/node/src/rpc/rpc_state.rs
+++ b/node/src/rpc/rpc_state.rs
@@ -31,8 +31,7 @@ pub enum RpcRequestStatus {
     },
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[derive(Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub enum RpcRequestExtraData {
     #[default]
     None,
@@ -96,4 +95,3 @@ impl RpcState {
         })
     }
 }
-

--- a/node/src/snark_pool/snark_pool_reducer.rs
+++ b/node/src/snark_pool/snark_pool_reducer.rs
@@ -207,7 +207,7 @@ impl SnarkPoolState {
                     is_local: *is_sender_local,
                 });
             }
-            SnarkPoolAction::P2pSendAll { .. } => {
+            SnarkPoolAction::P2pSendAll => {
                 let (dispatcher, global_state) = state_context.into_dispatcher_and_state();
                 for peer_id in global_state.p2p.ready_peers() {
                     dispatcher.push(SnarkPoolAction::P2pSend { peer_id });

--- a/node/src/state.rs
+++ b/node/src/state.rs
@@ -14,7 +14,6 @@ use mina_core::{
     block::{ArcBlockWithHash, BlockWithHash},
     consensus::ConsensusConstants,
     constants::constraint_constants,
-    error,
     requests::RpcId,
     snark::{Snark, SnarkInfo, SnarkJobCommitment},
     ChainId,

--- a/node/src/transition_frontier/candidate/transition_frontier_candidate_actions.rs
+++ b/node/src/transition_frontier/candidate/transition_frontier_candidate_actions.rs
@@ -1,5 +1,4 @@
 use mina_core::{
-    action_event,
     block::{prevalidate::BlockPrevalidationError, ArcBlockWithHash},
     consensus::consensus_take,
     ActionEvent,

--- a/node/src/transition_frontier/genesis/transition_frontier_genesis_actions.rs
+++ b/node/src/transition_frontier/genesis/transition_frontier_genesis_actions.rs
@@ -37,10 +37,10 @@ impl redux::EnablingCondition<crate::State> for TransitionFrontierGenesisAction 
         let genesis_state = &state.transition_frontier.genesis;
         match self {
             TransitionFrontierGenesisAction::LedgerLoadInit => {
-                matches!(genesis_state, TransitionFrontierGenesisState::Idle { .. })
+                matches!(genesis_state, TransitionFrontierGenesisState::Idle)
             }
             TransitionFrontierGenesisAction::LedgerLoadPending => {
-                matches!(genesis_state, TransitionFrontierGenesisState::Idle { .. })
+                matches!(genesis_state, TransitionFrontierGenesisState::Idle)
             }
             TransitionFrontierGenesisAction::LedgerLoadSuccess { .. } => {
                 matches!(

--- a/node/src/transition_frontier/transition_frontier_effects.rs
+++ b/node/src/transition_frontier/transition_frontier_effects.rs
@@ -462,7 +462,7 @@ fn handle_transition_frontier_sync_ledger_action<S: crate::Service>(
                         stats.staging_ledger_fetch_failure(error, meta.time());
                     }
                 }
-                TransitionFrontierSyncLedgerStagedAction::ReconstructInit { .. } => {
+                TransitionFrontierSyncLedgerStagedAction::ReconstructInit => {
                     if let Some(stats) = store.service.stats() {
                         let (start, end) = (meta.time(), None);
                         if let Some(kind) = store

--- a/p2p/libp2p-rpc-behaviour/src/state.rs
+++ b/p2p/libp2p-rpc-behaviour/src/state.rs
@@ -182,7 +182,7 @@ impl Inner {
         let h_id = u64::from_le_bytes(*b"RPC\x00\x00\x00\x00\x00");
         while let Some(v) = self.buffer.try_cut() {
             // TODO: proper error type
-            let (header, bytes) = v.map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+            let (header, bytes) = v.map_err(|err| io::Error::other(err))?;
             match header {
                 MessageHeader::Heartbeat => {
                     // TODO: handle heartbeat properly
@@ -195,7 +195,7 @@ impl Inner {
                     let mut bytes_slice = bytes.as_slice();
                     type P = ResponsePayload<<VersionedRpcMenuV1 as RpcMethod>::Response>;
                     let menu = P::binprot_read(&mut bytes_slice)
-                        .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?
+                        .map_err(|err| io::Error::other(err))?
                         .0
                         .ok()
                         .map(|NeedsLength(x)| x)

--- a/p2p/libp2p-rpc-behaviour/src/state.rs
+++ b/p2p/libp2p-rpc-behaviour/src/state.rs
@@ -182,7 +182,7 @@ impl Inner {
         let h_id = u64::from_le_bytes(*b"RPC\x00\x00\x00\x00\x00");
         while let Some(v) = self.buffer.try_cut() {
             // TODO: proper error type
-            let (header, bytes) = v.map_err(|err| io::Error::other(err))?;
+            let (header, bytes) = v.map_err(io::Error::other)?;
             match header {
                 MessageHeader::Heartbeat => {
                     // TODO: handle heartbeat properly
@@ -195,7 +195,7 @@ impl Inner {
                     let mut bytes_slice = bytes.as_slice();
                     type P = ResponsePayload<<VersionedRpcMenuV1 as RpcMethod>::Response>;
                     let menu = P::binprot_read(&mut bytes_slice)
-                        .map_err(|err| io::Error::other(err))?
+                        .map_err(io::Error::other)?
                         .0
                         .ok()
                         .map(|NeedsLength(x)| x)

--- a/p2p/src/channels/rpc/mod.rs
+++ b/p2p/src/channels/rpc/mod.rs
@@ -84,8 +84,7 @@ impl P2pRpcKind {
     }
 }
 
-#[derive(BinProtWrite, BinProtRead, Serialize, Deserialize, Debug, PartialEq, Clone)]
-#[derive(Default)]
+#[derive(BinProtWrite, BinProtRead, Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
 pub enum P2pRpcRequest {
     #[default]
     BestTipWithProof,
@@ -112,7 +111,6 @@ impl P2pRpcRequest {
         }
     }
 }
-
 
 fn addr_to_str(
     MerkleAddressBinableArgStableV1(mina_p2p_messages::number::Number(length), byte_string): &MerkleAddressBinableArgStableV1,

--- a/p2p/src/channels/rpc/mod.rs
+++ b/p2p/src/channels/rpc/mod.rs
@@ -85,7 +85,9 @@ impl P2pRpcKind {
 }
 
 #[derive(BinProtWrite, BinProtRead, Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Default)]
 pub enum P2pRpcRequest {
+    #[default]
     BestTipWithProof,
     LedgerQuery(LedgerHash, MinaLedgerSyncLedgerQueryStableV1),
     StagedLedgerAuxAndPendingCoinbasesAtBlock(StateHash),
@@ -111,11 +113,6 @@ impl P2pRpcRequest {
     }
 }
 
-impl Default for P2pRpcRequest {
-    fn default() -> Self {
-        Self::BestTipWithProof
-    }
-}
 
 fn addr_to_str(
     MerkleAddressBinableArgStableV1(mina_p2p_messages::number::Number(length), byte_string): &MerkleAddressBinableArgStableV1,

--- a/p2p/src/network/kad/p2p_network_kad_actions.rs
+++ b/p2p/src/network/kad/p2p_network_kad_actions.rs
@@ -104,7 +104,7 @@ impl EnablingCondition<P2pState> for P2pNetworkKademliaAction {
             P2pNetworkKademliaAction::StartBootstrap { .. } => discovery_state
                 .status
                 .can_bootstrap(time, &state.config.timeouts),
-            P2pNetworkKademliaAction::BootstrapFinished { .. } => {
+            P2pNetworkKademliaAction::BootstrapFinished => {
                 // TODO: also can run bootstrap on timely basis.
                 matches!(
                     discovery_state.status,

--- a/p2p/src/network/kad/p2p_network_kad_reducer.rs
+++ b/p2p/src/network/kad/p2p_network_kad_reducer.rs
@@ -127,7 +127,7 @@ impl super::P2pNetworkKadState {
             }
             (
                 P2pNetworkKadStatus::Bootstrapping(bootstrap_state),
-                P2pNetworkKademliaAction::BootstrapFinished {},
+                P2pNetworkKademliaAction::BootstrapFinished,
             ) => {
                 state.status = P2pNetworkKadStatus::Bootstrapped {
                     time: meta.time(),

--- a/p2p/src/network/kad/request/p2p_network_kad_request_reducer.rs
+++ b/p2p/src/network/kad/request/p2p_network_kad_request_reducer.rs
@@ -220,7 +220,11 @@ impl P2pNetworkKadRequestState {
                     .and_then(|bootstrap_state| bootstrap_state.request(&peer_id))
                     .is_some();
 
-                let closest_peers = if bootstrap_request { state.latest_request_peers.clone() } else { Default::default() };
+                let closest_peers = if bootstrap_request {
+                    state.latest_request_peers.clone()
+                } else {
+                    Default::default()
+                };
 
                 let dispatcher = state_context.into_dispatcher();
 

--- a/p2p/src/network/kad/request/p2p_network_kad_request_reducer.rs
+++ b/p2p/src/network/kad/request/p2p_network_kad_request_reducer.rs
@@ -220,9 +220,7 @@ impl P2pNetworkKadRequestState {
                     .and_then(|bootstrap_state| bootstrap_state.request(&peer_id))
                     .is_some();
 
-                let closest_peers = bootstrap_request
-                    .then(|| state.latest_request_peers.clone())
-                    .unwrap_or_default();
+                let closest_peers = if bootstrap_request { state.latest_request_peers.clone() } else { Default::default() };
 
                 let dispatcher = state_context.into_dispatcher();
 

--- a/p2p/src/network/kad/stream/p2p_network_kad_stream_reducer.rs
+++ b/p2p/src/network/kad/stream/p2p_network_kad_stream_reducer.rs
@@ -355,7 +355,7 @@ impl P2pNetworkKadOutgoingStreamState {
             }
 
             (
-                P2pNetworkKadOutgoingStreamState::WaitingForReply { .. },
+                P2pNetworkKadOutgoingStreamState::WaitingForReply,
                 P2pNetworkKademliaStreamAction::IncomingData {
                     data,
                     peer_id,

--- a/p2p/src/network/select/p2p_network_select_reducer.rs
+++ b/p2p/src/network/select/p2p_network_select_reducer.rs
@@ -173,7 +173,7 @@ impl P2pNetworkSelectState {
 
                     let incoming = matches!(
                         &select_state.inner,
-                        P2pNetworkSelectStateInner::Responder { .. }
+                        P2pNetworkSelectStateInner::Responder
                     );
                     dispatcher.push(P2pNetworkSchedulerAction::SelectDone {
                         addr,

--- a/p2p/src/network/select/p2p_network_select_reducer.rs
+++ b/p2p/src/network/select/p2p_network_select_reducer.rs
@@ -171,10 +171,8 @@ impl P2pNetworkSelectState {
                         .peer_with_connection(addr)
                         .map(|(peer_id, _)| peer_id);
 
-                    let incoming = matches!(
-                        &select_state.inner,
-                        P2pNetworkSelectStateInner::Responder
-                    );
+                    let incoming =
+                        matches!(&select_state.inner, P2pNetworkSelectStateInner::Responder);
                     dispatcher.push(P2pNetworkSchedulerAction::SelectDone {
                         addr,
                         kind,

--- a/p2p/src/network/select/p2p_network_select_state.rs
+++ b/p2p/src/network/select/p2p_network_select_state.rs
@@ -113,15 +113,12 @@ impl P2pNetworkSelectState {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, MallocSizeOf)]
+#[derive(Default)]
 pub enum P2pNetworkSelectStateInner {
     Error(String),
     Initiator { proposing: token::Protocol },
     Uncertain { proposing: token::Protocol },
+    #[default]
     Responder,
 }
 
-impl Default for P2pNetworkSelectStateInner {
-    fn default() -> Self {
-        Self::Responder
-    }
-}

--- a/p2p/src/network/select/p2p_network_select_state.rs
+++ b/p2p/src/network/select/p2p_network_select_state.rs
@@ -112,13 +112,15 @@ impl P2pNetworkSelectState {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, MallocSizeOf)]
-#[derive(Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, MallocSizeOf, Default)]
 pub enum P2pNetworkSelectStateInner {
     Error(String),
-    Initiator { proposing: token::Protocol },
-    Uncertain { proposing: token::Protocol },
+    Initiator {
+        proposing: token::Protocol,
+    },
+    Uncertain {
+        proposing: token::Protocol,
+    },
     #[default]
     Responder,
 }
-

--- a/p2p/testing/src/cluster.rs
+++ b/p2p/testing/src/cluster.rs
@@ -195,7 +195,7 @@ impl Ports {
     }
 
     fn round(u: u16) -> u16 {
-        ((u + 99) / 100) * 100
+        u.div_ceil(100) * 100
     }
 
     pub async fn take(&self, len: u16) -> Result<Range<u16>> {

--- a/p2p/tests/connection.rs
+++ b/p2p/tests/connection.rs
@@ -186,7 +186,7 @@ async fn mutual_rust_to_rust_many() -> anyhow::Result<()> {
     let node_to_node = nodes.into_iter().flat_map(|node| {
         nodes
             .into_iter()
-            .filter(move |other_node| (&node != other_node))
+            .filter(move |other_node| &node != other_node)
             .map(move |other_node| (node, other_node))
     });
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.84"
+channel = "1.92"
 
 # NOTE: When updating the Rust version here, also update:
 # - .github/config/versions.yaml (rust.stable)

--- a/tools/bootstrap-sandbox/src/snarked_ledger.rs
+++ b/tools/bootstrap-sandbox/src/snarked_ledger.rs
@@ -151,7 +151,7 @@ impl SnarkedLedger {
                 _ => panic!(),
             }
         } else {
-            let b = ((depth as usize + 7) / 8).min(4);
+            let b = (depth as usize).div_ceil(8).min(4);
             let p = if depth > 0 {
                 pos * (1 << (32 - depth))
             } else {

--- a/tools/testing/src/cluster/config.rs
+++ b/tools/testing/src/cluster/config.rs
@@ -60,7 +60,9 @@ impl ClusterConfig {
     }
 
     pub fn set_all_rust_to_rust_use_webrtc(&mut self) -> &mut Self {
-        assert!(cfg!(feature = "p2p-webrtc"));
+        if !cfg!(feature = "p2p-webrtc") {
+            unreachable!();
+        }
         self.all_rust_to_rust_use_webrtc = true;
         self
     }

--- a/tools/testing/src/cluster/config.rs
+++ b/tools/testing/src/cluster/config.rs
@@ -16,15 +16,13 @@ pub struct ClusterConfig {
     ocaml_node_executable: Option<OcamlNodeExecutable>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
-#[derive(Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, Default)]
 pub enum ProofKind {
     #[default]
     Dummy,
     ConstraintsChecked,
     Full,
 }
-
 
 impl ClusterConfig {
     pub fn new(ocaml_node_executable: Option<OcamlNodeExecutable>) -> anyhow::Result<Self> {

--- a/tools/testing/src/cluster/config.rs
+++ b/tools/testing/src/cluster/config.rs
@@ -17,18 +17,14 @@ pub struct ClusterConfig {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+#[derive(Default)]
 pub enum ProofKind {
+    #[default]
     Dummy,
     ConstraintsChecked,
     Full,
 }
 
-impl Default for ProofKind {
-    fn default() -> Self {
-        // once it's working, change to Self::ConstraintsChecked
-        Self::Dummy
-    }
-}
 
 impl ClusterConfig {
     pub fn new(ocaml_node_executable: Option<OcamlNodeExecutable>) -> anyhow::Result<Self> {

--- a/tools/testing/src/service/mod.rs
+++ b/tools/testing/src/service/mod.rs
@@ -186,7 +186,9 @@ impl NodeTestingService {
     }
 
     pub fn set_rust_to_rust_use_webrtc(&mut self) -> &mut Self {
-        assert!(cfg!(feature = "p2p-webrtc"));
+        if !cfg!(feature = "p2p-webrtc") {
+            unreachable!();
+        }
         self.rust_to_rust_use_webrtc = true;
         self
     }

--- a/vendor/redux/src/callback.rs
+++ b/vendor/redux/src/callback.rs
@@ -11,7 +11,7 @@ pub struct AnyAction(pub Box<dyn std::any::Any>);
 #[distributed_slice]
 pub static CALLBACKS: [(&str, fn(&str, Box<dyn std::any::Any>) -> AnyAction)];
 
-#[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Callback<T> {
     #[serde(skip, default = "default_fun_ptr")]
     fun_ptr: Option<fn(T) -> AnyAction>,

--- a/website/docs/developers/getting-started.mdx
+++ b/website/docs/developers/getting-started.mdx
@@ -72,7 +72,7 @@ additional tools for development:
 
 This installs:
 
-- Rust 1.84 (stable) and nightly toolchains
+- Rust 1.92 (stable) and nightly toolchains
 - Required components: `rustfmt`, `clippy`, `rust-src`
 - `taplo-cli`: TOML formatter required for `make format`
 

--- a/website/docs/developers/scripts/setup/install-rust.sh
+++ b/website/docs/developers/scripts/setup/install-rust.sh
@@ -1,15 +1,15 @@
 # Source cargo environment
 source ~/.cargo/env
 
-# Install Rust 1.84 (as specified in rust-toolchain.toml)
-rustup install 1.84
-rustup default 1.84
+# Install Rust 1.92 (as specified in rust-toolchain.toml)
+rustup install 1.92
+rustup default 1.92
 
 # Install nightly toolchain (required for some components)
 rustup install nightly
 
-# Add required components for Rust 1.84
-rustup component add rustfmt clippy rust-src --toolchain 1.84
+# Add required components for Rust 1.92
+rustup component add rustfmt clippy rust-src --toolchain 1.92
 
 # Add required components for nightly
 rustup component add rustfmt clippy rust-src --toolchain nightly


### PR DESCRIPTION
### Description

Updates the `stable` channel we use to Rust 1.92.

I've broken out many of the lint fixes into separate commits to make them 
easier to review. Note that some lint fixes triggered new lints which were
fixed in a subsequent commit.

### Related Issue(s)

* Closes #1560
* Closes #1877
* Opened follow-up #1893 
* Opened follow-up #1895

### Type of Change

- [x] This change requires a documentation update
- [x] Build-related changes

### Testing

CI should be passing for everything. The changes to the code are all
functionally identical. Follow-up issues have been opened for lint
exceptions that are introduced in this PR

### Changelog Entry

- **Changes** Update Rust to 1.92