### PR TITLE
CI/build-deps: add missing gnu-sed for MacOS builds

### DIFF
--- a/.github/actions/setup-build-deps/action.yml
+++ b/.github/actions/setup-build-deps/action.yml
@@ -19,7 +19,7 @@ runs:
       if: runner.os == 'macOS'
       shell: bash
       run: |
-        brew install protobuf libpcap
+        brew install protobuf libpcap gnu-sed
 
     - name: Install cargo-nextest
       if: inputs.install-nextest == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Build System**: enforce GNU sed on macOS, require `brew install gnu-sed`
   for `make fix-trailing-whitespace`, add CI test for cross-platform support,
   fix [#1864](https://github.com/o1-labs/mina-rust/issues/1864)
-  ([#1872](https://github.com/o1-labs/mina-rust/pull/1872))
+  ([#1898](https://github.com/o1-labs/mina-rust/pull/1898),
+  [#1872](https://github.com/o1-labs/mina-rust/pull/1872)).
 - **Dependency**: use tag instead of references of o1-labs/proof-systems, fix
   [[#1674](https://github.com/o1-labs/mina-rust/issues/1674)]
   ([#1673](https://github.com/o1-labs/mina-rust/pull/1673))


### PR DESCRIPTION
### Description

Builds on `develop` and `main` are broken, see for instance: https://github.com/o1-labs/mina-rust/actions/runs/20241109250/job/58109198438. It is related to https://github.com/o1-labs/mina-rust/pull/1872.

### Related Issue(s)

N/A

### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build-related changes
- [ ] Performance improvement

### Testing

See CI

### Changelog Entry

Added this PR to the changelog entry added by 3ecee09b367cc97c72cf041cbd69b1269d625977.
