### PR TITLE
CI: always runs build on latest MacOS

### DIFF
--- a/.github/workflows/build-macos-latest.yaml
+++ b/.github/workflows/build-macos-latest.yaml
@@ -3,6 +3,7 @@ name: Build macOS Latest
 on:
   push:
     branches: [main, develop]
+  pull_request:
   workflow_dispatch:
 
 concurrency:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [#1235](https://github.com/o1-labs/mina-rust/issues/1235)
   ([#1646](https://github.com/o1-labs/mina-rust/pull/1646))
 - *Build** Update Rust to 1.92 [#1894](https://github.com/o1-labs/mina-rust/issues/1894)
+- *CI*: run builds on macos-latest for each patch submission, fixing
+  [#1899](https://github.com/o1-labs/mina-rust/issues/1899)
+  ([#1900](https://github.com/o1-labs/mina-rust/pull/1900))
 
 ### Removed
 


### PR DESCRIPTION
This will fix https://github.com/o1-labs/mina-rust/issues/1899.

### Description

Run builds on macos-latest at each patch submission.

### Related Issue(s)

See https://github.com/o1-labs/mina-rust/issues/1899

### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactoring (no functional changes)
- [x] Build-related changes
- [ ] Performance improvement

### Testing

See CI

### Changelog Entry

**Changelog Summary:**

See history.