### PR TITLE
Docker: replace old compose-producer by local env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to Git's dynamic abbreviation based on repository size, fix
   [#1911](https://github.com/o1-labs/mina-rust/issues/1911)
   ([#1912](https://github.com/o1-labs/mina-rust/pull/1912))
+- **Docker compose files**: replace old environment by local in
+  docker-compose.block-producer.yml
+  ([#1916](https://github.com/o1-labs/mina-rust/pull/1916)
 
 ### Changes
 

--- a/docker-compose.block-producer.yml
+++ b/docker-compose.block-producer.yml
@@ -24,6 +24,6 @@ services:
   frontend:
     image: o1labs/mina-rust-frontend:${MINA_FRONTEND_TAG:-latest}
     environment:
-      MINA_FRONTEND_ENVIRONMENT: compose-producer
+      MINA_FRONTEND_ENVIRONMENT: local
     ports:
       - "8070:8070"

--- a/docker-compose.block-producer.yml
+++ b/docker-compose.block-producer.yml
@@ -26,4 +26,4 @@ services:
     environment:
       MINA_FRONTEND_ENVIRONMENT: local
     ports:
-      - "8070:8070"
+      - "8070:80"


### PR DESCRIPTION
### Description

The environment `compose-producer` does not exist. Replacing by the correct environment to use, `local`.

### Related Issue(s)

N/A. See https://discord.com/channels/484437221055922177/1290662938734231552/1446344064545984522

### Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build-related changes
- [ ] Performance improvement

### Testing

Run `docker compose -f docker-compose.block-producer.yml up`

### Changelog Entry

Please provide a one-line summary of your change for the changelog. This will be
used in the release notes. For example:

- **Added** a new endpoint for fetching user data.
- **Fixed** a bug where the login button was not responsive.

**Changelog Summary:**

See commit.