### PR TITLE
Ensure transaction hash is parsed as a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Frontend**: Fixed a bug where text was overlapping in the view.
+  ([#1957](https://github.com/o1-labs/mina-rust/pull/1957))
 - **CI**: fix version regex in build verification workflows to accept
   variable-length commit hashes (7+ characters) instead of exactly 7, adapting
   to Git's dynamic abbreviation based on repository size, fix

--- a/frontend/src/app/features/mempool/mempool.service.ts
+++ b/frontend/src/app/features/mempool/mempool.service.ts
@@ -40,7 +40,7 @@ export class MempoolService {
           const memo = decodeMemo(tx.data[1].payload.common.memo);
           return {
             kind: MempoolTransactionKind.PAYMENT,
-            txHash: tx.hash,
+            txHash: tx.hash?.toString(),
             sender: tx.data[1].payload.common.fee_payer_pk,
             fee: Number(tx.data[1].payload.common.fee),
             amount: Number(tx.data[1].payload.body[1].amount) / ONE_BILLION,


### PR DESCRIPTION
### Description

Fixing bug on text overlapping in mempool table.

### Related Issue(s)

https://github.com/orgs/o1-labs/projects/24/views/3?sliceBy%5Bvalue%5D=directcuteo&pane=issue&itemId=125294112&issue=o1-labs%7Cmina-rust%7C1331

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changelog Entry

- **Fixed** a bug where text was overlapping in the view.
