### PR TITLE
Fix more 1.92 Clippies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Docker compose files**: replace old environment by local in
   docker-compose.block-producer.yml
   ([#1916](https://github.com/o1-labs/mina-rust/pull/1916)
+- **CI**: Remove clippy exceptions for large enum/err variants added
+  as part of the Rust 1.92 upgrade
+  [#1968](https://github.com/o1-labs/mina-rust/pull/1968)
 
 ### Changes
 

--- a/Makefile
+++ b/Makefile
@@ -262,16 +262,12 @@ format-md: ## Format all markdown and MDX files to wrap at 80 characters
 .PHONY: lint
 lint: ## Run linter (clippy)
 	cargo clippy --all-targets -- -D warnings \
-	  --allow clippy::large_enum_variant \
-	  --allow clippy::result-large-err \
-	  --allow unused
+	  --allow unused_assignments
 
 .PHONY: lint-beta
 lint-beta: ## Run linter (clippy) using beta Rust
 	cargo +beta clippy --all-targets -- -D warnings \
-	  --allow clippy::large_enum_variant \
-	  --allow clippy::result-large-err \
-	  --allow unused
+	  --allow unused_assignments
 
 .PHONY: lint-bash
 lint-bash: ## Check all shell scripts using shellcheck

--- a/crates/cli/src/commands/misc.rs
+++ b/crates/cli/src/commands/misc.rs
@@ -1,6 +1,5 @@
 use libp2p_identity::PeerId;
 use mina_node::{account::AccountSecretKey, p2p::identity::SecretKey};
-use mina_node_account::AccountPublicKey;
 use std::{fs::File, io::Write};
 
 #[derive(Debug, clap::Args)]

--- a/crates/ledger/src/proofs/transaction.rs
+++ b/crates/ledger/src/proofs/transaction.rs
@@ -4397,6 +4397,7 @@ pub(super) mod tests {
 
     /// External worker input.
     #[derive(Debug, BinProtRead, BinProtWrite)]
+    #[expect(clippy::large_enum_variant, reason = "This enum is only used in tests")]
     pub enum ExternalSnarkWorkerRequest {
         /// Queries worker for readiness, expected reply is `true`.
         AwaitReadiness,

--- a/crates/ledger/src/scan_state/scan_state.rs
+++ b/crates/ledger/src/scan_state/scan_state.rs
@@ -2142,7 +2142,10 @@ impl ScanState {
                     }
                 };
 
-                Ok(snark_work::spec::Work::Transition((statement, witness)))
+                Ok(snark_work::spec::Work::Transition((
+                    statement,
+                    Box::new(witness),
+                )))
             }
             Extracted::Second(s) => {
                 let merged = s.0.statement().merge(&s.1.statement())?;
@@ -2196,7 +2199,10 @@ impl ScanState {
                     }
                 };
 
-                Some(snark_work::spec::Work::Transition((statement, witness)))
+                Some(snark_work::spec::Work::Transition((
+                    statement,
+                    Box::new(witness),
+                )))
             }
             Extracted::Second(s) => {
                 let merged = s.0.statement().merge(&s.1.statement()).unwrap();

--- a/crates/ledger/src/scan_state/snark_work.rs
+++ b/crates/ledger/src/scan_state/snark_work.rs
@@ -5,7 +5,7 @@ pub mod spec {
     };
 
     pub enum Work {
-        Transition((Box<Statement<()>>, TransactionWitness)),
+        Transition((Box<Statement<()>>, Box<TransactionWitness>)),
         Merge(Box<(Statement<()>, Box<(LedgerProof, LedgerProof)>)>),
     }
 }

--- a/crates/ledger/src/scan_state/snark_work.rs
+++ b/crates/ledger/src/scan_state/snark_work.rs
@@ -30,6 +30,7 @@ mod tests {
 
     /// External worker input.
     #[derive(Debug, BinProtRead, BinProtWrite)]
+    #[expect(clippy::large_enum_variant, reason = "This enum is only used in tests")]
     pub enum ExternalSnarkWorkerRequest {
         /// Queries worker for readiness, expected reply is `true`.
         AwaitReadiness,

--- a/crates/node/src/event_source/event_source_actions.rs
+++ b/crates/node/src/event_source/event_source_actions.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 pub type EventSourceActionWithMeta = redux::ActionWithMeta<EventSourceAction>;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[expect(clippy::large_enum_variant, reason = "This enum wraps super::Event")]
 pub enum EventSourceAction {
     /// Notify state machine that the new events might be received/available,
     /// so trigger processing of those events.

--- a/crates/node/src/event_source/event_source_effects.rs
+++ b/crates/node/src/event_source/event_source_effects.rs
@@ -489,7 +489,9 @@ pub fn event_source_effects<S: Service>(store: &mut Store<S>, action: EventSourc
             Event::GenesisLoad(res) => match res {
                 Err(err) => todo!("error while trying to load genesis config/ledger. - {err}"),
                 Ok(data) => {
-                    store.dispatch(TransitionFrontierGenesisAction::LedgerLoadSuccess { data });
+                    store.dispatch(TransitionFrontierGenesisAction::LedgerLoadSuccess {
+                        data: Box::new(data),
+                    });
                 }
             },
         },

--- a/crates/node/src/event_source/event_source_effects.rs
+++ b/crates/node/src/event_source/event_source_effects.rs
@@ -261,10 +261,7 @@ pub fn event_source_effects<S: Service>(store: &mut Store<S>, action: EventSourc
                             store.dispatch(P2pDisconnectionAction::Init { peer_id, reason });
                         }
                         Ok(message) => {
-                            store.dispatch(P2pChannelsMessageReceivedAction {
-                                peer_id,
-                                message: Box::new(message),
-                            });
+                            store.dispatch(P2pChannelsMessageReceivedAction { peer_id, message });
                         }
                     },
                     P2pChannelEvent::Closed(peer_id, chan_id) => {

--- a/crates/node/src/ledger/ledger_manager.rs
+++ b/crates/node/src/ledger/ledger_manager.rs
@@ -22,38 +22,48 @@ use std::collections::BTreeMap;
 /// can't be expressed in the Rust type system at the moment. For this
 /// reason this type is private while functions wrapping the whole call
 /// to the service are exposed as the service's methods.
-#[allow(dead_code)] // TODO
+#[expect(
+    clippy::large_enum_variant,
+    reason = "This is storing large messages, but size difference is only 2x between largest and second-largest variants"
+)]
 pub(super) enum LedgerRequest {
     Write(LedgerWriteRequest),
     Read(LedgerReadId, LedgerReadRequest),
+    /// expected response: `LedgerHash`
     AccountsSet {
         snarked_ledger_hash: LedgerHash,
         parent: LedgerAddress,
         accounts: Vec<MinaBaseAccountBinableArgStableV2>,
-    }, // expected response: LedgerHash
+    },
+    /// expected response: `Vec<Account>`
     AccountsGet {
         ledger_hash: LedgerHash,
         account_ids: Vec<AccountId>,
-    }, // expected response: Vec<Account>
+    },
+    /// expected response: `ChildHashes`
     ChildHashesGet {
         snarked_ledger_hash: LedgerHash,
         parent: LedgerAddress,
-    }, // expected response: ChildHashes
+    },
+    /// expected response: `Success`
     ComputeSnarkedLedgerHashes {
         snarked_ledger_hash: LedgerHash,
-    }, // expected response: Success
+    },
+    /// expected response: `SnarkedLedgerContentsCopied`
     CopySnarkedLedgerContentsForSync {
         origin_snarked_ledger_hash: Vec<LedgerHash>,
         target_snarked_ledger_hash: LedgerHash,
         overwrite: bool,
-    }, // expected response: SnarkedLedgerContentsCopied
+    },
+    /// expected response: `ProducersWithDelegatesMap`
     GetProducersWithDelegates {
         ledger_hash: LedgerHash,
         filter: fn(&CompressedPubKey) -> bool,
-    }, // expected response: ProducersWithDelegatesMap
+    },
+    /// expected response: `LedgerMask`
     GetMask {
         ledger_hash: LedgerHash,
-    }, // expected response: LedgerMask
+    },
     InsertGenesisLedger {
         mask: Mask,
     },

--- a/crates/node/src/ledger/ledger_service.rs
+++ b/crates/node/src/ledger/ledger_service.rs
@@ -1271,7 +1271,7 @@ impl LedgerCtx {
             .view()
             .map(|jobs| {
                 let jobs = jobs.collect::<Vec<JobValueWithIndex<'_>>>();
-                let mut iter = jobs.iter().peekable();
+                let iter = jobs.iter().peekable();
                 let mut res = Vec::with_capacity(jobs.len());
 
                 for job in iter {

--- a/crates/node/src/recorder/mod.rs
+++ b/crates/node/src/recorder/mod.rs
@@ -57,6 +57,10 @@ impl RecordedActionWithMeta<'_> {
         postcard::from_bytes(encoded)
     }
 
+    #[expect(
+        clippy::result_large_err,
+        reason = "The error variant is the same Self which is moved in; shouldn't blow up the stack"
+    )]
     pub fn as_action_with_meta(self) -> Result<ActionWithMeta, Self> {
         if let Some(action) = self.action {
             let action = action.into_owned();

--- a/crates/node/src/rpc/mod.rs
+++ b/crates/node/src/rpc/mod.rs
@@ -326,7 +326,7 @@ pub enum RpcSnarkerJobCommitResponse {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(tag = "kind")]
 pub enum RpcSnarkerJobSpecResponse {
-    Ok(SnarkWorkerWorkerRpcsVersionedGetWorkV2TResponse),
+    Ok(Box<SnarkWorkerWorkerRpcsVersionedGetWorkV2TResponse>),
     Err(SnarkWorkSpecError),
     JobNotFound,
 }

--- a/crates/node/src/rpc_effectful/rpc_effectful_effects.rs
+++ b/crates/node/src/rpc_effectful/rpc_effectful_effects.rs
@@ -543,14 +543,14 @@ pub fn rpc_effects<S: Service>(store: &mut Store<S>, action: ActionWithMeta<RpcE
             let fee = config.fee.clone();
             let input = match input {
                     Ok(instances) => RpcSnarkerJobSpecResponse::Ok(
-                        mina_p2p_messages::v2::SnarkWorkerWorkerRpcsVersionedGetWorkV2TResponse(Some((
+                        Box::new(mina_p2p_messages::v2::SnarkWorkerWorkerRpcsVersionedGetWorkV2TResponse(Some((
                             mina_p2p_messages::v2::SnarkWorkerWorkerRpcsVersionedGetWorkV2TResponseA0 {
                                 instances,
                                 fee,
                             },
                             public_key,
                         )))
-                    ),
+                    )),
                     Err(err) => RpcSnarkerJobSpecResponse::Err(err),
                 };
 

--- a/crates/node/src/state.rs
+++ b/crates/node/src/state.rs
@@ -459,6 +459,10 @@ impl State {
 
 #[serde_with::serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, MallocSizeOf)]
+#[expect(
+    clippy::large_enum_variant,
+    reason = "Doesn't make sense moving redux state onto heap"
+)]
 pub enum P2p {
     Pending(#[ignore_malloc_size_of = "constant"] P2pConfig),
     Ready(P2pState),

--- a/crates/node/src/transition_frontier/genesis/transition_frontier_genesis_actions.rs
+++ b/crates/node/src/transition_frontier/genesis/transition_frontier_genesis_actions.rs
@@ -17,7 +17,7 @@ pub enum TransitionFrontierGenesisAction {
     LedgerLoadInit,
     LedgerLoadPending,
     LedgerLoadSuccess {
-        data: GenesisConfigLoaded,
+        data: Box<GenesisConfigLoaded>,
     },
     Produce,
     ProveInit,

--- a/crates/node/src/transition_frontier/genesis/transition_frontier_genesis_reducer.rs
+++ b/crates/node/src/transition_frontier/genesis/transition_frontier_genesis_reducer.rs
@@ -44,7 +44,7 @@ impl TransitionFrontierGenesisState {
             TransitionFrontierGenesisAction::LedgerLoadSuccess { data } => {
                 *state = Self::LedgerLoadSuccess {
                     time: meta.time(),
-                    data: data.clone(),
+                    data: *data.clone(),
                 };
 
                 // Dispatch

--- a/crates/p2p/src/channels/streaming_rpc/p2p_channels_streaming_rpc_state.rs
+++ b/crates/p2p/src/channels/streaming_rpc/p2p_channels_streaming_rpc_state.rs
@@ -9,6 +9,10 @@ use super::{
 };
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[expect(
+    clippy::large_enum_variant,
+    reason = "Happy-path variant is the redux state"
+)]
 pub enum P2pChannelsStreamingRpcState {
     Disabled,
     Enabled,

--- a/crates/p2p/src/p2p_event.rs
+++ b/crates/p2p/src/p2p_event.rs
@@ -74,7 +74,7 @@ pub enum P2pConnectionEvent {
 pub enum P2pChannelEvent {
     Opened(PeerId, ChannelId, Result<(), String>),
     Sent(PeerId, ChannelId, MsgId, Result<(), String>),
-    Received(PeerId, Result<ChannelMsg, String>),
+    Received(PeerId, Result<Box<ChannelMsg>, String>),
     Closed(PeerId, ChannelId),
 }
 
@@ -155,7 +155,7 @@ impl fmt::Display for P2pChannelEvent {
                     Err(_) => return write!(f, "Err"),
                     Ok(msg) => {
                         write!(f, "{:?}, ", msg.channel_id())?;
-                        msg
+                        msg.as_ref()
                     }
                 };
 

--- a/crates/p2p/src/p2p_state.rs
+++ b/crates/p2p/src/p2p_state.rs
@@ -415,7 +415,7 @@ pub enum P2pPeerStatus {
         time: redux::Timestamp,
     },
 
-    Ready(P2pPeerStatusReady),
+    Ready(Box<P2pPeerStatusReady>),
 }
 
 impl P2pPeerStatus {

--- a/crates/p2p/src/peer/p2p_peer_reducer.rs
+++ b/crates/p2p/src/peer/p2p_peer_reducer.rs
@@ -42,11 +42,11 @@ impl P2pPeerState {
                 let Some(peer) = p2p_state.peers.get_mut(&peer_id) else {
                     return Ok(());
                 };
-                peer.status = P2pPeerStatus::Ready(P2pPeerStatusReady::new(
+                peer.status = P2pPeerStatus::Ready(Box::new(P2pPeerStatusReady::new(
                     incoming,
                     meta.time(),
                     &p2p_state.config.enabled_channels,
-                ));
+                )));
 
                 if !peer.is_libp2p {
                     let (dispatcher, state) = state_context.into_dispatcher_and_state();

--- a/crates/p2p/src/service_impl/webrtc/mod.rs
+++ b/crates/p2p/src/service_impl/webrtc/mod.rs
@@ -76,7 +76,7 @@ enum PeerCmdInternal {
 }
 
 enum PeerCmdAll {
-    External(PeerCmd),
+    External(Box<PeerCmd>),
     Internal(PeerCmdInternal),
 }
 
@@ -506,7 +506,7 @@ async fn peer_loop(
         let (cmd, _tracker) = tokio::select! {
             cmd = cmd_receiver.recv() => match cmd {
                 None => return,
-                Some(cmd) => (PeerCmdAll::External(cmd.0), Some(cmd.1)),
+                Some(cmd) => (PeerCmdAll::External(Box::new(cmd.0)), Some(cmd.1)),
             },
             cmd = internal_cmd_receiver.recv() => match cmd {
                 None => return,
@@ -514,87 +514,88 @@ async fn peer_loop(
             },
         };
         match cmd {
-            PeerCmdAll::External(
+            PeerCmdAll::External(cmd) => match *cmd {
                 PeerCmd::PeerHttpOfferSend(..)
                 | PeerCmd::AnswerSet(_)
-                | PeerCmd::ConnectionAuthorizationSend(_),
-            ) => {
-                bug_condition!("unexpected peer cmd");
-            }
-            PeerCmdAll::External(PeerCmd::ChannelOpen(id)) => {
-                let chan = pc
-                    .channel_create(RTCChannelConfig {
-                        label: id.name(),
-                        negotiated: Some(id.to_u16()),
-                    })
-                    .await;
-                let internal_cmd_sender = internal_cmd_sender.clone();
-                let fut = async move {
-                    let internal_cmd_sender_clone = internal_cmd_sender.clone();
-                    let result = async move {
-                        let chan = chan?;
-
-                        let (done_tx, mut done_rx) = mpsc::channel::<Result<(), Error>>(1);
-
-                        let done_tx_clone = done_tx.clone();
-                        chan.on_open(move || {
-                            let _ = done_tx_clone.try_send(Ok(()));
-                            std::future::ready(())
-                        });
-
-                        let done_tx_clone = done_tx.clone();
-                        let internal_cmd_sender = internal_cmd_sender_clone.clone();
-                        chan.on_error(move |err| {
-                            if done_tx_clone.try_send(Err(err.into())).is_err() {
-                                let _ =
-                                    internal_cmd_sender.send(PeerCmdInternal::ChannelClosed(id));
-                            }
-                            std::future::ready(())
-                        });
-
-                        let done_tx_clone = done_tx.clone();
-                        let internal_cmd_sender = internal_cmd_sender_clone.clone();
-                        chan.on_close(move || {
-                            if done_tx_clone.try_send(Err(Error::ChannelClosed)).is_err() {
-                                let _ =
-                                    internal_cmd_sender.send(PeerCmdInternal::ChannelClosed(id));
-                            }
-                            std::future::ready(())
-                        });
-
-                        done_rx.recv().await.ok_or(Error::ChannelClosed)??;
-
-                        Ok(chan)
-                    };
-
-                    let _ =
-                        internal_cmd_sender.send(PeerCmdInternal::ChannelOpened(id, result.await));
-                };
-                let mut aborted = aborted.clone();
-                spawn_local(async move {
-                    tokio::select! {
-                        _ = aborted.wait() => {}
-                        _ = fut => {}
-                    }
-                });
-            }
-            PeerCmdAll::External(PeerCmd::ChannelSend(msg_id, msg)) => {
-                let id = msg.channel_id();
-                let err = match channels.get_msg_sender(id) {
-                    Some(msg_sender) => match msg_buf.encode(&msg) {
-                        Ok(encoded) => match msg_sender.send((msg_id, encoded, _tracker)) {
-                            Ok(_) => None,
-                            Err(_) => Some("ChannelMsgMpscSendFailed".to_owned()),
-                        },
-                        Err(err) => Some(err.to_string()),
-                    },
-                    None => Some("ChannelNotOpen".to_owned()),
-                };
-                if let Some(err) = err {
-                    let _ =
-                        event_sender(P2pChannelEvent::Sent(peer_id, id, msg_id, Err(err)).into());
+                | PeerCmd::ConnectionAuthorizationSend(_) => {
+                    bug_condition!("unexpected peer cmd");
                 }
-            }
+                PeerCmd::ChannelOpen(id) => {
+                    let chan = pc
+                        .channel_create(RTCChannelConfig {
+                            label: id.name(),
+                            negotiated: Some(id.to_u16()),
+                        })
+                        .await;
+                    let internal_cmd_sender = internal_cmd_sender.clone();
+                    let fut = async move {
+                        let internal_cmd_sender_clone = internal_cmd_sender.clone();
+                        let result = async move {
+                            let chan = chan?;
+
+                            let (done_tx, mut done_rx) = mpsc::channel::<Result<(), Error>>(1);
+
+                            let done_tx_clone = done_tx.clone();
+                            chan.on_open(move || {
+                                let _ = done_tx_clone.try_send(Ok(()));
+                                std::future::ready(())
+                            });
+
+                            let done_tx_clone = done_tx.clone();
+                            let internal_cmd_sender = internal_cmd_sender_clone.clone();
+                            chan.on_error(move |err| {
+                                if done_tx_clone.try_send(Err(err.into())).is_err() {
+                                    let _ = internal_cmd_sender
+                                        .send(PeerCmdInternal::ChannelClosed(id));
+                                }
+                                std::future::ready(())
+                            });
+
+                            let done_tx_clone = done_tx.clone();
+                            let internal_cmd_sender = internal_cmd_sender_clone.clone();
+                            chan.on_close(move || {
+                                if done_tx_clone.try_send(Err(Error::ChannelClosed)).is_err() {
+                                    let _ = internal_cmd_sender
+                                        .send(PeerCmdInternal::ChannelClosed(id));
+                                }
+                                std::future::ready(())
+                            });
+
+                            done_rx.recv().await.ok_or(Error::ChannelClosed)??;
+
+                            Ok(chan)
+                        };
+
+                        let _ = internal_cmd_sender
+                            .send(PeerCmdInternal::ChannelOpened(id, result.await));
+                    };
+                    let mut aborted = aborted.clone();
+                    spawn_local(async move {
+                        tokio::select! {
+                            _ = aborted.wait() => {}
+                            _ = fut => {}
+                        }
+                    });
+                }
+                PeerCmd::ChannelSend(msg_id, msg) => {
+                    let id = msg.channel_id();
+                    let err = match channels.get_msg_sender(id) {
+                        Some(msg_sender) => match msg_buf.encode(&msg) {
+                            Ok(encoded) => match msg_sender.send((msg_id, encoded, _tracker)) {
+                                Ok(_) => None,
+                                Err(_) => Some("ChannelMsgMpscSendFailed".to_owned()),
+                            },
+                            Err(err) => Some(err.to_string()),
+                        },
+                        None => Some("ChannelNotOpen".to_owned()),
+                    };
+                    if let Some(err) = err {
+                        let _ = event_sender(
+                            P2pChannelEvent::Sent(peer_id, id, msg_id, Err(err)).into(),
+                        );
+                    }
+                }
+            },
             PeerCmdAll::Internal(PeerCmdInternal::ChannelOpened(chan_id, result)) => {
                 let (sender_tx, mut sender_rx) = mpsc::unbounded_channel();
                 let (chan, res) = match result {

--- a/crates/p2p/src/service_impl/webrtc/mod.rs
+++ b/crates/p2p/src/service_impl/webrtc/mod.rs
@@ -659,7 +659,7 @@ async fn peer_loop(
                         while !data.is_empty() {
                             let res = match process_msg(chan_id, &mut buf, &mut len, &mut data) {
                                 Ok(None) => continue,
-                                Ok(Some(msg)) => Ok(msg),
+                                Ok(Some(msg)) => Ok(Box::new(msg)),
                                 Err(err) => Err(err),
                             };
                             let _ =

--- a/tools/bootstrap-sandbox/src/snarked_ledger.rs
+++ b/tools/bootstrap-sandbox/src/snarked_ledger.rs
@@ -1,6 +1,5 @@
 use binprot::{BinProtRead, BinProtWrite};
 use std::{future::Future, io, pin::Pin};
-use thiserror::Error;
 
 use ledger::{Account, AccountIndex, Address, BaseLedger, Database, Mask};
 use mina_p2p_messages::{list::List, rpc::AnswerSyncLedgerQueryV2, v2};
@@ -12,14 +11,6 @@ pub struct SnarkedLedger {
     // NOTE: it is not the same as the merkle tree root
     pub top_hash: Option<v2::LedgerHash>,
     pub num: u32,
-}
-
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("{0}")]
-    Serde(#[from] serde_json::Error),
-    #[error("{0}")]
-    Io(#[from] io::Error),
 }
 
 impl SnarkedLedger {

--- a/tools/testing/src/scenario/event_details.rs
+++ b/tools/testing/src/scenario/event_details.rs
@@ -8,14 +8,13 @@ use mina_node::{
 };
 
 pub fn event_details(state: &State, event: &Event) -> Option<String> {
-    if let Event::P2p(P2pEvent::Channel(P2pChannelEvent::Received(
-        peer_id,
-        Ok(ChannelMsg::Rpc(RpcChannelMsg::Response(req_id, _))),
-    ))) = event
-    {
-        let rpc_state = &state.p2p.get_ready_peer(peer_id)?.channels.rpc;
-        if *req_id == rpc_state.pending_local_rpc_id()? {
-            return Some(format!("Request: {}", rpc_state.pending_local_rpc()?));
+    // this could be a let-chain but we're on rust 2021 instead of 2024 >:(
+    if let Event::P2p(P2pEvent::Channel(P2pChannelEvent::Received(peer_id, Ok(msg)))) = event {
+        if let ChannelMsg::Rpc(RpcChannelMsg::Response(req_id, _)) = &**msg {
+            let rpc_state = &state.p2p.get_ready_peer(peer_id)?.channels.rpc;
+            if *req_id == rpc_state.pending_local_rpc_id()? {
+                return Some(format!("Request: {}", rpc_state.pending_local_rpc()?));
+            }
         }
     }
 


### PR DESCRIPTION
### Description

Addresses the `clippy::{large_enum_variants,result_large_err}` lints introduced by the 1.92 upgrade. Some enum variants were boxed where it made sense, others we're allowed as the size difference between the largest/second-largest wasn't too big to warrant a larger refactor. 

Removes the `--allow clippy::{large_enum_variants,result_large_err}` from `make lint[-beta]`

Additionally, the `--allow unused` was changed to `--allow unused_assignments`, which is the more specific lint that was triggering #1893. Seeing as that's likely a compiler bug, we're keeping that issue open. However, `--allow unused` did allow some `dead_code` to slip through the cracks, so that's been addressed here too.

### Related Issue(s)

Closes #1895 

### Type of Change

- [x] Refactoring (no functional changes)
- [x] Performance improvement (potentially! some multi-kb structures were moved from stack to heap)

### Testing

Code should compile and CI should pass. There are no functional changes in this PR.

### Changelog Entry

- **Fixed**: **CI**: Remove clippy exceptions for large enum/err variants added as part of the Rust 1.92 upgrade
