### PR TITLE
Comment out instructions in PR template so they don't show up if you forget to clear them

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,14 @@
 ### Description
 
-A clear and concise description of what the change is.
+<!-- A clear and concise description of what the change is. -->
 
 ### Related Issue(s)
 
-Please link to any related issues here.
+<!-- Please link to any related issues here. -->
 
 ### Type of Change
 
-Please delete options that are not relevant.
+<!-- Please delete options that are not relevant. -->
 
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
@@ -21,6 +21,7 @@ Please delete options that are not relevant.
 
 ### Testing
 
+<!--
 Please describe the tests that you ran to verify your changes. Provide
 instructions so we can reproduce. Please also list any relevant details for your
 test configuration.
@@ -28,12 +29,16 @@ test configuration.
 - [ ] Test A
 - [ ] Test B
 
+-->
+
 ### Changelog Entry
 
+<!--
 Please provide a one-line summary of your change for the changelog. This will be
 used in the release notes. For example:
 
 - **Added** a new endpoint for fetching user data.
 - **Fixed** a bug where the login button was not responsive.
+-->
 
 **Changelog Summary:**


### PR DESCRIPTION
### Description

Sometimes it's easy to forget to clear the instructions and then you have to go edit your PR a bunch of times. This tweak leaves the instructions as a comment so they don't show up if you forget to remove them while writing your PR.

### Related Issue(s)

N/A, spur of the moment PR

### Type of Change

- [x] Process change ¯\\\_(ツ)_/¯

### Testing

N/A, it's literally just the PR template

### Changelog Entry

I hope we can make an exception for this as this is just adding comment blocks in the PR template and doesn't affect anything else about the codebase or build.