### PR TITLE
Website: "Web Node" nomenclature consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1900](https://github.com/o1-labs/mina-rust/pull/1900))
 - **Docs**: add notes in `.cargo/config.toml` about the magic RUSTFLAGS for WASM
   [#1863](https://github.com/o1-labs/mina-rust/issues/1863)
+- **Docs**: Consistent naming of the "web node" across docs
+  [#1858](https://github.com/o1-labs/mina-rust/issues/1858)
 
 ### Removed
 

--- a/website/docs/developers/architecture.md
+++ b/website/docs/developers/architecture.md
@@ -375,7 +375,7 @@ _libp2p-based Network:_
 
 _WebRTC-based Network:_
 
-- Used by webnode (browser-based node)
+- Used by the web node (browser-based node)
 - Direct WebRTC transport implementation
 - Different design pattern from libp2p
 - Optimized for browser constraints

--- a/website/docs/developers/frontend/api-endpoints.mdx
+++ b/website/docs/developers/frontend/api-endpoints.mdx
@@ -1568,7 +1568,7 @@ query Peers {
 
 #### POST `https://us-central1-webnode-gtm-test.cloudfunctions.net/handleValidationAndStore`
 
-Store WebNode heartbeat data for analytics.
+Store web node heartbeat data for analytics.
 
 **Request body:**
 
@@ -1584,7 +1584,7 @@ Store WebNode heartbeat data for analytics.
 
 **Response:** Success/error status
 
-**Used by:** WebNode heartbeat service
+**Used by:** Web Node Heartbeat Service
 
 ## Static asset endpoints
 
@@ -1621,10 +1621,10 @@ Get fuzzing file details and coverage.
 
 **Used by:** Fuzzing file viewer
 
-## WebNode WASM API
+## Web Node WASM API
 
-When running WebNode, the frontend interacts with a WebAssembly module instead
-of making HTTP requests. These are method calls on the WASM instance:
+When running the web node, the frontend interacts with a WebAssembly module
+instead of making HTTP requests. These are method calls on the WASM instance:
 
 - `webnode.status()` - Get node status
 - `webnode.stats().block_producer()` - Get block producer statistics
@@ -1654,7 +1654,7 @@ of making HTTP requests. These are method calls on the WASM instance:
 - **GraphQL**: 1 endpoint
 - **Firebase**: 1 endpoint
 - **Static assets**: 4 endpoints
-- **WebNode WASM**: 10+ methods
+- **Web Node WASM**: 10+ methods
 
 **Total**: 40+ API endpoints
 
@@ -1667,4 +1667,5 @@ of making HTTP requests. These are method calls on the WASM instance:
 
 The frontend uses HTTP polling through RxJS observables rather than WebSocket
 connections. The `RustService` acts as a central HTTP client wrapper with
-special handling for WebNode (WASM-based) versus regular Rust node backends.
+special handling for the web node (WASM-based) versus regular Rust node
+backends.

--- a/website/docs/developers/frontend/index.mdx
+++ b/website/docs/developers/frontend/index.mdx
@@ -25,7 +25,7 @@ A comprehensive web interface for monitoring and interacting with your Mina Rust
 node. View real-time blockchain state, network activity, and node metrics
 through an intuitive dashboard.
 
-### [WebNode](./webnode)
+### [Web Node](./web-node)
 
 Run a Mina node directly in your web browser using WebAssembly. This
 experimental feature enables block production without installing native
@@ -107,7 +107,7 @@ make build-local
 # Production deployment
 make build-production
 
-# WebNode deployment
+# Web node deployment
 make build-webnode
 ```
 

--- a/website/docs/developers/frontend/web-node.mdx
+++ b/website/docs/developers/frontend/web-node.mdx
@@ -1,5 +1,5 @@
 ---
-title: WebNode
+title: Web Node
 description: Run a Mina node in your web browser using WebAssembly
 sidebar_position: 4
 ---
@@ -11,17 +11,17 @@ import DeployWebnode from "!!raw-loader!../scripts/frontend/deploy-webnode.sh";
 import DockerBuildWebnode from "!!raw-loader!../scripts/frontend/docker-build-webnode.sh";
 import DockerRunWebnode from "!!raw-loader!../scripts/frontend/docker-run-webnode.sh";
 
-# WebNode
+# Web Node
 
-The WebNode is an experimental implementation of the Mina Rust node compiled to
+The web node is an experimental implementation of the Mina Rust node compiled to
 WebAssembly, enabling users to run a fully functional Mina node directly in
 their web browser. This groundbreaking approach eliminates the need for native
 software installation and pushes the boundaries of decentralized infrastructure.
 
 ## Overview
 
-WebNode leverages WebAssembly (WASM) technology to bring the full power of the
-Mina Rust node to web browsers. This enables block production, transaction
+The web node leverages WebAssembly (WASM) technology to bring the full power of
+the Mina Rust node to web browsers. This enables block production, transaction
 validation, and network participation without traditional infrastructure
 requirements.
 
@@ -34,9 +34,9 @@ requirements.
 - **Zero installation** - No software installation or system configuration
   required
 
-## Building WebNode
+## Building the web node
 
-Build the WebNode version of the frontend:
+Build the web node version of the frontend:
 
 <CodeBlock language="bash" title="scripts/frontend/build-webnode.sh">
   {BuildWebnode}
@@ -46,28 +46,28 @@ Build the WebNode version of the frontend:
 
 :::info Frontend Build Only
 
-These Makefile commands only build the frontend portion of the WebNode. The
+These Makefile commands only build the frontend portion of the web node. The
 WebAssembly module build is not included in these commands.
 
 :::
 
 <!-- prettier-ignore-stop -->
 
-## Running WebNode
+## Running the web node
 
 ### Development Mode
 
-Start the WebNode development server:
+Start the web node development server:
 
 <CodeBlock language="bash" title="scripts/frontend/start-webnode-local.sh">
   {StartWebnodeLocal}
 </CodeBlock>
 
-Access the WebNode at `http://localhost:4200`
+Access the web node at `http://localhost:4200`
 
 ### Production Deployment
 
-Deploy WebNode to a web server:
+Deploy the web node to a web server:
 
 <CodeBlock language="bash" title="scripts/frontend/deploy-webnode.sh">
   {DeployWebnode}
@@ -75,7 +75,7 @@ Deploy WebNode to a web server:
 
 ## Docker deployment
 
-WebNode can be deployed using Docker with automatic WASM file management.
+The web node can be deployed using Docker with automatic WASM file management.
 
 ### Environment configuration
 
@@ -90,7 +90,7 @@ WebAssembly-based node operation:
   circuit files for proof verification
 - **Browser optimization** - Optimizes the build for in-browser execution and
   resource management
-- **WebNode-specific APIs** - Enables WebNode-specific GraphQL endpoints and
+- **Web node-specific APIs** - Enables web node-specific GraphQL endpoints and
   state management
 
 ### Build Docker image
@@ -107,9 +107,9 @@ WebAssembly-based node operation:
 
 <!-- prettier-ignore-start -->
 
-:::info WebNode Docker Features
+:::info Web Node Docker Features
 
-The Docker image for WebNode:
+The Docker image for the web node:
 
 - **Pre-includes WASM files** - WebAssembly files are built during image
   creation

--- a/website/docs/developers/p2p-evolution.md
+++ b/website/docs/developers/p2p-evolution.md
@@ -9,8 +9,8 @@ slug: /developers/p2p-evolution
 
 This document outlines the evolution plan for Mina's P2P networking layer,
 building on the successful pull-based design already implemented for the Mina
-Rust node webnodes. The idea of using QUIC as a transport was originally
-proposed by George in his "Networking layer 2.0" document.
+Rust web nodes. The idea of using QUIC as a transport was originally proposed by
+George in his "Networking layer 2.0" document.
 
 **Status**: The pull-based P2P protocol is implemented and operational. This
 document proposes enhancements including QUIC transport, block propagation
@@ -32,21 +32,21 @@ The Mina ecosystem currently has divergent P2P implementations:
 2. **The Mina Rust node**
    - Support both libp2p (for OCaml compatibility) AND pull-based WebRTC
    - Must internally normalize between push and pull models, adding complexity
-   - Webnodes use WebRTC exclusively and require Rust nodes as bridges to libp2p
-     network
+   - Web nodes use WebRTC exclusively and require Rust nodes as bridges to
+     libp2p network
    - Maintenance burden of supporting two different protocol designs
 
 This creates significant complexity:
 
 - The Mina Rust node maintains two protocol implementations
-- Webnodes cannot directly communicate with OCaml nodes
+- Web nodes cannot directly communicate with OCaml nodes
 - Different security and performance characteristics
 - Inconsistent behavior and debugging challenges
 
 ## Vision: Unified Pull-Based P2P Layer
 
-The goal is to evolve the Mina Rust node's pull-based P2P design to improve
-webnode networking immediately and potentially become the universal networking
+The goal is to evolve the Mina Rust node's pull-based P2P design to improve web
+node networking immediately and potentially become the universal networking
 layer for all Mina nodes (both Rust and OCaml), with multiple transport options.
 Full ecosystem adoption would require coordination and agreement with the OCaml
 Mina team.
@@ -284,8 +284,8 @@ Pull-based protocol remains transport-agnostic:
 
 The P2P layer evolution builds on the Mina Rust node's successful pull-based
 design to create a more efficient, secure, and unified networking layer for the
-Mina ecosystem. While immediate improvements benefit the Mina Rust node and
-webnodes, the long-term vision of ecosystem-wide adoption would require
+Mina ecosystem. While immediate improvements benefit the Mina Rust native node
+and web nodes, the long-term vision of ecosystem-wide adoption would require
 coordination with the OCaml Mina team and careful migration planning.
 
 The phased approach allows for immediate improvements while keeping future

--- a/website/docs/developers/why-rust.md
+++ b/website/docs/developers/why-rust.md
@@ -6,7 +6,7 @@ description:
   alternative Mina Protocol implementation
 ---
 
-# Why are we developing the Mina Rust Node and the Mina Web node?
+# Why are we developing the Mina Rust Node and the Mina Web Node?
 
 ## Diversifying the Mina ecosystem
 

--- a/website/docs/node-operators/infrastructure/frontend.mdx
+++ b/website/docs/node-operators/infrastructure/frontend.mdx
@@ -54,10 +54,10 @@ To update the Node Dashboard deployment:
 6. Ask the platform lead or rust node team lead to review and merge the PR
 7. Once merged, ArgoCD will automatically deploy the update
 
-## WebNode
+## Web Node
 
-This section is still a work in progress. For information about the WebNode,
+This section is still a work in progress. For information about the web node,
 refer to the developers documentation of the
-[web node](../../developers/frontend/webnode.mdx).
+[web node](../../developers/frontend/web-node.mdx).
 
 Track progress: [Issue #1474](https://github.com/o1-labs/mina-rust/issues/1474)

--- a/website/docs/node-operators/web-node/local-web-node-docker.mdx
+++ b/website/docs/node-operators/web-node/local-web-node-docker.mdx
@@ -1,15 +1,15 @@
 ---
 sidebar_position: 1
-title: Local WebNode (Docker)
-description: How to deploy and launch a webnode using Docker images
+title: Local Web Node (Docker)
+description: How to deploy and launch a web node using Docker images
 ---
 
 import CodeBlock from "@theme/CodeBlock";
 import GenerateEncryptedKeypairDocker from "!!raw-loader!../scripts/generate-encrypted-keypair-docker.sh";
 
-# Deploying and launching a webnode using Docker
+# Deploying and launching a web node using Docker
 
-If you intend to just run the webnode instead of actively developing it, it is
+If you intend to just run the web node instead of actively developing it, it is
 substantially easier to get set up using prebuilt Docker images. These images
 are automatically built on every versioned release.
 
@@ -17,7 +17,7 @@ are automatically built on every versioned release.
 
 ### 1. (Optional) Generate a block producer key
 
-If you want your webnode to produce blocks, generate an encrypted key pair and
+If you want your web node to produce blocks, generate an encrypted key pair and
 package it for upload:
 
 <CodeBlock
@@ -27,9 +27,9 @@ package it for upload:
   {GenerateEncryptedKeypairDocker}
 </CodeBlock>
 
-### 2. Launch the webnode container
+### 2. Launch the web node container
 
-Launch the webnode container:
+Launch the web node container:
 
 ```sh
 # Launch the latest version of the frontend in webnode configuration
@@ -44,23 +44,23 @@ docker run \
 Navigate to [http://localhost:4200](http://localhost:4200). If you used a
 different port (`-p`) when launching the container, update the port accordingly.
 
-The webnode runs in **observer mode** by default (no block production). To
+The web node runs in **observer mode** by default (no block production). To
 enable block production:
 
 1. Click the file upload area on the startup screen
 2. Select the `webnode-key.zip` file you generated in step 1
 3. Click "Start Web Node" to begin producing blocks
 
-If you skip the file upload, the webnode will run as an observer only.
+If you skip the file upload, the web node will run as an observer only.
 
 ## Environment Variable Reference
 
-The Dockerized WebNode can be configured with additional environment variables
+The Dockerized web node can be configured with additional environment variables
 to customize behavior.
 
 ### `MINA_FRONTEND_ENVIRONMENT`
 
-This is required to launch the frontend in general. To serve a webnode, it must
+This is required to launch the frontend in general. To serve a web node, it must
 be set to the value `webnode`.
 
 Example:

--- a/website/docs/node-operators/web-node/local-web-node.mdx
+++ b/website/docs/node-operators/web-node/local-web-node.mdx
@@ -1,13 +1,13 @@
 ---
 sidebar_position: 1
-title: Local WebNode
-description: How to build and launch webnode from source
+title: Local Web Node
+description: How to build and launch a web node from source
 ---
 
 import CodeBlock from "@theme/CodeBlock";
 import GenerateEncryptedKeypairCargo from "!!raw-loader!../scripts/generate-encrypted-keypair-cargo.sh";
 
-# How to build and launch webnode from source
+# How to build and launch a web node from source
 
 ## Steps
 
@@ -52,8 +52,8 @@ cd frontend/src/assets/webnode
 git clone --depth 1 https://github.com/o1-labs/circuit-blobs.git
 ```
 
-(Optional) Generate a block producer key if you want to produce blocks. The
-webnode runs in observer mode by default:
+(Optional) Generate a block producer key if you want to produce blocks. The web
+node runs in observer mode by default:
 
 <CodeBlock
   language="bash"
@@ -62,7 +62,7 @@ webnode runs in observer mode by default:
   {GenerateEncryptedKeypairCargo}
 </CodeBlock>
 
-Install frontend dependencies and run the webnode:
+Install frontend dependencies and run the web node:
 
 ```sh
 cd frontend

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -114,7 +114,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'developers/frontend/index',
         'developers/frontend/node-dashboard',
-        'developers/frontend/webnode',
+        'developers/frontend/web-node',
         'developers/frontend/environment-configuration',
         'developers/frontend/api-endpoints',
       ],

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -60,8 +60,8 @@ const sidebars: SidebarsConfig = {
       label: 'Advanced Topics',
       items: [
         'node-operators/alpha-testing',
-        'node-operators/webnode/local-webnode',
-        'node-operators/webnode/local-webnode-docker',
+        'node-operators/web-node/local-web-node',
+        'node-operators/web-node/local-web-node-docker',
         'node-operators/testing/overview',
       ],
     },


### PR DESCRIPTION
### Description

Standardizes the naming convention for "web node" across documentation to
improve consistency. Renames the MDX files/directories so URLs reflect the
spacing (`webnode` -> `web-node`)

**Naming Standards Applied:**

- **Titles/headings**: "Web Node" (title case with space)
- **General prose**: "web node" (lowercase with space)
- **Technical code**: Unchanged (WebNode, web-node, webnode remain as-is)
  Caveat: Renamed some `website/docs` files/dirs to `web-node` for URL consistency

### Related Issue(s)

Fixes #1858

### Type of Change

- [x] This change requires a documentation update
- [x] Refactoring (no functional changes)

### Testing

Verified changes through:

- [x] Visual inspection of all modified markdown/MDX files
- [x] `make check-md` - Confirms all markdown files are properly formatted
- [x] `make check-trailing-whitespace` - Confirms no trailing whitespace
- [x] Manual review of rendered documentation for consistency

All changes are documentation-only with no functional impact on code behavior.

### Changelog Entry

**Changes**: **Docs**: Consistent naming of the "web node" across docs [#1858](https://github.com/o1-labs/mina-rust/issues/1858)


