### PR TITLE
Docs: fix mismatched code reference

### DIFF
--- a/website/docs/developers/referencing-code-in-documentation.md
+++ b/website/docs/developers/referencing-code-in-documentation.md
@@ -33,10 +33,10 @@ https://github.com/o1-labs/mina-rust/blob/develop/path/to/file.rs#LStartLine-LEn
 
 Here's a real example from the zkApps documentation:
 
-<!-- CODE_REFERENCE: ledger/src/scan_state/transaction_logic/valid.rs#L80-L83-->
+<!-- CODE_REFERENCE: crates/ledger/src/scan_state/transaction_logic/valid.rs#L80-L83-->
 
-```rust reference title="ledger/src/scan_state/transaction_logic/valid.rs"
-https://github.com/o1-labs/mina-rust/blob/develop/ledger/src/scan_state/transaction_logic/valid.rs#L80-L83
+```rust reference title="crates/ledger/src/scan_state/transaction_logic/valid.rs"
+https://github.com/o1-labs/mina-rust/blob/develop/crates/ledger/src/scan_state/transaction_logic/valid.rs#L80-L83
 ```
 
 ### Components explained


### PR DESCRIPTION
### Description

We've been getting a "code reference mismatch" comment on every PR since #1910,
as a path wasn't updated in the docs. This fixes aforementioned path

### Related Issue(s)

N/A, been recurring on PRs ever since #1910

### Type of Change

- [x] Documentation update

### Testing

Success!
<img width="927" height="309" alt="image" src="https://github.com/user-attachments/assets/d39b9fd4-8f11-4abd-8ab5-4f93eb5aa743" />
### Changelog Entry

Opting to skip changelog, this should've been part of #1910