### PR TITLE
CI: switch macOS 14 and 15 workflows to weekly schedule

### DIFF
--- a/.github/workflows/build-macos-14.yaml
+++ b/.github/workflows/build-macos-14.yaml
@@ -1,8 +1,9 @@
 name: Build macOS 14
 
 on:
-  push:
-    branches: [main, develop]
+  schedule:
+    # Run every Monday at 6:00 AM UTC
+    - cron: '0 6 * * 1'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/build-macos-15.yaml
+++ b/.github/workflows/build-macos-15.yaml
@@ -1,8 +1,9 @@
 name: Build macOS 15
 
 on:
-  push:
-    branches: [main, develop]
+  schedule:
+    # Run every Monday at 6:00 AM UTC
+    - cron: '0 6 * * 1'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/frontend-macos-14.yaml
+++ b/.github/workflows/frontend-macos-14.yaml
@@ -1,8 +1,9 @@
 name: Frontend macOS 14
 
 on:
-  push:
-    branches: [main, develop]
+  schedule:
+    # Run every Monday at 6:00 AM UTC
+    - cron: '0 6 * * 1'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/frontend-macos-15.yaml
+++ b/.github/workflows/frontend-macos-15.yaml
@@ -1,8 +1,9 @@
 name: Frontend macOS 15
 
 on:
-  push:
-    branches: [main, develop]
+  schedule:
+    # Run every Monday at 6:00 AM UTC
+    - cron: '0 6 * * 1'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

- Switch `build-macos-14`, `build-macos-15`, `frontend-macos-14`, and
  `frontend-macos-15` workflows from push triggers to weekly schedule
  (Sunday 6:00 AM UTC)
- Retain `workflow_dispatch` for manual triggering when needed

This frees up macOS runners for `macos-latest` jobs and reduces CI queue times
while still catching macOS-specific issues on a regular cadence.

Fixes #2026

## Test plan

- [ ] Verify workflows no longer trigger on push to main/develop
- [ ] Verify workflows can still be triggered manually via workflow_dispatch
- [ ] Wait for Sunday to confirm scheduled runs work correctly