### PR TITLE
Create symlink for WASM blobs in Dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -136,6 +136,12 @@ COPY frontend/httpd.conf /usr/local/apache2/conf/httpd.conf
 # Copy WASM files from build stage
 COPY --from=wasm_files . /usr/local/apache2/htdocs/assets/webnode/
 
+# For whatever reason, Angular is going to complain about not being able
+# to follow the symlink in frontend/src/assets/webnode/pkg, (even though
+# it's not actually ever served directly). To avoid this, we symlink the
+# wasm blobs to satisfy Angular building at launch time.
+RUN ln -s /usr/local/apache2/htdocs/assets/webnode pkg
+
 # Copy circuit blobs for devnet and mainnet from local directory
 COPY circuit-blobs/3.0.0mainnet /usr/local/apache2/htdocs/assets/webnode/circuit-blobs/3.0.0mainnet
 COPY circuit-blobs/berkeley-devnet /usr/local/apache2/htdocs/assets/webnode/circuit-blobs/berkeley-devnet


### PR DESCRIPTION
Add symlink for Angular to access WASM blobs during build.

### Description

A bug slipped through the cracks when we fixed the WASM build (frontend mostly gets built after the docker container is launched), and nobody noticed it cause there's no automated testing for launching the frontend. This PR fixes aforementioned bug.

### Related Issue(s)

Unblocks @richardpringle working on #1871 

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Build-related changes

### Testing

Launched the container with `--entrypoint /bin/bash -i -t`, ran the `ln -s ...` command before launching `/usr/local/bin/startup.sh httpd-foreground` which Just Worked™.
The change here just makes it part of the Dockerfile in a logical place.

### Changelog Entry
No changelog, unbreaking the build