### PR TITLE
Deprecate WebRTC-Multiaddrish signaling format in favor of standard Multiaddr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [#2006](https://github.com/o1-labs/mina-rust/pull/2006)
 - **Dependencies**: bump up tokio from 1.26.0 to 1.46.1
   ([#2053](https://github.com/o1-labs/mina-rust/pull/2053))
+- **Web Node**: Standardized WebRTC peer address to Multiaddr and deprecated
+  old "WebRTC-Multiaddrish" format [#2052](https://github.com/o1-labs/mina-rust/pull/2052)
 
 ### Removed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5367,6 +5367,7 @@ dependencies = [
  "strum_macros",
  "thiserror 1.0.60",
  "tokio",
+ "tracing",
  "unsigned-varint 0.8.0",
  "url",
  "warp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "alloc-test"
-version = "0.18.1"
+version = "0.1.1"
 dependencies = [
  "clap 4.5.20",
  "derive_builder",
@@ -7224,7 +7224,7 @@ dependencies = [
 
 [[package]]
 name = "redux"
-version = "0.18.1"
+version = "0.1.0"
 dependencies = [
  "enum_dispatch",
  "fuzzcheck 0.10.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1391,9 +1391,9 @@ dependencies = [
 
 [[package]]
 name = "bs58"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
  "tinyvec",
 ]
@@ -2146,9 +2146,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.4.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "data-encoding-macro"
@@ -2879,7 +2879,7 @@ dependencies = [
 [[package]]
 name = "futures-bounded"
 version = "0.1.0"
-source = "git+https://github.com/openmina/rust-libp2p?rev=5c44c7d9#5c44c7d953f50134a00ded1f9924fa2edd5e09b9"
+source = "git+https://github.com/o1-labs/rust-libp2p?rev=e88cec09bd2554f4cc79ff90f200e4c864adf495#e88cec09bd2554f4cc79ff90f200e4c864adf495"
 dependencies = [
  "futures-timer",
  "futures-util",
@@ -4310,7 +4310,7 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 [[package]]
 name = "libp2p"
 version = "0.53.0"
-source = "git+https://github.com/openmina/rust-libp2p?rev=5c44c7d9#5c44c7d953f50134a00ded1f9924fa2edd5e09b9"
+source = "git+https://github.com/o1-labs/rust-libp2p?rev=e88cec09bd2554f4cc79ff90f200e4c864adf495#e88cec09bd2554f4cc79ff90f200e4c864adf495"
 dependencies = [
  "bytes",
  "either",
@@ -4344,7 +4344,7 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.3.0"
-source = "git+https://github.com/openmina/rust-libp2p?rev=5c44c7d9#5c44c7d953f50134a00ded1f9924fa2edd5e09b9"
+source = "git+https://github.com/o1-labs/rust-libp2p?rev=e88cec09bd2554f4cc79ff90f200e4c864adf495#e88cec09bd2554f4cc79ff90f200e4c864adf495"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -4355,7 +4355,7 @@ dependencies = [
 [[package]]
 name = "libp2p-connection-limits"
 version = "0.3.0"
-source = "git+https://github.com/openmina/rust-libp2p?rev=5c44c7d9#5c44c7d953f50134a00ded1f9924fa2edd5e09b9"
+source = "git+https://github.com/o1-labs/rust-libp2p?rev=e88cec09bd2554f4cc79ff90f200e4c864adf495#e88cec09bd2554f4cc79ff90f200e4c864adf495"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -4366,7 +4366,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.41.0"
-source = "git+https://github.com/openmina/rust-libp2p?rev=5c44c7d9#5c44c7d953f50134a00ded1f9924fa2edd5e09b9"
+source = "git+https://github.com/o1-labs/rust-libp2p?rev=e88cec09bd2554f4cc79ff90f200e4c864adf495#e88cec09bd2554f4cc79ff90f200e4c864adf495"
 dependencies = [
  "either",
  "fnv",
@@ -4394,7 +4394,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.41.0"
-source = "git+https://github.com/openmina/rust-libp2p?rev=5c44c7d9#5c44c7d953f50134a00ded1f9924fa2edd5e09b9"
+source = "git+https://github.com/o1-labs/rust-libp2p?rev=e88cec09bd2554f4cc79ff90f200e4c864adf495#e88cec09bd2554f4cc79ff90f200e4c864adf495"
 dependencies = [
  "async-trait",
  "futures",
@@ -4409,7 +4409,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.46.0"
-source = "git+https://github.com/openmina/rust-libp2p?rev=5c44c7d9#5c44c7d953f50134a00ded1f9924fa2edd5e09b9"
+source = "git+https://github.com/o1-labs/rust-libp2p?rev=e88cec09bd2554f4cc79ff90f200e4c864adf495#e88cec09bd2554f4cc79ff90f200e4c864adf495"
 dependencies = [
  "asynchronous-codec",
  "base64 0.21.7",
@@ -4441,7 +4441,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.44.0"
-source = "git+https://github.com/openmina/rust-libp2p?rev=5c44c7d9#5c44c7d953f50134a00ded1f9924fa2edd5e09b9"
+source = "git+https://github.com/o1-labs/rust-libp2p?rev=e88cec09bd2554f4cc79ff90f200e4c864adf495#e88cec09bd2554f4cc79ff90f200e4c864adf495"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -4462,27 +4462,27 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.7"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd6317441f361babc74c2989c6484eb0726045399b6648de039e1805ea96972"
+checksum = "55cca1eb2bc1fd29f099f3daaab7effd01e1a54b7c577d0ed082521034d912e8"
 dependencies = [
- "bs58 0.5.0",
+ "bs58 0.5.1",
  "ed25519-dalek",
  "hkdf",
- "log",
  "multihash 0.19.1",
  "quick-protobuf",
  "rand",
  "serde",
  "sha2 0.10.8",
  "thiserror 1.0.60",
+ "tracing",
  "zeroize",
 ]
 
 [[package]]
 name = "libp2p-kad"
 version = "0.45.0"
-source = "git+https://github.com/openmina/rust-libp2p?rev=5c44c7d9#5c44c7d953f50134a00ded1f9924fa2edd5e09b9"
+source = "git+https://github.com/o1-labs/rust-libp2p?rev=e88cec09bd2554f4cc79ff90f200e4c864adf495#e88cec09bd2554f4cc79ff90f200e4c864adf495"
 dependencies = [
  "arrayvec",
  "asynchronous-codec",
@@ -4511,7 +4511,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.45.0"
-source = "git+https://github.com/openmina/rust-libp2p?rev=5c44c7d9#5c44c7d953f50134a00ded1f9924fa2edd5e09b9"
+source = "git+https://github.com/o1-labs/rust-libp2p?rev=e88cec09bd2554f4cc79ff90f200e4c864adf495#e88cec09bd2554f4cc79ff90f200e4c864adf495"
 dependencies = [
  "data-encoding",
  "futures",
@@ -4531,7 +4531,7 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.14.0"
-source = "git+https://github.com/openmina/rust-libp2p?rev=5c44c7d9#5c44c7d953f50134a00ded1f9924fa2edd5e09b9"
+source = "git+https://github.com/o1-labs/rust-libp2p?rev=e88cec09bd2554f4cc79ff90f200e4c864adf495#e88cec09bd2554f4cc79ff90f200e4c864adf495"
 dependencies = [
  "instant",
  "libp2p-core",
@@ -4547,7 +4547,7 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.44.0"
-source = "git+https://github.com/openmina/rust-libp2p?rev=5c44c7d9#5c44c7d953f50134a00ded1f9924fa2edd5e09b9"
+source = "git+https://github.com/o1-labs/rust-libp2p?rev=e88cec09bd2554f4cc79ff90f200e4c864adf495#e88cec09bd2554f4cc79ff90f200e4c864adf495"
 dependencies = [
  "bytes",
  "curve25519-dalek",
@@ -4572,7 +4572,7 @@ dependencies = [
 [[package]]
 name = "libp2p-pnet"
 version = "0.24.0"
-source = "git+https://github.com/openmina/rust-libp2p?rev=5c44c7d9#5c44c7d953f50134a00ded1f9924fa2edd5e09b9"
+source = "git+https://github.com/o1-labs/rust-libp2p?rev=e88cec09bd2554f4cc79ff90f200e4c864adf495#e88cec09bd2554f4cc79ff90f200e4c864adf495"
 dependencies = [
  "futures",
  "log",
@@ -4585,7 +4585,7 @@ dependencies = [
 [[package]]
 name = "libp2p-quic"
 version = "0.10.0"
-source = "git+https://github.com/openmina/rust-libp2p?rev=5c44c7d9#5c44c7d953f50134a00ded1f9924fa2edd5e09b9"
+source = "git+https://github.com/o1-labs/rust-libp2p?rev=e88cec09bd2554f4cc79ff90f200e4c864adf495#e88cec09bd2554f4cc79ff90f200e4c864adf495"
 dependencies = [
  "bytes",
  "futures",
@@ -4617,7 +4617,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.44.0"
-source = "git+https://github.com/openmina/rust-libp2p?rev=5c44c7d9#5c44c7d953f50134a00ded1f9924fa2edd5e09b9"
+source = "git+https://github.com/o1-labs/rust-libp2p?rev=e88cec09bd2554f4cc79ff90f200e4c864adf495#e88cec09bd2554f4cc79ff90f200e4c864adf495"
 dependencies = [
  "either",
  "fnv",
@@ -4639,7 +4639,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.34.0"
-source = "git+https://github.com/openmina/rust-libp2p?rev=5c44c7d9#5c44c7d953f50134a00ded1f9924fa2edd5e09b9"
+source = "git+https://github.com/o1-labs/rust-libp2p?rev=e88cec09bd2554f4cc79ff90f200e4c864adf495#e88cec09bd2554f4cc79ff90f200e4c864adf495"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-warning",
@@ -4651,7 +4651,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.41.0"
-source = "git+https://github.com/openmina/rust-libp2p?rev=5c44c7d9#5c44c7d953f50134a00ded1f9924fa2edd5e09b9"
+source = "git+https://github.com/o1-labs/rust-libp2p?rev=e88cec09bd2554f4cc79ff90f200e4c864adf495#e88cec09bd2554f4cc79ff90f200e4c864adf495"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4667,7 +4667,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.3.0"
-source = "git+https://github.com/openmina/rust-libp2p?rev=5c44c7d9#5c44c7d953f50134a00ded1f9924fa2edd5e09b9"
+source = "git+https://github.com/o1-labs/rust-libp2p?rev=e88cec09bd2554f4cc79ff90f200e4c864adf495#e88cec09bd2554f4cc79ff90f200e4c864adf495"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -4685,7 +4685,7 @@ dependencies = [
 [[package]]
 name = "libp2p-upnp"
 version = "0.2.0"
-source = "git+https://github.com/openmina/rust-libp2p?rev=5c44c7d9#5c44c7d953f50134a00ded1f9924fa2edd5e09b9"
+source = "git+https://github.com/o1-labs/rust-libp2p?rev=e88cec09bd2554f4cc79ff90f200e4c864adf495#e88cec09bd2554f4cc79ff90f200e4c864adf495"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4700,7 +4700,7 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.45.0"
-source = "git+https://github.com/openmina/rust-libp2p?rev=5c44c7d9#5c44c7d953f50134a00ded1f9924fa2edd5e09b9"
+source = "git+https://github.com/o1-labs/rust-libp2p?rev=e88cec09bd2554f4cc79ff90f200e4c864adf495#e88cec09bd2554f4cc79ff90f200e4c864adf495"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -5349,6 +5349,7 @@ dependencies = [
  "multiaddr",
  "multihash 0.18.1",
  "p2p-testing",
+ "percent-encoding",
  "prost 0.12.4",
  "prost-build",
  "quick-protobuf",
@@ -5447,7 +5448,7 @@ dependencies = [
  "ark-ff",
  "bitvec",
  "blake2",
- "bs58 0.5.0",
+ "bs58 0.5.1",
  "hex",
  "mina-curves",
  "mina-hasher",
@@ -5649,12 +5650,12 @@ dependencies = [
 
 [[package]]
 name = "multiaddr"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b852bc02a2da5feed68cd14fa50d0774b92790a5bdbfa932a813926c8472070"
+version = "0.18.2"
+source = "git+https://github.com/multiformats/rust-multiaddr?rev=a4a4fbd555bdda40a6758fa5e2e3ad69947ffcd7#a4a4fbd555bdda40a6758fa5e2e3ad69947ffcd7"
 dependencies = [
  "arrayref",
  "byteorder",
+ "bytes",
  "data-encoding",
  "libp2p-identity",
  "multibase",
@@ -5662,7 +5663,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "static_assertions",
- "unsigned-varint 0.7.2",
+ "unsigned-varint 0.8.0",
  "url",
 ]
 
@@ -5728,7 +5729,7 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 [[package]]
 name = "multistream-select"
 version = "0.13.0"
-source = "git+https://github.com/openmina/rust-libp2p?rev=5c44c7d9#5c44c7d953f50134a00ded1f9924fa2edd5e09b9"
+source = "git+https://github.com/o1-labs/rust-libp2p?rev=e88cec09bd2554f4cc79ff90f200e4c864adf495#e88cec09bd2554f4cc79ff90f200e4c864adf495"
 dependencies = [
  "bytes",
  "futures",
@@ -7006,7 +7007,7 @@ dependencies = [
 [[package]]
 name = "quick-protobuf-codec"
 version = "0.2.0"
-source = "git+https://github.com/openmina/rust-libp2p?rev=5c44c7d9#5c44c7d953f50134a00ded1f9924fa2edd5e09b9"
+source = "git+https://github.com/o1-labs/rust-libp2p?rev=e88cec09bd2554f4cc79ff90f200e4c864adf495#e88cec09bd2554f4cc79ff90f200e4c864adf495"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -7718,7 +7719,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
-source = "git+https://github.com/openmina/rust-libp2p?rev=5c44c7d9#5c44c7d953f50134a00ded1f9924fa2edd5e09b9"
+source = "git+https://github.com/o1-labs/rust-libp2p?rev=e88cec09bd2554f4cc79ff90f200e4c864adf495#e88cec09bd2554f4cc79ff90f200e4c864adf495"
 dependencies = [
  "futures",
  "pin-project",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,8 +142,8 @@ lazy_static = "1.4.0"
 leb128 = "0.2.1"
 ledger = { path = "crates/ledger", package = "mina-tree" }
 libc = "0.2.151"
-libp2p = { git = "https://github.com/openmina/rust-libp2p", rev = "5c44c7d9", default-features = false }
-libp2p-identity = { version = "=0.2.7", features = ["peerid"] }
+libp2p = { git = "https://github.com/o1-labs/rust-libp2p", rev = "e88cec09bd2554f4cc79ff90f200e4c864adf495", default-features = false }
+libp2p-identity = { version = "=0.2.9", features = ["peerid"] }
 linkme = "0.3.22"
 local-ip-address = "0.6.1"
 log = "0.4.25"
@@ -169,7 +169,7 @@ mina-snark = { path = "crates/snark" }
 mina-transport = { path = "tools/transport" }
 mina-vrf = { path = "crates/vrf" }
 mio = { version = "1.0.4", features = ["os-poll", "net"] }
-multiaddr = "0.18.1"
+multiaddr = { git = "https://github.com/multiformats/rust-multiaddr", rev = "a4a4fbd555bdda40a6758fa5e2e3ad69947ffcd7" }
 multihash = { version = "0.18.1", features = ["blake2b"] }
 nix = { version = "0.27.1", features = ["process", "signal"] }
 nom = "8.0.0"
@@ -184,6 +184,7 @@ once_cell = "1"
 p256 = { version = "0.13", features = ["default", "ecdh", "ecdsa"] }
 p384 = "0.13"
 pcap = "2.4"
+percent-encoding = "2.3"
 pin-project-lite = "0.2.10"
 poly-commitment = { git = "https://github.com/o1-labs/proof-systems", tag = "0.2.0" }
 poseidon = { path = "poseidon" }

--- a/crates/node/web/src/lib.rs
+++ b/crates/node/web/src/lib.rs
@@ -93,7 +93,7 @@ fn parse_bp_key(key: JsValue) -> Option<AccountSecretKey> {
 ///   to the `--peer-list-url` flag in the native node, but allows multiple URLs
 ///   to be supplied.
 /// * `seed_nodes_addresses` - Optional list of peer addresses to connect to
-///   directly, in [WebRTC Multiaddr-ish format](https://o1-labs.github.io/mina-rust/docs/developers/webrtc#address-format-differences)
+///   directly, in [WebRTC multiaddr format](https://o1-labs.github.io/mina-rust/docs/developers/webrtc#address-formats).
 ///   This is directly comparable to the `--peers` flag in the native node.
 /// * `genesis_config_url` - Optional URL to fetch genesis configuration from.
 ///   Genesis config must be in bin_prot format. If not provided, uses the default
@@ -116,7 +116,7 @@ fn parse_bp_key(key: JsValue) -> Option<AccountSecretKey> {
 /// const rpc = await run(
 ///   null,  // No block production
 ///   ["https://bootnodes.minaprotocol.com/networks/devnet-webrtc.txt"],
-///   ["/PEER_ID/https/webrtc-peer-signaling.example.com/443"],
+///   ["/dns4/webrtc-peer-signaling.example.com/tcp/443/webrtc/https/p2p/PEER_ID"],
 ///   null, // Use the default devnet configuration
 /// );
 /// ```

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -19,6 +19,7 @@ ed25519-dalek = { workspace = true }
 faster-stun = { workspace = true, optional = true }
 hex = { workspace = true }
 multihash = { workspace = true }
+percent-encoding = { workspace = true }
 rand = { workspace = true, features = ["small_rng"] }
 reqwest = { workspace = true, optional = true }
 serde = { workspace = true }

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -30,6 +30,7 @@ smallvec = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 thiserror = { workspace = true }
+tracing = { workspace = true }
 unsigned-varint = { workspace = true }
 url = { workspace = true }
 x25519-dalek = { workspace = true }

--- a/crates/p2p/src/connection/outgoing/mod.rs
+++ b/crates/p2p/src/connection/outgoing/mod.rs
@@ -323,6 +323,80 @@ impl P2pConnectionOutgoingInitOpts {
     pub fn from_libp2p_socket_addr(peer_id: PeerId, addr: SocketAddr) -> Self {
         P2pConnectionOutgoingInitOpts::LibP2P((peer_id, addr).into())
     }
+
+    fn parse_p2p_relay_webrtc_multiaddr(
+        maddr: &multiaddr::Multiaddr,
+    ) -> Result<Self, P2pConnectionOutgoingInitOptsParseError> {
+        let mut iter = maddr.iter();
+
+        let Some(Protocol::P2p(relay_peer_id_hash)) = iter.next() else {
+            return Err(P2pConnectionOutgoingInitOptsParseError::Other(
+                "expected p2p protocol for relay".to_string(),
+            ));
+        };
+        let relay_peer_id = libp2p_identity::PeerId::from_multihash(relay_peer_id_hash.into())
+            .map_err(|_| {
+                P2pConnectionOutgoingInitOptsParseError::Other(
+                    "invalid relay peer_id multihash".to_string(),
+                )
+            })?
+            .try_into()
+            .map_err(|_| {
+                P2pConnectionOutgoingInitOptsParseError::Other(
+                    "unexpected error converting relay PeerId".to_string(),
+                )
+            })?;
+
+        // Expect /webrtc
+        if iter.next() != Some(Protocol::WebRTC) {
+            return Err(P2pConnectionOutgoingInitOptsParseError::Other(
+                "expected webrtc protocol".to_string(),
+            ));
+        };
+
+        // Expect /p2p-circuit
+        if iter.next() != Some(Protocol::P2pCircuit) {
+            return Err(P2pConnectionOutgoingInitOptsParseError::Other(
+                "expected p2p-circuit protocol".to_string(),
+            ));
+        };
+
+        // Get target peer_id
+        let peer_id = Self::parse_p2p_peer_id(iter.next(), "target")?;
+
+        Ok(Self::WebRTC {
+            peer_id,
+            signaling: webrtc::SignalingMethod::P2p { relay_peer_id },
+        })
+    }
+
+    fn parse_p2p_peer_id(
+        protocol: Option<multiaddr::Protocol>,
+        label: &'static str,
+    ) -> Result<PeerId, P2pConnectionOutgoingInitOptsParseError> {
+        match protocol {
+            Some(Protocol::P2p(peer_id_hash)) => {
+                libp2p_identity::PeerId::from_multihash(peer_id_hash.into())
+                    .map_err(|_| {
+                        P2pConnectionOutgoingInitOptsParseError::Other(format!(
+                            "invalid {label} peer_id multihash"
+                        ))
+                    })?
+                    .try_into()
+                    .map_err(|_| {
+                        P2pConnectionOutgoingInitOptsParseError::Other(format!(
+                            "unexpected error converting {label} PeerId"
+                        ))
+                    })
+            }
+            Some(other_protocol) => Err(P2pConnectionOutgoingInitOptsParseError::Other(format!(
+                "expected p2p protocol for {label} peer id, got {other_protocol:?}"
+            ))),
+            None => Err(P2pConnectionOutgoingInitOptsParseError::Other(format!(
+                "missing {label} peer id"
+            ))),
+        }
+    }
 }
 
 impl P2pConnectionOutgoingInitLibp2pOpts {
@@ -451,171 +525,102 @@ impl TryFrom<&multiaddr::Multiaddr> for P2pConnectionOutgoingInitOpts {
         // Check if this is a WebRTC multiaddr
         let is_webrtc = maddr.iter().any(|p| p == Protocol::WebRTC);
 
-        if is_webrtc {
-            let mut iter = maddr.iter().peekable();
+        // Standard libp2p multiaddr (no /webrtc)
+        if !is_webrtc {
+            cfg_if::cfg_if! {
+                if #[cfg(target_arch = "wasm32")] {
+                    return Err(P2pConnectionOutgoingInitOptsParseError::Other(
+                        "libp2p not supported in wasm".to_owned(),
+                    ))
+                } else {
+                    return Ok(Self::LibP2P(maddr.try_into()?))
+                }
+            };
+        }
 
-            // Check for P2P relay format: /p2p/{relay}/webrtc/p2p-circuit/p2p/{target}
-            if matches!(iter.peek(), Some(Protocol::P2p(_))) {
-                let relay_peer_id = match iter.next() {
-                    Some(Protocol::P2p(hash)) => {
-                        libp2p_identity::PeerId::from_multihash(hash.into())
-                            .map_err(|_| {
-                                P2pConnectionOutgoingInitOptsParseError::Other(
-                                    "invalid relay peer_id multihash".to_string(),
-                                )
-                            })?
-                            .try_into()
-                            .map_err(|_| {
-                                P2pConnectionOutgoingInitOptsParseError::Other(
-                                    "unexpected error converting relay PeerId".to_string(),
-                                )
-                            })?
+        let mut iter = maddr.iter();
+
+        // Check for P2P relay format: /p2p/{relay}/webrtc/p2p-circuit/p2p/{target}
+        // and go to parse_p2p_relay_webrtc_multiaddr.
+        // Otherwise, parse one of the HTTP-based variants:
+        // /dns|dns4|dns6|ip4|ip6/{host}/tcp/{port}/webrtc/http|https/[http-proxy/{proxy_path}/]p2p/{peer_id}
+        match iter.next() {
+            Some(Protocol::P2p(_)) => Self::parse_p2p_relay_webrtc_multiaddr(maddr),
+            other_transport_protocol => {
+                // Extract /dns|dns4|dns6|ip4|ip6/{host}
+                let host = match other_transport_protocol {
+                    Some(Protocol::Ip4(v)) => Host::Ipv4(v),
+                    Some(Protocol::Ip6(v)) => Host::Ipv6(v),
+                    Some(Protocol::Dns(v) | Protocol::Dns4(v) | Protocol::Dns6(v)) => {
+                        Host::Domain(v.to_string())
                     }
                     _ => {
                         return Err(P2pConnectionOutgoingInitOptsParseError::Other(
-                            "expected p2p protocol for relay".to_string(),
+                            "expected host (dns/dns4/dns6/ip4/ip6) in webrtc multiaddr".to_string(),
                         ))
                     }
+                };
+
+                // Extract /tcp/{port}
+                let Some(Protocol::Tcp(port)) = iter.next() else {
+                    return Err(P2pConnectionOutgoingInitOptsParseError::Other(
+                        "expected tcp port in webrtc multiaddr".to_string(),
+                    ));
                 };
 
                 // Skip /webrtc
-                match iter.next() {
-                    Some(Protocol::WebRTC) => {}
+                if iter.next() != Some(Protocol::WebRTC) {
+                    return Err(P2pConnectionOutgoingInitOptsParseError::Other(
+                        "expected webrtc protocol".to_string(),
+                    ));
+                };
+
+                // Determine signaling method: http, https, or proxy with http-path
+                let signaling_info = HttpSignalingInfo { host, port };
+                let scheme = match iter.next() {
+                    Some(Protocol::Http) => webrtc::ProxyScheme::Http,
+                    Some(Protocol::Https) => webrtc::ProxyScheme::Https,
                     _ => {
                         return Err(P2pConnectionOutgoingInitOptsParseError::Other(
-                            "expected webrtc protocol".to_string(),
+                            "expected http or https protocol after webrtc".to_string(),
                         ))
                     }
-                }
-
-                // Expect /p2p-circuit
-                match iter.next() {
-                    Some(Protocol::P2pCircuit) => {}
-                    _ => {
-                        return Err(P2pConnectionOutgoingInitOptsParseError::Other(
-                            "expected p2p-circuit protocol".to_string(),
-                        ))
+                };
+                let (signaling, peer_id) = match iter.next() {
+                    Some(Protocol::HttpPath(path)) => {
+                        let signaling = webrtc::SignalingMethod::Proxied(
+                            scheme,
+                            webrtc::PathPrefix(path.to_string()),
+                            signaling_info,
+                        );
+                        let peer_id = Self::parse_p2p_peer_id(iter.next(), "webrtc")?;
+                        (signaling, peer_id)
                     }
-                }
-
-                // Get target peer_id
-                let peer_id = match iter.next() {
-                    Some(Protocol::P2p(hash)) => {
-                        libp2p_identity::PeerId::from_multihash(hash.into())
-                            .map_err(|_| {
-                                P2pConnectionOutgoingInitOptsParseError::Other(
-                                    "invalid target peer_id multihash".to_string(),
-                                )
-                            })?
-                            .try_into()
-                            .map_err(|_| {
-                                P2pConnectionOutgoingInitOptsParseError::Other(
-                                    "unexpected error converting target PeerId".to_string(),
-                                )
-                            })?
+                    p2p @ Some(Protocol::P2p(_)) => {
+                        let signaling = match scheme {
+                            webrtc::ProxyScheme::Http => {
+                                webrtc::SignalingMethod::Http(signaling_info)
+                            }
+                            webrtc::ProxyScheme::Https => {
+                                webrtc::SignalingMethod::Https(signaling_info)
+                            }
+                        };
+                        let peer_id = Self::parse_p2p_peer_id(p2p, "webrtc")?;
+                        (signaling, peer_id)
                     }
-                    _ => {
+                    Some(other_protocol) => {
                         return Err(P2pConnectionOutgoingInitOptsParseError::Other(
-                            "expected p2p protocol for target peer".to_string(),
+                            format!("expected /p2p/peer_id or /http-path/encoded_path, got {other_protocol:?}"
+                        )))
+                    },
+                    None => {
+                        return Err(P2pConnectionOutgoingInitOptsParseError::Other(
+                            "expected p2p protocol with peer_id".to_string(),
                         ))
                     }
                 };
 
-                return Ok(Self::WebRTC {
-                    peer_id,
-                    signaling: webrtc::SignalingMethod::P2p { relay_peer_id },
-                });
-            }
-
-            // HTTP(S) signaling format: /dns4|ip4/{host}/tcp/{port}/webrtc/http|https/p2p/{peer_id}
-            let host = match iter.next() {
-                Some(Protocol::Ip4(v)) => Host::Ipv4(v),
-                Some(Protocol::Ip6(v)) => Host::Ipv6(v),
-                Some(Protocol::Dns(v) | Protocol::Dns4(v) | Protocol::Dns6(v)) => {
-                    Host::Domain(v.to_string())
-                }
-                _ => {
-                    return Err(P2pConnectionOutgoingInitOptsParseError::Other(
-                        "expected host (ip4/ip6/dns) in webrtc multiaddr".to_string(),
-                    ))
-                }
-            };
-
-            let port = match iter.next() {
-                Some(Protocol::Tcp(p)) => p,
-                _ => {
-                    return Err(P2pConnectionOutgoingInitOptsParseError::Other(
-                        "expected tcp port in webrtc multiaddr".to_string(),
-                    ))
-                }
-            };
-
-            // Skip /webrtc
-            match iter.next() {
-                Some(Protocol::WebRTC) => {}
-                _ => {
-                    return Err(P2pConnectionOutgoingInitOptsParseError::Other(
-                        "expected webrtc protocol".to_string(),
-                    ))
-                }
-            }
-
-            // Determine signaling method: http, https, or proxy with http-path
-            let signaling_info = HttpSignalingInfo { host, port };
-            let scheme = match iter.next() {
-                Some(Protocol::Http) => webrtc::ProxyScheme::Http,
-                Some(Protocol::Https) => webrtc::ProxyScheme::Https,
-                _ => {
-                    return Err(P2pConnectionOutgoingInitOptsParseError::Other(
-                        "expected http or https protocol after webrtc".to_string(),
-                    ))
-                }
-            };
-            let signaling = if let Some(Protocol::HttpPath(path)) = iter.peek() {
-                let path = path.to_string();
-                iter.next(); // consume the peeked item
-                webrtc::SignalingMethod::Proxied(scheme, webrtc::PathPrefix(path), signaling_info)
-            } else {
-                match scheme {
-                    webrtc::ProxyScheme::Http => webrtc::SignalingMethod::Http(signaling_info),
-                    webrtc::ProxyScheme::Https => webrtc::SignalingMethod::Https(signaling_info),
-                }
-            };
-
-            // Get peer_id
-            let peer_id = match iter.next() {
-                Some(Protocol::P2p(hash)) => libp2p_identity::PeerId::from_multihash(hash.into())
-                    .map_err(|_| {
-                        P2pConnectionOutgoingInitOptsParseError::Other(
-                            "invalid peer_id multihash".to_string(),
-                        )
-                    })?
-                    .try_into()
-                    .map_err(|_| {
-                        P2pConnectionOutgoingInitOptsParseError::Other(
-                            "unexpected error converting PeerId".to_string(),
-                        )
-                    })?,
-                _ => {
-                    return Err(P2pConnectionOutgoingInitOptsParseError::Other(
-                        "expected p2p protocol with peer_id".to_string(),
-                    ))
-                }
-            };
-
-            Ok(Self::WebRTC { peer_id, signaling })
-        } else {
-            // Standard libp2p multiaddr (no /webrtc)
-            #[cfg(target_arch = "wasm32")]
-            {
-                Err(P2pConnectionOutgoingInitOptsParseError::Other(
-                    "libp2p not supported in wasm".to_owned(),
-                ))
-            }
-
-            #[cfg(not(target_arch = "wasm32"))]
-            {
-                Ok(Self::LibP2P(maddr.try_into()?))
+                Ok(Self::WebRTC { peer_id, signaling })
             }
         }
     }
@@ -644,6 +649,13 @@ impl From<&P2pConnectionOutgoingInitOpts> for Multiaddr {
             P2pConnectionOutgoingInitOpts::WebRTC { peer_id, signaling } => {
                 use webrtc::SignalingMethod;
 
+                // expect() safety: by the time we have a P2pConnectionOutgoingInitOpts
+                // peer_id was already validated. This is a quirk of the libp2p_identity vs mina-p2p types
+                // validation logics in:
+                // 1. P2pConnectionOutgoingInitLibp2pOpts::try_from_mina_rpc()
+                // 2. impl TryFrom<&multiaddr::Multiaddr> for P2pConnectionOutgoingInitLibp2pOpts
+                // P2pConnectionOutgoingInitOpts will never come in over the wire or from a rogue peer,
+                // possibly only bad CLI flags.
                 let peer_id_proto = Protocol::P2p(
                     libp2p_identity::PeerId::try_from(*peer_id).expect("valid peer_id"),
                 );
@@ -710,6 +722,7 @@ impl From<&P2pConnectionOutgoingInitOpts> for Multiaddr {
                             .with(peer_id_proto)
                     }
                     SignalingMethod::P2p { relay_peer_id } => {
+                        // same expect() safety as peer_id_proto
                         let relay_id_proto = Protocol::P2p(
                             libp2p_identity::PeerId::try_from(*relay_peer_id)
                                 .expect("valid relay_peer_id"),
@@ -722,6 +735,7 @@ impl From<&P2pConnectionOutgoingInitOpts> for Multiaddr {
                     }
                 }
             }
+            // same expect() safety rationale as the others. it's all from peer_id >__>
             P2pConnectionOutgoingInitOpts::LibP2P(v) => v.to_maddr().expect("valid libp2p opts"),
         }
     }
@@ -746,23 +760,23 @@ impl TryFrom<&multiaddr::Multiaddr> for P2pConnectionOutgoingInitLibp2pOpts {
                 Some(Protocol::Dns(v) | Protocol::Dns4(v) | Protocol::Dns6(v)) => {
                     Host::Domain(v.to_string())
                 }
-                Some(_) => {
+                Some(other_host) => {
                     return Err(P2pConnectionOutgoingInitOptsParseError::Other(
-                        "unexpected part in multiaddr! expected host".to_string(),
+                        format!("unexpected transport in multiaddr! expected /dns|dns4|dns6|ip4|ip6/<host>, got {other_host:?}!")
                     ));
                 }
                 None => {
                     return Err(P2pConnectionOutgoingInitOptsParseError::Other(
-                        "missing host part from multiaddr".to_string(),
+                        "missing /dns|dns4|dns6|ip4|ip6/host from multiaddr".to_string(),
                     ));
                 }
             },
             port: match iter.next() {
                 Some(Protocol::Tcp(port)) => port,
-                Some(_) => {
-                    return Err(P2pConnectionOutgoingInitOptsParseError::Other(
-                        "unexpected part in multiaddr! expected port".to_string(),
-                    ));
+                Some(other_port) => {
+                    return Err(P2pConnectionOutgoingInitOptsParseError::Other(format!(
+                        "unexpected part in multiaddr! expected /tcp/<port>, got {other_port:?}"
+                    )));
                 }
                 None => {
                     return Err(P2pConnectionOutgoingInitOptsParseError::Other(
@@ -814,13 +828,6 @@ mod measurement {
 
 #[cfg(test)]
 mod tests {
-    //! Unit tests for P2pConnectionOutgoingInitOpts multiaddr parsing
-    //!
-    //! Run these tests with:
-    //! ```bash
-    //! cargo test -p mina-p2p connection::outgoing::tests
-    //! ```
-
     use super::*;
     use std::net::Ipv4Addr;
 
@@ -842,9 +849,9 @@ mod tests {
                     assert_eq!(info.host, Host::Domain("signal.example.com".to_string()));
                     assert_eq!(info.port, 8080);
                 }
-                _ => panic!("Expected Http signaling method"),
+                x => panic!("Expected Http signaling method, got {x:?}"),
             },
-            _ => panic!("Expected WebRTC variant"),
+            x => panic!("Expected WebRTC variant, got {x:?}"),
         }
     }
 
@@ -862,9 +869,9 @@ mod tests {
                     assert_eq!(info.host, Host::Ipv4(Ipv4Addr::new(192, 168, 1, 100)));
                     assert_eq!(info.port, 8080);
                 }
-                _ => panic!("Expected Http signaling method"),
+                x => panic!("Expected Http signaling method, got {x:?}"),
             },
-            _ => panic!("Expected WebRTC variant"),
+            x => panic!("Expected WebRTC variant, got {x:?}"),
         }
     }
 
@@ -882,9 +889,9 @@ mod tests {
                     assert_eq!(info.host, Host::Domain("signal.example.com".to_string()));
                     assert_eq!(info.port, 443);
                 }
-                _ => panic!("Expected Https signaling method"),
+                x => panic!("Expected Https signaling method, got {x:?}"),
             },
-            _ => panic!("Expected WebRTC variant"),
+            x => panic!("Expected WebRTC variant, got {x:?}"),
         }
     }
 
@@ -904,9 +911,9 @@ mod tests {
                     assert_eq!(info.host, Host::Domain("proxy.example.com".to_string()));
                     assert_eq!(info.port, 443);
                 }
-                _ => panic!("Expected Proxied signaling method"),
+                x => panic!("Expected Proxied signaling method, got {x:?}"),
             },
-            _ => panic!("Expected WebRTC variant"),
+            x => panic!("Expected WebRTC variant, got {x:?}"),
         }
     }
 
@@ -923,9 +930,9 @@ mod tests {
                 webrtc::SignalingMethod::P2p { .. } => {
                     // Successfully parsed as P2P relay
                 }
-                _ => panic!("Expected P2p signaling method"),
+                x => panic!("Expected P2p signaling method, got {x:?}"),
             },
-            _ => panic!("Expected WebRTC variant"),
+            x => panic!("Expected WebRTC variant, got {x:?}"),
         }
     }
 
@@ -945,7 +952,7 @@ mod tests {
                 );
                 assert_eq!(libp2p_opts.port, 10003);
             }
-            _ => panic!("Expected LibP2P variant"),
+            x => panic!("Expected LibP2P variant, got {x:?}"),
         }
     }
 
@@ -960,11 +967,11 @@ mod tests {
         let opts1: P2pConnectionOutgoingInitOpts = maddr_str.parse().unwrap();
 
         // Encode: convert to Multiaddr, then to string
-        let maddr: Multiaddr = (&opts1).into();
+        let maddr = Multiaddr::from(&opts1);
         let encoded_str = maddr.to_string();
 
         // Second decode: parse the encoded string
-        let opts2: P2pConnectionOutgoingInitOpts = encoded_str.parse().unwrap();
+        let opts2 = P2pConnectionOutgoingInitOpts::from_str(&encoded_str).unwrap();
 
         // Both decodes should match structurally
         assert_eq!(opts1, opts2);
@@ -1032,13 +1039,16 @@ mod tests {
         let maddr: Multiaddr = maddr_str.parse().unwrap();
         let opts: P2pConnectionOutgoingInitOpts = (&maddr).try_into().unwrap();
 
-        assert!(matches!(
-            opts,
-            P2pConnectionOutgoingInitOpts::WebRTC {
-                signaling: webrtc::SignalingMethod::Http(_),
-                ..
-            }
-        ));
+        assert!(
+            matches!(
+                opts,
+                P2pConnectionOutgoingInitOpts::WebRTC {
+                    signaling: webrtc::SignalingMethod::Http(_),
+                    ..
+                }
+            ),
+            "expected WebRTC with Http signaling, got {opts:?}"
+        );
     }
 
     #[test]
@@ -1106,9 +1116,12 @@ mod tests {
 
         match opts {
             P2pConnectionOutgoingInitOpts::WebRTC { signaling, .. } => {
-                assert!(matches!(signaling, webrtc::SignalingMethod::Http(_)));
+                assert!(
+                    matches!(signaling, webrtc::SignalingMethod::Http(_)),
+                    "expected Http signaling, got {signaling:?}"
+                );
             }
-            _ => panic!("Expected WebRTC variant"),
+            x => panic!("Expected WebRTC variant, got {x:?}"),
         }
     }
 }

--- a/crates/p2p/src/connection/outgoing/mod.rs
+++ b/crates/p2p/src/connection/outgoing/mod.rs
@@ -590,7 +590,7 @@ impl TryFrom<&multiaddr::Multiaddr> for P2pConnectionOutgoingInitOpts {
                     Some(Protocol::HttpPath(path)) => {
                         let signaling = webrtc::SignalingMethod::Proxied(
                             scheme,
-                            webrtc::PathPrefix(path.to_string()),
+                            path.into(),
                             signaling_info,
                         );
                         let peer_id = Self::parse_p2p_peer_id(iter.next(), "webrtc")?;
@@ -703,7 +703,7 @@ impl From<&P2pConnectionOutgoingInitOpts> for Multiaddr {
                             .with(Protocol::HttpPath(path.into()))
                             .with(peer_id_proto)
                     }
-                    SignalingMethod::Proxied(scheme, webrtc::PathPrefix(path), info) => {
+                    SignalingMethod::Proxied(scheme, path, info) => {
                         let host_proto = match &info.host {
                             Host::Domain(v) => Protocol::Dns4(v.into()),
                             Host::Ipv4(v) => Protocol::Ip4(*v),
@@ -905,9 +905,9 @@ mod tests {
 
         match opts {
             P2pConnectionOutgoingInitOpts::WebRTC { signaling, .. } => match signaling {
-                webrtc::SignalingMethod::Proxied(scheme, webrtc::PathPrefix(path), info) => {
+                webrtc::SignalingMethod::Proxied(scheme, path, info) => {
                     assert_eq!(scheme, webrtc::ProxyScheme::Https);
-                    assert_eq!(path, "cluster/123/mina/webrtc/signal");
+                    assert_eq!(path.as_ref(), "cluster/123/mina/webrtc/signal");
                     assert_eq!(info.host, Host::Domain("proxy.example.com".to_string()));
                     assert_eq!(info.port, 443);
                 }

--- a/crates/p2p/src/connection/outgoing/mod.rs
+++ b/crates/p2p/src/connection/outgoing/mod.rs
@@ -19,12 +19,12 @@ use thiserror::Error;
 use mina_p2p_messages::v2;
 
 use crate::{
-    webrtc::{self, Host},
+    webrtc::{self, Host, HttpSignalingInfo},
     PeerId,
 };
 
 #[cfg(feature = "p2p-libp2p")]
-use crate::webrtc::{HttpSignalingInfo, SignalingMethod};
+use crate::webrtc::SignalingMethod;
 
 // TODO(binier): maybe move to `crate::webrtc` module
 #[derive(
@@ -305,7 +305,7 @@ impl P2pConnectionOutgoingInitOpts {
                 }
                 SignalingMethod::Proxied(scheme, path_prefix, info) => {
                     Some(v2::NetworkPeerPeerStableV1 {
-                        host: format!("{}://{}{}", scheme, info.host, path_prefix)
+                        host: format!("{scheme}://{}{}", info.host, path_prefix)
                             .as_bytes()
                             .into(),
                         libp2p_port: (info.port as u64).into(),
@@ -333,19 +333,8 @@ impl P2pConnectionOutgoingInitLibp2pOpts {
 
 impl fmt::Display for P2pConnectionOutgoingInitOpts {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::WebRTC { peer_id, signaling } => {
-                write!(f, "/{}{}", peer_id, signaling)
-            }
-
-            Self::LibP2P(v) => {
-                if let Some(maddr) = v.to_maddr() {
-                    write!(f, "{}", maddr)
-                } else {
-                    write!(f, "*INVALID MULTIADDRESS*")
-                }
-            }
-        }
+        let maddr: Multiaddr = self.into();
+        write!(f, "{}", maddr)
     }
 }
 
@@ -369,30 +358,20 @@ impl FromStr for P2pConnectionOutgoingInitOpts {
             return Err(P2pConnectionOutgoingInitOptsParseError::NotEnoughArgs);
         }
 
-        let is_libp2p_maddr = s.starts_with("/ip") || s.starts_with("/dns");
-
-        if is_libp2p_maddr {
-            let maddr = multiaddr::Multiaddr::from_str(s)
-                .map_err(|e| P2pConnectionOutgoingInitOptsParseError::Other(e.to_string()))?;
-
-            let opts = (&maddr).try_into()?;
-
-            return Ok(Self::LibP2P(opts));
-        }
-        #[cfg(target_arch = "wasm32")]
-        if is_libp2p_maddr {
-            return Err(P2pConnectionOutgoingInitOptsParseError::Other(
-                "libp2p not supported in wasm".to_owned(),
-            ));
+        // Try parsing as multiaddr first (the preferred format)
+        if let Ok(maddr) = Multiaddr::from_str(s) {
+            return Self::try_from(&maddr);
         }
 
+        // Fallback: try legacy WebRTC format (/{peer_id}/{signaling_method}/...)
+        // This format is deprecated; prefer multiaddr format instead.
         let id_end_index = s[1..]
             .find('/')
             .map(|i| i + 1)
             .filter(|i| s.len() > *i)
             .ok_or(P2pConnectionOutgoingInitOptsParseError::NotEnoughArgs)?;
 
-        Ok(Self::WebRTC {
+        let opts = Self::WebRTC {
             peer_id: s[1..id_end_index].parse::<PeerId>().map_err(|err| {
                 P2pConnectionOutgoingInitOptsParseError::PeerIdParseError(err.to_string())
             })?,
@@ -401,7 +380,17 @@ impl FromStr for P2pConnectionOutgoingInitOpts {
                 .map_err(|err| {
                     P2pConnectionOutgoingInitOptsParseError::SignalingMethodParseError(err)
                 })?,
-        })
+        };
+
+        // Emit deprecation warning with the suggested multiaddr format
+        let suggested_maddr: Multiaddr = (&opts).into();
+        tracing::warn!(
+            message = "Deprecated address format detected. Please use multiaddr format instead.",
+            legacy_format = %s,
+            suggested_format = %suggested_maddr,
+        );
+
+        Ok(opts)
     }
 }
 
@@ -447,8 +436,188 @@ impl TryFrom<P2pConnectionOutgoingInitLibp2pOpts> for multiaddr::Multiaddr {
 impl TryFrom<&multiaddr::Multiaddr> for P2pConnectionOutgoingInitOpts {
     type Error = P2pConnectionOutgoingInitOptsParseError;
 
-    fn try_from(value: &multiaddr::Multiaddr) -> Result<Self, Self::Error> {
-        Ok(Self::LibP2P(value.try_into()?))
+    /// Parses a multiaddr into connection options.
+    ///
+    /// Supports both WebRTC and LibP2P multiaddr formats:
+    ///
+    /// **WebRTC formats** (contain `/webrtc` protocol):
+    /// - HTTP(S): `/<dns|dns4|dns6|ip4|ip6>/{host}/tcp/{port}/webrtc/<http|https>/p2p/{peer_id}`
+    /// - Proxied: `/<dns|dns4|dns6|ip4|ip6>/{host}/tcp/{port}/webrtc/<http|https>/http-path/{path}/p2p/{peer_id}`
+    /// - P2P Relay: `/p2p/{relay_peer_id}/webrtc/p2p-circuit/p2p/{target_peer_id}`
+    ///
+    /// **LibP2P format**:
+    /// - `/<dns|dns4|dns6|ip4|ip6>/{host}/tcp/{port}/p2p/{peer_id}`
+    fn try_from(maddr: &multiaddr::Multiaddr) -> Result<Self, Self::Error> {
+        // Check if this is a WebRTC multiaddr
+        let is_webrtc = maddr.iter().any(|p| p == Protocol::WebRTC);
+
+        if is_webrtc {
+            let mut iter = maddr.iter().peekable();
+
+            // Check for P2P relay format: /p2p/{relay}/webrtc/p2p-circuit/p2p/{target}
+            if matches!(iter.peek(), Some(Protocol::P2p(_))) {
+                let relay_peer_id = match iter.next() {
+                    Some(Protocol::P2p(hash)) => {
+                        libp2p_identity::PeerId::from_multihash(hash.into())
+                            .map_err(|_| {
+                                P2pConnectionOutgoingInitOptsParseError::Other(
+                                    "invalid relay peer_id multihash".to_string(),
+                                )
+                            })?
+                            .try_into()
+                            .map_err(|_| {
+                                P2pConnectionOutgoingInitOptsParseError::Other(
+                                    "unexpected error converting relay PeerId".to_string(),
+                                )
+                            })?
+                    }
+                    _ => {
+                        return Err(P2pConnectionOutgoingInitOptsParseError::Other(
+                            "expected p2p protocol for relay".to_string(),
+                        ))
+                    }
+                };
+
+                // Skip /webrtc
+                match iter.next() {
+                    Some(Protocol::WebRTC) => {}
+                    _ => {
+                        return Err(P2pConnectionOutgoingInitOptsParseError::Other(
+                            "expected webrtc protocol".to_string(),
+                        ))
+                    }
+                }
+
+                // Expect /p2p-circuit
+                match iter.next() {
+                    Some(Protocol::P2pCircuit) => {}
+                    _ => {
+                        return Err(P2pConnectionOutgoingInitOptsParseError::Other(
+                            "expected p2p-circuit protocol".to_string(),
+                        ))
+                    }
+                }
+
+                // Get target peer_id
+                let peer_id = match iter.next() {
+                    Some(Protocol::P2p(hash)) => {
+                        libp2p_identity::PeerId::from_multihash(hash.into())
+                            .map_err(|_| {
+                                P2pConnectionOutgoingInitOptsParseError::Other(
+                                    "invalid target peer_id multihash".to_string(),
+                                )
+                            })?
+                            .try_into()
+                            .map_err(|_| {
+                                P2pConnectionOutgoingInitOptsParseError::Other(
+                                    "unexpected error converting target PeerId".to_string(),
+                                )
+                            })?
+                    }
+                    _ => {
+                        return Err(P2pConnectionOutgoingInitOptsParseError::Other(
+                            "expected p2p protocol for target peer".to_string(),
+                        ))
+                    }
+                };
+
+                return Ok(Self::WebRTC {
+                    peer_id,
+                    signaling: webrtc::SignalingMethod::P2p { relay_peer_id },
+                });
+            }
+
+            // HTTP(S) signaling format: /dns4|ip4/{host}/tcp/{port}/webrtc/http|https/p2p/{peer_id}
+            let host = match iter.next() {
+                Some(Protocol::Ip4(v)) => Host::Ipv4(v),
+                Some(Protocol::Ip6(v)) => Host::Ipv6(v),
+                Some(Protocol::Dns(v) | Protocol::Dns4(v) | Protocol::Dns6(v)) => {
+                    Host::Domain(v.to_string())
+                }
+                _ => {
+                    return Err(P2pConnectionOutgoingInitOptsParseError::Other(
+                        "expected host (ip4/ip6/dns) in webrtc multiaddr".to_string(),
+                    ))
+                }
+            };
+
+            let port = match iter.next() {
+                Some(Protocol::Tcp(p)) => p,
+                _ => {
+                    return Err(P2pConnectionOutgoingInitOptsParseError::Other(
+                        "expected tcp port in webrtc multiaddr".to_string(),
+                    ))
+                }
+            };
+
+            // Skip /webrtc
+            match iter.next() {
+                Some(Protocol::WebRTC) => {}
+                _ => {
+                    return Err(P2pConnectionOutgoingInitOptsParseError::Other(
+                        "expected webrtc protocol".to_string(),
+                    ))
+                }
+            }
+
+            // Determine signaling method: http, https, or proxy with http-path
+            let signaling_info = HttpSignalingInfo { host, port };
+            let scheme = match iter.next() {
+                Some(Protocol::Http) => webrtc::ProxyScheme::Http,
+                Some(Protocol::Https) => webrtc::ProxyScheme::Https,
+                _ => {
+                    return Err(P2pConnectionOutgoingInitOptsParseError::Other(
+                        "expected http or https protocol after webrtc".to_string(),
+                    ))
+                }
+            };
+            let signaling = if let Some(Protocol::HttpPath(path)) = iter.peek() {
+                let path = path.to_string();
+                iter.next(); // consume the peeked item
+                webrtc::SignalingMethod::Proxied(scheme, webrtc::PathPrefix(path), signaling_info)
+            } else {
+                match scheme {
+                    webrtc::ProxyScheme::Http => webrtc::SignalingMethod::Http(signaling_info),
+                    webrtc::ProxyScheme::Https => webrtc::SignalingMethod::Https(signaling_info),
+                }
+            };
+
+            // Get peer_id
+            let peer_id = match iter.next() {
+                Some(Protocol::P2p(hash)) => libp2p_identity::PeerId::from_multihash(hash.into())
+                    .map_err(|_| {
+                        P2pConnectionOutgoingInitOptsParseError::Other(
+                            "invalid peer_id multihash".to_string(),
+                        )
+                    })?
+                    .try_into()
+                    .map_err(|_| {
+                        P2pConnectionOutgoingInitOptsParseError::Other(
+                            "unexpected error converting PeerId".to_string(),
+                        )
+                    })?,
+                _ => {
+                    return Err(P2pConnectionOutgoingInitOptsParseError::Other(
+                        "expected p2p protocol with peer_id".to_string(),
+                    ))
+                }
+            };
+
+            Ok(Self::WebRTC { peer_id, signaling })
+        } else {
+            // Standard libp2p multiaddr (no /webrtc)
+            #[cfg(target_arch = "wasm32")]
+            {
+                Err(P2pConnectionOutgoingInitOptsParseError::Other(
+                    "libp2p not supported in wasm".to_owned(),
+                ))
+            }
+
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                Ok(Self::LibP2P(maddr.try_into()?))
+            }
+        }
     }
 }
 
@@ -456,7 +625,111 @@ impl TryFrom<multiaddr::Multiaddr> for P2pConnectionOutgoingInitOpts {
     type Error = P2pConnectionOutgoingInitOptsParseError;
 
     fn try_from(value: multiaddr::Multiaddr) -> Result<Self, Self::Error> {
-        Ok(Self::LibP2P((&value).try_into()?))
+        (&value).try_into()
+    }
+}
+
+impl From<&P2pConnectionOutgoingInitOpts> for Multiaddr {
+    /// Converts connection options to a multiaddr.
+    ///
+    /// **WebRTC formats** :
+    /// - HTTP(S): `/<dns|dns4|dns6|ip4|ip6>/{host}/tcp/{port}/webrtc/<http|https>/p2p/{peer_id}`
+    /// - Proxy: `/<dns|dns4|dns6|ip4|ip6>/{host}/tcp/{port}/webrtc/<http|https>/http-path/{url_encoded_prefix}/p2p/{peer_id}`
+    /// - P2P Relay: `/p2p/{relay_peer_id}/webrtc/p2p-circuit/p2p/{target_peer_id}`
+    ///
+    /// **LibP2P format**:
+    /// - `/<dns|dns4|dns6|ip4|ip6>/{host}/tcp/{port}/p2p/{peer_id}`
+    fn from(opts: &P2pConnectionOutgoingInitOpts) -> Self {
+        match opts {
+            P2pConnectionOutgoingInitOpts::WebRTC { peer_id, signaling } => {
+                use webrtc::SignalingMethod;
+
+                let peer_id_proto = Protocol::P2p(
+                    libp2p_identity::PeerId::try_from(*peer_id).expect("valid peer_id"),
+                );
+
+                match signaling {
+                    SignalingMethod::Http(info) => {
+                        let host_proto = match &info.host {
+                            Host::Domain(v) => Protocol::Dns4(v.into()),
+                            Host::Ipv4(v) => Protocol::Ip4(*v),
+                            Host::Ipv6(v) => Protocol::Ip6(*v),
+                        };
+                        Multiaddr::empty()
+                            .with(host_proto)
+                            .with(Protocol::Tcp(info.port))
+                            .with(Protocol::WebRTC)
+                            .with(Protocol::Http)
+                            .with(peer_id_proto)
+                    }
+                    SignalingMethod::Https(info) => {
+                        let host_proto = match &info.host {
+                            Host::Domain(v) => Protocol::Dns4(v.into()),
+                            Host::Ipv4(v) => Protocol::Ip4(*v),
+                            Host::Ipv6(v) => Protocol::Ip6(*v),
+                        };
+                        Multiaddr::empty()
+                            .with(host_proto)
+                            .with(Protocol::Tcp(info.port))
+                            .with(Protocol::WebRTC)
+                            .with(Protocol::Https)
+                            .with(peer_id_proto)
+                    }
+                    SignalingMethod::HttpsProxy(cluster_id, info) => {
+                        // Convert legacy cluster_id to path format: /clusters/{id}
+                        let host_proto = match &info.host {
+                            Host::Domain(v) => Protocol::Dns4(v.into()),
+                            Host::Ipv4(v) => Protocol::Ip4(*v),
+                            Host::Ipv6(v) => Protocol::Ip6(*v),
+                        };
+                        let path = format!("clusters/{}", cluster_id);
+                        Multiaddr::empty()
+                            .with(host_proto)
+                            .with(Protocol::Tcp(info.port))
+                            .with(Protocol::WebRTC)
+                            .with(Protocol::Https)
+                            .with(Protocol::HttpPath(path.into()))
+                            .with(peer_id_proto)
+                    }
+                    SignalingMethod::Proxied(scheme, webrtc::PathPrefix(path), info) => {
+                        let host_proto = match &info.host {
+                            Host::Domain(v) => Protocol::Dns4(v.into()),
+                            Host::Ipv4(v) => Protocol::Ip4(*v),
+                            Host::Ipv6(v) => Protocol::Ip6(*v),
+                        };
+                        let scheme_proto = match scheme {
+                            webrtc::ProxyScheme::Http => Protocol::Http,
+                            webrtc::ProxyScheme::Https => Protocol::Https,
+                        };
+                        Multiaddr::empty()
+                            .with(host_proto)
+                            .with(Protocol::Tcp(info.port))
+                            .with(Protocol::WebRTC)
+                            .with(scheme_proto)
+                            .with(Protocol::HttpPath(path.into()))
+                            .with(peer_id_proto)
+                    }
+                    SignalingMethod::P2p { relay_peer_id } => {
+                        let relay_id_proto = Protocol::P2p(
+                            libp2p_identity::PeerId::try_from(*relay_peer_id)
+                                .expect("valid relay_peer_id"),
+                        );
+                        Multiaddr::empty()
+                            .with(relay_id_proto)
+                            .with(Protocol::WebRTC)
+                            .with(Protocol::P2pCircuit)
+                            .with(peer_id_proto)
+                    }
+                }
+            }
+            P2pConnectionOutgoingInitOpts::LibP2P(v) => v.to_maddr().expect("valid libp2p opts"),
+        }
+    }
+}
+
+impl From<P2pConnectionOutgoingInitOpts> for Multiaddr {
+    fn from(opts: P2pConnectionOutgoingInitOpts) -> Self {
+        (&opts).into()
     }
 }
 
@@ -535,6 +808,307 @@ mod measurement {
     impl MallocSizeOf for P2pConnectionOutgoingInitOpts {
         fn size_of(&self, _ops: &mut MallocSizeOfOps) -> usize {
             0
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Unit tests for P2pConnectionOutgoingInitOpts multiaddr parsing
+    //!
+    //! Run these tests with:
+    //! ```bash
+    //! cargo test -p mina-p2p connection::outgoing::tests
+    //! ```
+
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    // Use libp2p PeerId format for test multiaddrs
+    const TEST_PEER_ID_LIBP2P: &str = "12D3KooWEiGVAFC7curXWXiGZyMWnZK9h8BKr88U8D5PKV3dXciv";
+    const TEST_RELAY_PEER_ID_LIBP2P: &str = "12D3KooWAdgYL6hv18M3iDBdaK1dRygPivSfAfBNDzie6YqydVbs";
+
+    #[test]
+    fn test_parse_webrtc_http_signaling_domain() {
+        let maddr_str = format!(
+            "/dns4/signal.example.com/tcp/8080/webrtc/http/p2p/{}",
+            TEST_PEER_ID_LIBP2P
+        );
+        let opts: P2pConnectionOutgoingInitOpts = maddr_str.parse().unwrap();
+
+        match opts {
+            P2pConnectionOutgoingInitOpts::WebRTC { signaling, .. } => match signaling {
+                webrtc::SignalingMethod::Http(info) => {
+                    assert_eq!(info.host, Host::Domain("signal.example.com".to_string()));
+                    assert_eq!(info.port, 8080);
+                }
+                _ => panic!("Expected Http signaling method"),
+            },
+            _ => panic!("Expected WebRTC variant"),
+        }
+    }
+
+    #[test]
+    fn test_parse_webrtc_http_signaling_ipv4() {
+        let maddr_str = format!(
+            "/ip4/192.168.1.100/tcp/8080/webrtc/http/p2p/{}",
+            TEST_PEER_ID_LIBP2P
+        );
+        let opts: P2pConnectionOutgoingInitOpts = maddr_str.parse().unwrap();
+
+        match opts {
+            P2pConnectionOutgoingInitOpts::WebRTC { signaling, .. } => match signaling {
+                webrtc::SignalingMethod::Http(info) => {
+                    assert_eq!(info.host, Host::Ipv4(Ipv4Addr::new(192, 168, 1, 100)));
+                    assert_eq!(info.port, 8080);
+                }
+                _ => panic!("Expected Http signaling method"),
+            },
+            _ => panic!("Expected WebRTC variant"),
+        }
+    }
+
+    #[test]
+    fn test_parse_webrtc_https_signaling() {
+        let maddr_str = format!(
+            "/dns4/signal.example.com/tcp/443/webrtc/https/p2p/{}",
+            TEST_PEER_ID_LIBP2P
+        );
+        let opts: P2pConnectionOutgoingInitOpts = maddr_str.parse().unwrap();
+
+        match opts {
+            P2pConnectionOutgoingInitOpts::WebRTC { signaling, .. } => match signaling {
+                webrtc::SignalingMethod::Https(info) => {
+                    assert_eq!(info.host, Host::Domain("signal.example.com".to_string()));
+                    assert_eq!(info.port, 443);
+                }
+                _ => panic!("Expected Https signaling method"),
+            },
+            _ => panic!("Expected WebRTC variant"),
+        }
+    }
+
+    #[test]
+    fn test_parse_webrtc_https_proxy_with_http_path() {
+        let maddr_str = format!(
+            "/dns4/proxy.example.com/tcp/443/webrtc/https/http-path/cluster%2F123%2Fmina%2Fwebrtc%2Fsignal/p2p/{}",
+            TEST_PEER_ID_LIBP2P
+        );
+        let opts: P2pConnectionOutgoingInitOpts = maddr_str.parse().unwrap();
+
+        match opts {
+            P2pConnectionOutgoingInitOpts::WebRTC { signaling, .. } => match signaling {
+                webrtc::SignalingMethod::Proxied(scheme, webrtc::PathPrefix(path), info) => {
+                    assert_eq!(scheme, webrtc::ProxyScheme::Https);
+                    assert_eq!(path, "cluster/123/mina/webrtc/signal");
+                    assert_eq!(info.host, Host::Domain("proxy.example.com".to_string()));
+                    assert_eq!(info.port, 443);
+                }
+                _ => panic!("Expected Proxied signaling method"),
+            },
+            _ => panic!("Expected WebRTC variant"),
+        }
+    }
+
+    #[test]
+    fn test_parse_webrtc_p2p_relay() {
+        let maddr_str = format!(
+            "/p2p/{}/webrtc/p2p-circuit/p2p/{}",
+            TEST_RELAY_PEER_ID_LIBP2P, TEST_PEER_ID_LIBP2P
+        );
+        let opts: P2pConnectionOutgoingInitOpts = maddr_str.parse().unwrap();
+
+        match opts {
+            P2pConnectionOutgoingInitOpts::WebRTC { signaling, .. } => match signaling {
+                webrtc::SignalingMethod::P2p { .. } => {
+                    // Successfully parsed as P2P relay
+                }
+                _ => panic!("Expected P2p signaling method"),
+            },
+            _ => panic!("Expected WebRTC variant"),
+        }
+    }
+
+    #[test]
+    fn test_parse_libp2p_multiaddr() {
+        let maddr_str = format!(
+            "/dns4/seed-1.devnet.gcp.o1test.net/tcp/10003/p2p/{}",
+            TEST_PEER_ID_LIBP2P
+        );
+        let opts: P2pConnectionOutgoingInitOpts = maddr_str.parse().unwrap();
+
+        match opts {
+            P2pConnectionOutgoingInitOpts::LibP2P(libp2p_opts) => {
+                assert_eq!(
+                    libp2p_opts.host,
+                    Host::Domain("seed-1.devnet.gcp.o1test.net".to_string())
+                );
+                assert_eq!(libp2p_opts.port, 10003);
+            }
+            _ => panic!("Expected LibP2P variant"),
+        }
+    }
+
+    #[test]
+    fn test_roundtrip_webrtc_http() {
+        let maddr_str = format!(
+            "/dns4/signal.example.com/tcp/8080/webrtc/http/p2p/{}",
+            TEST_PEER_ID_LIBP2P
+        );
+
+        // First decode: parse multiaddr string
+        let opts1: P2pConnectionOutgoingInitOpts = maddr_str.parse().unwrap();
+
+        // Encode: convert to Multiaddr, then to string
+        let maddr: Multiaddr = (&opts1).into();
+        let encoded_str = maddr.to_string();
+
+        // Second decode: parse the encoded string
+        let opts2: P2pConnectionOutgoingInitOpts = encoded_str.parse().unwrap();
+
+        // Both decodes should match structurally
+        assert_eq!(opts1, opts2);
+    }
+
+    #[test]
+    fn test_roundtrip_webrtc_https() {
+        let maddr_str = format!(
+            "/dns4/signal.example.com/tcp/443/webrtc/https/p2p/{}",
+            TEST_PEER_ID_LIBP2P
+        );
+
+        let opts1: P2pConnectionOutgoingInitOpts = maddr_str.parse().unwrap();
+        let maddr: Multiaddr = (&opts1).into();
+        let opts2: P2pConnectionOutgoingInitOpts = (&maddr).try_into().unwrap();
+
+        assert_eq!(opts1, opts2);
+    }
+
+    #[test]
+    fn test_roundtrip_webrtc_https_proxy() {
+        let maddr_str = format!(
+            "/dns4/proxy.example.com/tcp/443/webrtc/https/http-path/cluster%2F123/p2p/{}",
+            TEST_PEER_ID_LIBP2P
+        );
+
+        let opts1: P2pConnectionOutgoingInitOpts = maddr_str.parse().unwrap();
+        let maddr: Multiaddr = (&opts1).into();
+        let opts2: P2pConnectionOutgoingInitOpts = (&maddr).try_into().unwrap();
+
+        assert_eq!(opts1, opts2);
+    }
+
+    #[test]
+    fn test_roundtrip_webrtc_p2p_relay() {
+        let maddr_str = format!(
+            "/p2p/{}/webrtc/p2p-circuit/p2p/{}",
+            TEST_RELAY_PEER_ID_LIBP2P, TEST_PEER_ID_LIBP2P
+        );
+
+        let opts1: P2pConnectionOutgoingInitOpts = maddr_str.parse().unwrap();
+        let maddr: Multiaddr = (&opts1).into();
+        let opts2: P2pConnectionOutgoingInitOpts = (&maddr).try_into().unwrap();
+
+        assert_eq!(opts1, opts2);
+    }
+
+    #[test]
+    fn test_roundtrip_libp2p() {
+        let maddr_str = format!("/dns4/example.com/tcp/10003/p2p/{}", TEST_PEER_ID_LIBP2P);
+
+        let opts1: P2pConnectionOutgoingInitOpts = maddr_str.parse().unwrap();
+        let maddr: Multiaddr = (&opts1).into();
+        let opts2: P2pConnectionOutgoingInitOpts = (&maddr).try_into().unwrap();
+
+        assert_eq!(opts1, opts2);
+    }
+
+    #[test]
+    fn test_from_multiaddr_webrtc_http() {
+        let maddr_str = format!(
+            "/dns4/signal.example.com/tcp/8080/webrtc/http/p2p/{}",
+            TEST_PEER_ID_LIBP2P
+        );
+        let maddr: Multiaddr = maddr_str.parse().unwrap();
+        let opts: P2pConnectionOutgoingInitOpts = (&maddr).try_into().unwrap();
+
+        assert!(matches!(
+            opts,
+            P2pConnectionOutgoingInitOpts::WebRTC {
+                signaling: webrtc::SignalingMethod::Http(_),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_to_multiaddr_webrtc_http() {
+        // Create peer_id from libp2p PeerId directly
+        let libp2p_peer_id: libp2p_identity::PeerId = TEST_PEER_ID_LIBP2P.parse().unwrap();
+        let peer_id: PeerId = libp2p_peer_id.try_into().unwrap();
+
+        let opts = P2pConnectionOutgoingInitOpts::WebRTC {
+            peer_id,
+            signaling: webrtc::SignalingMethod::Http(HttpSignalingInfo {
+                host: Host::Domain("signal.example.com".to_string()),
+                port: 8080,
+            }),
+        };
+
+        let maddr: Multiaddr = (&opts).into();
+        let maddr_str = maddr.to_string();
+
+        assert!(maddr_str.contains("/webrtc/http/"));
+        assert!(maddr_str.contains("/dns4/signal.example.com/"));
+        assert!(maddr_str.contains("/tcp/8080/"));
+
+        // Verify roundtrip
+        let opts2: P2pConnectionOutgoingInitOpts = (&maddr).try_into().unwrap();
+        assert_eq!(opts, opts2);
+    }
+
+    #[test]
+    fn test_to_multiaddr_webrtc_p2p_relay() {
+        let libp2p_peer_id: libp2p_identity::PeerId = TEST_PEER_ID_LIBP2P.parse().unwrap();
+        let peer_id: PeerId = libp2p_peer_id.try_into().unwrap();
+
+        let libp2p_relay_peer_id: libp2p_identity::PeerId =
+            TEST_RELAY_PEER_ID_LIBP2P.parse().unwrap();
+        let relay_peer_id: PeerId = libp2p_relay_peer_id.try_into().unwrap();
+
+        let opts = P2pConnectionOutgoingInitOpts::WebRTC {
+            peer_id,
+            signaling: webrtc::SignalingMethod::P2p { relay_peer_id },
+        };
+
+        let maddr: Multiaddr = (&opts).into();
+        let maddr_str = maddr.to_string();
+
+        assert!(maddr_str.contains("/webrtc/p2p-circuit/"));
+        assert!(maddr_str.starts_with("/p2p/"));
+
+        // Verify roundtrip
+        let opts2: P2pConnectionOutgoingInitOpts = (&maddr).try_into().unwrap();
+        assert_eq!(opts, opts2);
+    }
+
+    #[test]
+    fn test_legacy_format_still_works() {
+        // Use a peer_id in the legacy format (internal base58 check encoding)
+        // First parse from libp2p format to get a valid internal PeerId
+        let libp2p_peer_id: libp2p_identity::PeerId = TEST_PEER_ID_LIBP2P.parse().unwrap();
+        let peer_id: PeerId = libp2p_peer_id.try_into().unwrap();
+        let legacy_peer_id_str = peer_id.to_string();
+
+        // Test that legacy format /{peer_id}/{signaling} still parses
+        let legacy_str = format!("/{}/http/signal.example.com/8080", legacy_peer_id_str);
+        let opts: P2pConnectionOutgoingInitOpts = legacy_str.parse().unwrap();
+
+        match opts {
+            P2pConnectionOutgoingInitOpts::WebRTC { signaling, .. } => {
+                assert!(matches!(signaling, webrtc::SignalingMethod::Http(_)));
+            }
+            _ => panic!("Expected WebRTC variant"),
         }
     }
 }

--- a/crates/p2p/src/connection/outgoing/mod.rs
+++ b/crates/p2p/src/connection/outgoing/mod.rs
@@ -303,6 +303,17 @@ impl P2pConnectionOutgoingInitOpts {
                         ),
                     })
                 }
+                SignalingMethod::Proxied(scheme, path_prefix, info) => {
+                    Some(v2::NetworkPeerPeerStableV1 {
+                        host: format!("{}://{}{}", scheme, info.host, path_prefix)
+                            .as_bytes()
+                            .into(),
+                        libp2p_port: (info.port as u64).into(),
+                        peer_id: v2::NetworkPeerPeerIdStableV1(
+                            (*peer_id).to_string().into_bytes().into(),
+                        ),
+                    })
+                }
                 SignalingMethod::P2p { .. } => None,
             },
         }

--- a/crates/p2p/src/connection/outgoing_effectful/p2p_connection_outgoing_effectful_effects.rs
+++ b/crates/p2p/src/connection/outgoing_effectful/p2p_connection_outgoing_effectful_effects.rs
@@ -42,7 +42,8 @@ impl P2pConnectionOutgoingEffectfulAction {
                 match signaling_method {
                     webrtc::SignalingMethod::Http(_)
                     | webrtc::SignalingMethod::Https(_)
-                    | webrtc::SignalingMethod::HttpsProxy(_, _) => {
+                    | webrtc::SignalingMethod::HttpsProxy(_, _)
+                    | webrtc::SignalingMethod::Proxied(_, _, _) => {
                         let Some(url) = signaling_method.http_url() else {
                             return;
                         };

--- a/crates/p2p/src/webrtc/mod.rs
+++ b/crates/p2p/src/webrtc/mod.rs
@@ -18,7 +18,9 @@ pub use signal::{
 };
 
 mod signaling_method;
-pub use signaling_method::{HttpSignalingInfo, SignalingMethod, SignalingMethodParseError};
+pub use signaling_method::{
+    HttpSignalingInfo, PathPrefix, ProxyScheme, SignalingMethod, SignalingMethodParseError,
+};
 
 mod connection_auth;
 pub use connection_auth::{ConnectionAuth, ConnectionAuthEncrypted};

--- a/crates/p2p/src/webrtc/signaling_method/mod.rs
+++ b/crates/p2p/src/webrtc/signaling_method/mod.rs
@@ -68,8 +68,44 @@ use crate::PeerId;
 /// The legacy `HttpsProxy(u16, HttpSignalingInfo)` is preserved for BinProt
 /// backward compatibility.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Clone, derive_more::Display)]
-#[display(fmt = "{_0}")]
-pub struct PathPrefix(pub String);
+pub struct PathPrefix(String);
+
+impl PathPrefix {
+    /// Consumes the PathPrefix and returns the inner String.
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl From<String> for PathPrefix {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for PathPrefix {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+impl From<Cow<'_, str>> for PathPrefix {
+    fn from(s: Cow<'_, str>) -> Self {
+        Self(s.into_owned())
+    }
+}
+
+impl<'a> From<&'a PathPrefix> for Cow<'a, str> {
+    fn from(p: &'a PathPrefix) -> Self {
+        Cow::Borrowed(p.as_ref())
+    }
+}
+
+impl AsRef<str> for PathPrefix {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
 
 /// Proxy connection scheme (HTTP or HTTPS).
 ///
@@ -103,13 +139,13 @@ impl BinProtRead for PathPrefix {
     {
         let bytes: Vec<u8> = BinProtRead::binprot_read(r)?;
         let s = String::from_utf8(bytes).map_err(|e| binprot::Error::from(e.utf8_error()))?;
-        Ok(PathPrefix(s))
+        Ok(s.into())
     }
 }
 
 impl BinProtWrite for PathPrefix {
     fn binprot_write<W: std::io::Write>(&self, w: &mut W) -> std::io::Result<()> {
-        self.0.as_bytes().to_vec().binprot_write(w)
+        self.as_ref().as_bytes().to_vec().binprot_write(w)
     }
 }
 
@@ -239,17 +275,18 @@ impl SignalingMethod {
                 Cow::Owned(format!("/clusters/{cluster_id}/")),
                 info,
             ),
-            Self::Proxied(scheme, PathPrefix(prefix), info) => {
+            Self::Proxied(scheme, prefix, info) => {
                 // Handle empty prefix or just "/" as equivalent to no prefix
-                let prefix_cow = if prefix.is_empty() || prefix == "/" {
+                let prefix_str = prefix.as_ref();
+                let prefix_cow = if prefix_str.is_empty() || prefix_str == "/" {
                     slash
                 } else {
-                    let needs_start_slash = !prefix.starts_with('/');
-                    let needs_end_slash = !prefix.ends_with('/');
+                    let needs_start_slash = !prefix_str.starts_with('/');
+                    let needs_end_slash = !prefix_str.ends_with('/');
                     Cow::Owned(format!(
                         "{}{}{}",
                         if needs_start_slash { "/" } else { "" },
-                        prefix,
+                        prefix_str,
                         if needs_end_slash { "/" } else { "" }
                     ))
                 };
@@ -315,8 +352,8 @@ impl fmt::Display for SignalingMethod {
                 write!(f, "/https_proxy/{cluster_id}")?;
                 signaling.fmt(f)
             }
-            Self::Proxied(scheme, PathPrefix(path_prefix), signaling) => {
-                let encoded = utf8_percent_encode(path_prefix, NON_ALPHANUMERIC);
+            Self::Proxied(scheme, path_prefix, signaling) => {
+                let encoded = utf8_percent_encode(path_prefix.as_ref(), NON_ALPHANUMERIC);
                 write!(f, "/proxied/{scheme}/{encoded}")?;
                 signaling.fmt(f)
             }
@@ -468,11 +505,7 @@ impl FromStr for SignalingMethod {
                     .decode_utf8()
                     .map_err(|e| SignalingMethodParseError::HostParseError(e.to_string()))?
                     .into_owned();
-                Ok(Self::Proxied(
-                    scheme,
-                    PathPrefix(path_prefix),
-                    rest.parse()?,
-                ))
+                Ok(Self::Proxied(scheme, path_prefix.into(), rest.parse()?))
             }
             method => Err(SignalingMethodParseError::UnknownSignalingMethod(
                 method.to_owned(),
@@ -859,8 +892,8 @@ mod tests {
             .parse()
             .unwrap();
         match method {
-            SignalingMethod::Proxied(ProxyScheme::Https, PathPrefix(prefix), info) => {
-                assert_eq!(prefix, "/clusters/123");
+            SignalingMethod::Proxied(ProxyScheme::Https, prefix, info) => {
+                assert_eq!(prefix.as_ref(), "/clusters/123");
                 assert_eq!(info.host, Host::Domain("proxy.example.com".to_string()));
                 assert_eq!(info.port, 443);
             }
@@ -876,8 +909,8 @@ mod tests {
                 .parse()
                 .unwrap();
         match method {
-            SignalingMethod::Proxied(ProxyScheme::Https, PathPrefix(prefix), info) => {
-                assert_eq!(prefix, "/api/v2/webrtc");
+            SignalingMethod::Proxied(ProxyScheme::Https, prefix, info) => {
+                assert_eq!(prefix.as_ref(), "/api/v2/webrtc");
                 assert_eq!(info.host, Host::Domain("gateway.example.com".to_string()));
                 assert_eq!(info.port, 8443);
             }
@@ -889,7 +922,7 @@ mod tests {
     fn test_roundtrip_proxied() {
         let original = SignalingMethod::Proxied(
             ProxyScheme::Https,
-            PathPrefix("/clusters/789".to_string()),
+            "/clusters/789".into(),
             HttpSignalingInfo {
                 host: Host::Domain("proxy.example.com".to_string()),
                 port: 443,
@@ -910,7 +943,7 @@ mod tests {
     fn test_proxied_https_url() {
         let method = SignalingMethod::Proxied(
             ProxyScheme::Https,
-            PathPrefix("/custom/path".to_string()),
+            "/custom/path".into(),
             HttpSignalingInfo {
                 host: Host::Domain("gateway.example.com".to_string()),
                 port: 443,
@@ -928,7 +961,7 @@ mod tests {
     fn test_proxied_https_url_no_leading_slash() {
         let method = SignalingMethod::Proxied(
             ProxyScheme::Https,
-            PathPrefix("custom/path".to_string()),
+            "custom/path".into(),
             HttpSignalingInfo {
                 host: Host::Domain("gateway.example.com".to_string()),
                 port: 443,
@@ -947,7 +980,7 @@ mod tests {
     fn test_proxied_https_url_trailing_slash() {
         let method = SignalingMethod::Proxied(
             ProxyScheme::Https,
-            PathPrefix("/custom/path/".to_string()),
+            "/custom/path/".into(),
             HttpSignalingInfo {
                 host: Host::Domain("gateway.example.com".to_string()),
                 port: 443,
@@ -966,8 +999,8 @@ mod tests {
     fn test_proxied_with_ipv4() {
         let method: SignalingMethod = "/proxied/https/%2Ftest/192.168.1.1/8443".parse().unwrap();
         match method {
-            SignalingMethod::Proxied(ProxyScheme::Https, PathPrefix(prefix), info) => {
-                assert_eq!(prefix, "/test");
+            SignalingMethod::Proxied(ProxyScheme::Https, prefix, info) => {
+                assert_eq!(prefix.as_ref(), "/test");
                 assert_eq!(info.host, Host::Ipv4(Ipv4Addr::new(192, 168, 1, 1)));
                 assert_eq!(info.port, 8443);
             }
@@ -997,11 +1030,7 @@ mod tests {
         };
 
         let legacy = SignalingMethod::HttpsProxy(123, info.clone());
-        let proxied = SignalingMethod::Proxied(
-            ProxyScheme::Https,
-            PathPrefix("/clusters/123".to_string()),
-            info,
-        );
+        let proxied = SignalingMethod::Proxied(ProxyScheme::Https, "/clusters/123".into(), info);
 
         assert_eq!(legacy.http_url(), proxied.http_url());
         assert_eq!(
@@ -1014,7 +1043,7 @@ mod tests {
     fn test_proxied_empty_prefix() {
         let method = SignalingMethod::Proxied(
             ProxyScheme::Https,
-            PathPrefix("".to_string()),
+            "".into(),
             HttpSignalingInfo {
                 host: Host::Domain("gateway.example.com".to_string()),
                 port: 443,
@@ -1030,7 +1059,7 @@ mod tests {
     fn test_proxied_just_slash() {
         let method = SignalingMethod::Proxied(
             ProxyScheme::Https,
-            PathPrefix("/".to_string()),
+            "/".into(),
             HttpSignalingInfo {
                 host: Host::Domain("gateway.example.com".to_string()),
                 port: 443,
@@ -1050,44 +1079,28 @@ mod tests {
         };
 
         // No slashes
-        let m1 = SignalingMethod::Proxied(
-            ProxyScheme::Https,
-            PathPrefix("path".to_string()),
-            info.clone(),
-        );
+        let m1 = SignalingMethod::Proxied(ProxyScheme::Https, "path".into(), info.clone());
         assert_eq!(
             m1.http_url().unwrap(),
             "https://example.com:443/path/mina/webrtc/signal"
         );
 
         // Leading slash only
-        let m2 = SignalingMethod::Proxied(
-            ProxyScheme::Https,
-            PathPrefix("/path".to_string()),
-            info.clone(),
-        );
+        let m2 = SignalingMethod::Proxied(ProxyScheme::Https, "/path".into(), info.clone());
         assert_eq!(
             m2.http_url().unwrap(),
             "https://example.com:443/path/mina/webrtc/signal"
         );
 
         // Trailing slash only
-        let m3 = SignalingMethod::Proxied(
-            ProxyScheme::Https,
-            PathPrefix("path/".to_string()),
-            info.clone(),
-        );
+        let m3 = SignalingMethod::Proxied(ProxyScheme::Https, "path/".into(), info.clone());
         assert_eq!(
             m3.http_url().unwrap(),
             "https://example.com:443/path/mina/webrtc/signal"
         );
 
         // Both slashes
-        let m4 = SignalingMethod::Proxied(
-            ProxyScheme::Https,
-            PathPrefix("/path/".to_string()),
-            info.clone(),
-        );
+        let m4 = SignalingMethod::Proxied(ProxyScheme::Https, "/path/".into(), info.clone());
         assert_eq!(
             m4.http_url().unwrap(),
             "https://example.com:443/path/mina/webrtc/signal"
@@ -1104,7 +1117,7 @@ mod tests {
         // No outer slashes
         let m1 = SignalingMethod::Proxied(
             ProxyScheme::Https,
-            PathPrefix("api/v2/clusters/123".to_string()),
+            "api/v2/clusters/123".into(),
             info.clone(),
         );
         assert_eq!(
@@ -1115,7 +1128,7 @@ mod tests {
         // Both outer slashes
         let m2 = SignalingMethod::Proxied(
             ProxyScheme::Https,
-            PathPrefix("/api/v2/clusters/123/".to_string()),
+            "/api/v2/clusters/123/".into(),
             info.clone(),
         );
         assert_eq!(
@@ -1129,8 +1142,8 @@ mod tests {
         // %2F is URL-encoded "/"
         let method: SignalingMethod = "/proxied/https/%2F/example.com/443".parse().unwrap();
         match &method {
-            SignalingMethod::Proxied(ProxyScheme::Https, PathPrefix(prefix), info) => {
-                assert_eq!(prefix, "/");
+            SignalingMethod::Proxied(ProxyScheme::Https, prefix, info) => {
+                assert_eq!(prefix.as_ref(), "/");
                 assert_eq!(info.host, Host::Domain("example.com".to_string()));
                 assert_eq!(info.port, 443);
             }
@@ -1150,7 +1163,7 @@ mod tests {
         // the same URL as Https variant. Test verifies the expected parse error.
         let original = SignalingMethod::Proxied(
             ProxyScheme::Https,
-            PathPrefix("".to_string()),
+            "".into(),
             HttpSignalingInfo {
                 host: Host::Domain("example.com".to_string()),
                 port: 443,
@@ -1174,7 +1187,7 @@ mod tests {
     fn test_proxied_http_scheme() {
         let method = SignalingMethod::Proxied(
             ProxyScheme::Http,
-            PathPrefix("/api/proxy".to_string()),
+            "/api/proxy".into(),
             HttpSignalingInfo {
                 host: Host::Domain("gateway.example.com".to_string()),
                 port: 8080,
@@ -1192,7 +1205,7 @@ mod tests {
     fn test_proxied_http_scheme_roundtrip() {
         let original = SignalingMethod::Proxied(
             ProxyScheme::Http,
-            PathPrefix("/dev/proxy".to_string()),
+            "/dev/proxy".into(),
             HttpSignalingInfo {
                 host: Host::Domain("localhost".to_string()),
                 port: 3000,
@@ -1212,8 +1225,8 @@ mod tests {
             .parse()
             .unwrap();
         match method {
-            SignalingMethod::Proxied(ProxyScheme::Http, PathPrefix(prefix), info) => {
-                assert_eq!(prefix, "/dev/proxy");
+            SignalingMethod::Proxied(ProxyScheme::Http, prefix, info) => {
+                assert_eq!(prefix.as_ref(), "/dev/proxy");
                 assert_eq!(info.host, Host::Domain("localhost".to_string()));
                 assert_eq!(info.port, 3000);
             }

--- a/crates/p2p/src/webrtc/signaling_method/mod.rs
+++ b/crates/p2p/src/webrtc/signaling_method/mod.rs
@@ -102,7 +102,7 @@ impl BinProtRead for PathPrefix {
         Self: Sized,
     {
         let bytes: Vec<u8> = BinProtRead::binprot_read(r)?;
-        let s = String::from_utf8(bytes).map_err(|e| binprot::Error::CustomError(Box::new(e)))?;
+        let s = String::from_utf8(bytes).map_err(|e| binprot::Error::from(e.utf8_error()))?;
         Ok(PathPrefix(s))
     }
 }
@@ -338,7 +338,7 @@ impl fmt::Display for SignalingMethod {
 /// The parser can fail for various reasons including missing components,
 /// invalid formats, or unsupported method types. Each error variant provides
 /// specific context about what went wrong during parsing.
-#[derive(Error, Serialize, Deserialize, Debug, Clone)]
+#[derive(Error, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub enum SignalingMethodParseError {
     /// Insufficient arguments provided for the signaling method.
     ///
@@ -534,7 +534,7 @@ mod tests {
                 assert_eq!(info.host, Host::Domain("example.com".to_string()));
                 assert_eq!(info.port, 8080);
             }
-            _ => panic!("Expected Http variant"),
+            x => panic!("Expected Http variant, got {x:?}"),
         }
     }
 
@@ -546,7 +546,7 @@ mod tests {
                 assert_eq!(info.host, Host::Domain("signal.example.com".to_string()));
                 assert_eq!(info.port, 443);
             }
-            _ => panic!("Expected Https variant"),
+            x => panic!("Expected Https variant, got {x:?}"),
         }
     }
 
@@ -559,7 +559,7 @@ mod tests {
                 assert_eq!(info.host, Host::Domain("proxy.example.com".to_string()));
                 assert_eq!(info.port, 443);
             }
-            _ => panic!("Expected HttpsProxy variant"),
+            x => panic!("Expected HttpsProxy variant, got {x:?}"),
         }
     }
 
@@ -572,7 +572,7 @@ mod tests {
                 assert_eq!(info.host, Host::Domain("proxy.example.com".to_string()));
                 assert_eq!(info.port, 443);
             }
-            _ => panic!("Expected HttpsProxy variant"),
+            x => panic!("Expected HttpsProxy variant, got {x:?}"),
         }
     }
 
@@ -584,7 +584,7 @@ mod tests {
                 assert_eq!(info.host, Host::Ipv4(Ipv4Addr::new(192, 168, 1, 1)));
                 assert_eq!(info.port, 8080);
             }
-            _ => panic!("Expected Http variant"),
+            x => panic!("Expected Http variant, got {x:?}"),
         }
     }
 
@@ -596,152 +596,115 @@ mod tests {
                 assert!(matches!(info.host, Host::Ipv6(_)));
                 assert_eq!(info.port, 443);
             }
-            _ => panic!("Expected Https variant"),
+            x => panic!("Expected Https variant, got {x:?}"),
         }
     }
 
     #[test]
     fn test_from_str_empty_string() {
         let result: Result<SignalingMethod, _> = "".parse();
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            SignalingMethodParseError::NotEnoughArgs
-        ));
+        assert_eq!(result, Err(SignalingMethodParseError::NotEnoughArgs));
     }
 
     #[test]
     fn test_from_str_no_leading_slash() {
         let result: Result<SignalingMethod, _> = "http/example.com/8080".parse();
-        assert!(result.is_err());
-        // Without leading slash, it treats "http" as unknown method since
-        // there's no slash at start
-        assert!(matches!(
-            result.unwrap_err(),
-            SignalingMethodParseError::UnknownSignalingMethod(_)
-        ));
+        // Without leading slash, it parses "ttp" as the method (s[1..] gives
+        // "ttp/example.com/8080")
+        assert_eq!(
+            result,
+            Err(SignalingMethodParseError::UnknownSignalingMethod(
+                "ttp".to_string()
+            ))
+        );
     }
 
     #[test]
     fn test_from_str_only_slash() {
         let result: Result<SignalingMethod, _> = "/".parse();
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            SignalingMethodParseError::NotEnoughArgs
-        ));
+        assert_eq!(result, Err(SignalingMethodParseError::NotEnoughArgs));
     }
 
     #[test]
     fn test_from_str_unknown_method() {
         let result: Result<SignalingMethod, _> = "/websocket/example.com/8080".parse();
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            SignalingMethodParseError::UnknownSignalingMethod(_)
-        ));
+        assert_eq!(
+            result,
+            Err(SignalingMethodParseError::UnknownSignalingMethod(
+                "websocket".to_string()
+            ))
+        );
     }
 
     #[test]
     fn test_from_str_unknown_method_with_valid_format() {
         let result: Result<SignalingMethod, _> = "/ftp/example.com/21".parse();
-        assert!(result.is_err());
-        match result.unwrap_err() {
-            SignalingMethodParseError::UnknownSignalingMethod(method) => {
-                assert_eq!(method, "ftp");
-            }
-            _ => panic!("Expected UnknownSignalingMethod error"),
-        }
+        assert_eq!(
+            result,
+            Err(SignalingMethodParseError::UnknownSignalingMethod(
+                "ftp".to_string()
+            ))
+        );
     }
 
     #[test]
     fn test_from_str_http_missing_host() {
         let result: Result<SignalingMethod, _> = "/http".parse();
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            SignalingMethodParseError::NotEnoughArgs
-        ));
+        assert_eq!(result, Err(SignalingMethodParseError::NotEnoughArgs));
     }
 
     #[test]
     fn test_from_str_http_missing_port() {
         let result: Result<SignalingMethod, _> = "/http/example.com".parse();
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            SignalingMethodParseError::NotEnoughArgs
-        ));
+        assert_eq!(result, Err(SignalingMethodParseError::NotEnoughArgs));
     }
 
     #[test]
     fn test_from_str_http_invalid_port() {
         let result: Result<SignalingMethod, _> = "/http/example.com/abc".parse();
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            SignalingMethodParseError::PortParseError(_)
-        ));
+        assert!(
+            matches!(result, Err(SignalingMethodParseError::PortParseError(_))),
+            "expected PortParseError, got {result:?}"
+        );
     }
 
     #[test]
     fn test_from_str_http_port_too_large() {
         let result: Result<SignalingMethod, _> = "/http/example.com/99999".parse();
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            SignalingMethodParseError::PortParseError(_)
-        ));
+        assert!(
+            matches!(result, Err(SignalingMethodParseError::PortParseError(_))),
+            "expected PortParseError, got {result:?}"
+        );
     }
 
     #[test]
     fn test_from_str_https_proxy_missing_cluster_id() {
         let result: Result<SignalingMethod, _> = "/https_proxy".parse();
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            SignalingMethodParseError::NotEnoughArgs
-        ));
+        assert_eq!(result, Err(SignalingMethodParseError::NotEnoughArgs));
     }
 
     #[test]
     fn test_from_str_https_proxy_missing_host() {
         let result: Result<SignalingMethod, _> = "/https_proxy/123".parse();
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            SignalingMethodParseError::NotEnoughArgs
-        ));
+        assert_eq!(result, Err(SignalingMethodParseError::NotEnoughArgs));
     }
 
     #[test]
     fn test_from_str_https_proxy_invalid_cluster_id() {
         let result: Result<SignalingMethod, _> = "/https_proxy/abc/proxy.example.com/443".parse();
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            SignalingMethodParseError::InvalidClusterId
-        ));
+        assert_eq!(result, Err(SignalingMethodParseError::InvalidClusterId));
     }
 
     #[test]
     fn test_from_str_https_proxy_cluster_id_too_large() {
         let result: Result<SignalingMethod, _> = "/https_proxy/99999/proxy.example.com/443".parse();
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            SignalingMethodParseError::InvalidClusterId
-        ));
+        assert_eq!(result, Err(SignalingMethodParseError::InvalidClusterId));
     }
 
     #[test]
     fn test_from_str_https_proxy_negative_cluster_id() {
         let result: Result<SignalingMethod, _> = "/https_proxy/-1/proxy.example.com/443".parse();
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            SignalingMethodParseError::InvalidClusterId
-        ));
+        assert_eq!(result, Err(SignalingMethodParseError::InvalidClusterId));
     }
 
     #[test]
@@ -749,25 +712,29 @@ mod tests {
         // This will depend on Host's parsing behavior - assuming it rejects
         // certain formats
         let result: Result<SignalingMethod, _> = "/http//8080".parse();
-        assert!(result.is_err());
         // Should be either NotEnoughArgs or HostParseError depending on
         // implementation
-        assert!(matches!(
-            result.unwrap_err(),
-            SignalingMethodParseError::NotEnoughArgs | SignalingMethodParseError::HostParseError(_)
-        ));
+        assert!(
+            matches!(
+                result,
+                Err(SignalingMethodParseError::NotEnoughArgs)
+                    | Err(SignalingMethodParseError::HostParseError(_))
+            ),
+            "expected NotEnoughArgs or HostParseError, got {result:?}"
+        );
     }
 
     #[test]
     fn test_from_str_extra_slashes() {
         let result: Result<SignalingMethod, _> = "//http//example.com//8080//".parse();
-        assert!(result.is_err());
-        // The extra slashes mean method parsing fails - "http" becomes unknown
-        // method
-        assert!(matches!(
-            result.unwrap_err(),
-            SignalingMethodParseError::UnknownSignalingMethod(_)
-        ));
+        // The double leading slashes mean s[1..] gives "/http//...", split
+        // produces empty first component
+        assert_eq!(
+            result,
+            Err(SignalingMethodParseError::UnknownSignalingMethod(
+                "".to_string()
+            ))
+        );
     }
 
     #[test]
@@ -815,29 +782,27 @@ mod tests {
     #[test]
     fn test_case_sensitivity() {
         let result: Result<SignalingMethod, _> = "/HTTP/example.com/8080".parse();
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            SignalingMethodParseError::UnknownSignalingMethod(_)
-        ));
+        assert_eq!(
+            result,
+            Err(SignalingMethodParseError::UnknownSignalingMethod(
+                "HTTP".to_string()
+            ))
+        );
 
         let result: Result<SignalingMethod, _> = "/Http/example.com/8080".parse();
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            SignalingMethodParseError::UnknownSignalingMethod(_)
-        ));
+        assert_eq!(
+            result,
+            Err(SignalingMethodParseError::UnknownSignalingMethod(
+                "Http".to_string()
+            ))
+        );
     }
 
     #[test]
     fn test_whitespace_handling() {
         // The parser should filter empty components from split
         let result: Result<SignalingMethod, _> = "/http/ /8080".parse();
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            SignalingMethodParseError::NotEnoughArgs
-        ));
+        assert_eq!(result, Err(SignalingMethodParseError::NotEnoughArgs));
     }
 
     #[test]
@@ -849,7 +814,7 @@ mod tests {
                 assert_eq!(info.host, Host::Domain("proxy.example.com".to_string()));
                 assert_eq!(info.port, 443);
             }
-            _ => panic!("Expected HttpsProxy variant"),
+            x => panic!("Expected HttpsProxy variant, got {x:?}"),
         }
     }
 
@@ -860,7 +825,7 @@ mod tests {
             SignalingMethod::Http(info) => {
                 assert_eq!(info.port, 80);
             }
-            _ => panic!("Expected Http variant"),
+            x => panic!("Expected Http variant, got {x:?}"),
         }
 
         let method: SignalingMethod = "/https/localhost/443".parse().unwrap();
@@ -868,7 +833,7 @@ mod tests {
             SignalingMethod::Https(info) => {
                 assert_eq!(info.port, 443);
             }
-            _ => panic!("Expected Https variant"),
+            x => panic!("Expected Https variant, got {x:?}"),
         }
     }
 
@@ -881,7 +846,7 @@ mod tests {
                 assert_eq!(info.host, Host::Ipv4(Ipv4Addr::new(192, 168, 1, 1)));
                 assert_eq!(info.port, 8443);
             }
-            _ => panic!("Expected HttpsProxy variant"),
+            x => panic!("Expected HttpsProxy variant, got {x:?}"),
         }
     }
 
@@ -899,7 +864,7 @@ mod tests {
                 assert_eq!(info.host, Host::Domain("proxy.example.com".to_string()));
                 assert_eq!(info.port, 443);
             }
-            _ => panic!("Expected Proxied variant"),
+            x => panic!("Expected Proxied variant, got {x:?}"),
         }
     }
 
@@ -916,7 +881,7 @@ mod tests {
                 assert_eq!(info.host, Host::Domain("gateway.example.com".to_string()));
                 assert_eq!(info.port, 8443);
             }
-            _ => panic!("Expected Proxied variant"),
+            x => panic!("Expected Proxied variant, got {x:?}"),
         }
     }
 
@@ -932,9 +897,10 @@ mod tests {
         );
 
         let serialized = original.to_string();
-        // Verify the serialized format contains scheme and URL-encoded path
-        assert!(serialized.contains("/proxied/https/"));
-        assert!(serialized.contains("%2F")); // URL-encoded slashes
+        assert_eq!(
+            serialized,
+            "/proxied/https/%2Fclusters%2F789/proxy.example.com/443"
+        );
 
         let deserialized: SignalingMethod = serialized.parse().unwrap();
         assert_eq!(original, deserialized);
@@ -1012,21 +978,13 @@ mod tests {
     #[test]
     fn test_proxied_missing_prefix() {
         let result: Result<SignalingMethod, _> = "/proxied".parse();
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            SignalingMethodParseError::NotEnoughArgs
-        ));
+        assert_eq!(result, Err(SignalingMethodParseError::NotEnoughArgs));
     }
 
     #[test]
     fn test_proxied_missing_host() {
         let result: Result<SignalingMethod, _> = "/proxied/https/%2Fprefix".parse();
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            SignalingMethodParseError::NotEnoughArgs
-        ));
+        assert_eq!(result, Err(SignalingMethodParseError::NotEnoughArgs));
     }
 
     // HttpsProxy vs Proxied equivalency tests
@@ -1176,7 +1134,7 @@ mod tests {
                 assert_eq!(info.host, Host::Domain("example.com".to_string()));
                 assert_eq!(info.port, 443);
             }
-            _ => panic!("Expected Proxied variant"),
+            x => panic!("Expected Proxied variant, got {x:?}"),
         }
 
         // Roundtrip
@@ -1259,19 +1217,18 @@ mod tests {
                 assert_eq!(info.host, Host::Domain("localhost".to_string()));
                 assert_eq!(info.port, 3000);
             }
-            _ => panic!("Expected Proxied variant with Http scheme"),
+            x => panic!("Expected Proxied variant with Http scheme, got {x:?}"),
         }
     }
 
     #[test]
     fn test_proxied_invalid_scheme() {
         let result: Result<SignalingMethod, _> = "/proxied/ftp/%2Fpath/example.com/21".parse();
-        assert!(result.is_err());
-        match result.unwrap_err() {
-            SignalingMethodParseError::UnknownSignalingMethod(method) => {
-                assert_eq!(method, "proxied/ftp");
-            }
-            _ => panic!("Expected UnknownSignalingMethod error"),
-        }
+        assert_eq!(
+            result,
+            Err(SignalingMethodParseError::UnknownSignalingMethod(
+                "proxied/ftp".to_string()
+            ))
+        );
     }
 }

--- a/crates/p2p/src/webrtc/signaling_method/mod.rs
+++ b/crates/p2p/src/webrtc/signaling_method/mod.rs
@@ -34,7 +34,8 @@
 //!
 //! - HTTP: `/http/{host}/{port}`
 //! - HTTPS: `/https/{host}/{port}`
-//! - HTTPS Proxy: `/https_proxy/{cluster_id}/{host}/{port}`
+//! - HTTPS Proxy (legacy): `/https_proxy/{cluster_id}/{host}/{port}`
+//! - Proxied: `/proxied/{http|https}/{encoded_prefix}/{host}/{port}`
 //! - P2P Relay: `/p2p/{peer_id}`
 //!
 //! ## Connection Strategy
@@ -48,13 +49,69 @@
 mod http;
 pub use http::HttpSignalingInfo;
 
-use std::{fmt, str::FromStr};
+use std::{borrow::Cow, fmt, str::FromStr};
 
+use binprot::{BinProtRead, BinProtWrite};
 use binprot_derive::{BinProtRead, BinProtWrite};
+use percent_encoding::{percent_decode_str, utf8_percent_encode, NON_ALPHANUMERIC};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::PeerId;
+
+/// URL path prefix for proxy signaling.
+///
+/// This newtype wraps a String path prefix (e.g., "/clusters/123") and provides
+/// BinProt serialization by encoding as a length-prefixed byte array.
+///
+/// Used by `Proxied` variant for flexible path-based proxy configurations.
+/// The legacy `HttpsProxy(u16, HttpSignalingInfo)` is preserved for BinProt
+/// backward compatibility.
+#[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Clone, derive_more::Display)]
+#[display(fmt = "{_0}")]
+pub struct PathPrefix(pub String);
+
+/// Proxy connection scheme (HTTP or HTTPS).
+///
+/// Determines whether the proxy connection uses plain HTTP or secure HTTPS.
+/// HTTPS is recommended for production environments.
+#[derive(
+    BinProtWrite,
+    BinProtRead,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Debug,
+    Clone,
+    Copy,
+    derive_more::Display,
+)]
+pub enum ProxyScheme {
+    /// Plain HTTP proxy connection.
+    #[display(fmt = "http")]
+    Http,
+    /// Secure HTTPS proxy connection.
+    #[display(fmt = "https")]
+    Https,
+}
+
+impl BinProtRead for PathPrefix {
+    fn binprot_read<R: std::io::Read + ?Sized>(r: &mut R) -> Result<Self, binprot::Error>
+    where
+        Self: Sized,
+    {
+        let bytes: Vec<u8> = BinProtRead::binprot_read(r)?;
+        let s = String::from_utf8(bytes).map_err(|e| binprot::Error::CustomError(Box::new(e)))?;
+        Ok(PathPrefix(s))
+    }
+}
+
+impl BinProtWrite for PathPrefix {
+    fn binprot_write<W: std::io::Write>(&self, w: &mut W) -> std::io::Result<()> {
+        self.0.as_bytes().to_vec().binprot_write(w)
+    }
+}
 
 /// WebRTC signaling transport method configuration.
 ///
@@ -100,11 +157,13 @@ pub enum SignalingMethod {
     /// production environments to protect signaling data in transit.
     Https(HttpSignalingInfo),
 
-    /// HTTPS proxy signaling connection.
+    /// HTTPS proxy signaling connection (legacy format).
     ///
     /// Uses an SSL gateway/proxy server to reach the actual signaling server.
     /// The first parameter is the cluster ID for routing, and the second
     /// parameter contains the proxy server connection information.
+    ///
+    /// Kept for BinProt backward compatibility. Prefer `Proxied` for new code.
     HttpsProxy(u16, HttpSignalingInfo),
 
     /// P2P relay signaling through an existing peer connection.
@@ -116,27 +175,35 @@ pub enum SignalingMethod {
         /// The peer ID of the relay peer that will forward signaling messages.
         relay_peer_id: PeerId,
     },
+
+    /// Proxy signaling connection (extended format).
+    ///
+    /// Uses a gateway/proxy server to reach the actual signaling server.
+    /// Supports both HTTP and HTTPS proxy connections via the `ProxyScheme` field.
+    ///
+    /// Fields:
+    /// - `ProxyScheme`: Whether to use HTTP or HTTPS for the proxy connection
+    /// - `PathPrefix`: The URL path prefix (e.g., "/clusters/123")
+    /// - `HttpSignalingInfo`: The proxy server connection information
+    Proxied(ProxyScheme, PathPrefix, HttpSignalingInfo),
 }
 
 impl SignalingMethod {
     /// Determines if this signaling method supports direct connections.
     ///
-    /// Direct connection methods (HTTP, HTTPS, HTTPS Proxy) can establish
+    /// Direct connection methods (HTTP, HTTPS, HTTPS Proxy, Proxied) can establish
     /// signaling channels immediately without requiring existing peer connections.
     /// P2P relay methods require an already-established peer connection to function.
     ///
     /// # Returns
     ///
-    /// * `true` for HTTP, HTTPS, and HTTPS Proxy methods
+    /// * `true` for HTTP, HTTPS, HTTPS Proxy, and Proxied methods
     /// * `false` for P2P relay methods
     ///
     /// This is useful for connection strategy decisions and determining whether
     /// bootstrap connections are needed before signaling can occur.
     pub fn can_connect_directly(&self) -> bool {
-        match self {
-            Self::Http(_) | Self::Https(_) | Self::HttpsProxy(_, _) => true,
-            Self::P2p { .. } => false,
-        }
+        !matches!(self, Self::P2p { .. })
     }
 
     /// Constructs the HTTP(S) URL for sending WebRTC offers.
@@ -149,6 +216,7 @@ impl SignalingMethod {
     /// - **HTTP**: `http://{host}:{port}/mina/webrtc/signal`
     /// - **HTTPS**: `https://{host}:{port}/mina/webrtc/signal`
     /// - **HTTPS Proxy**: `https://{host}:{port}/clusters/{cluster_id}/mina/webrtc/signal`
+    /// - **Proxied**: `{http|https}://{host}:{port}{prefix}/mina/webrtc/signal`
     ///
     /// # Returns
     ///
@@ -162,21 +230,38 @@ impl SignalingMethod {
     /// let url = method.http_url(); // Some("https://signal.example.com:443/mina/webrtc/signal")
     /// ```
     pub fn http_url(&self) -> Option<String> {
-        let (http, info) = match self {
-            Self::Http(info) => ("http", info),
-            Self::Https(info) => ("https", info),
-            Self::HttpsProxy(cluster_id, info) => {
+        let slash = Cow::Borrowed("/");
+        let (http, prefix, HttpSignalingInfo { host, port }) = match self {
+            Self::Http(info) => ("http", slash, info),
+            Self::Https(info) => ("https", slash, info),
+            Self::HttpsProxy(cluster_id, info) => (
+                "https",
+                Cow::Owned(format!("/clusters/{cluster_id}/")),
+                info,
+            ),
+            Self::Proxied(scheme, PathPrefix(prefix), info) => {
+                // Handle empty prefix or just "/" as equivalent to no prefix
+                let prefix_cow = if prefix.is_empty() || prefix == "/" {
+                    slash
+                } else {
+                    let needs_start_slash = !prefix.starts_with('/');
+                    let needs_end_slash = !prefix.ends_with('/');
+                    Cow::Owned(format!(
+                        "{}{}{}",
+                        if needs_start_slash { "/" } else { "" },
+                        prefix,
+                        if needs_end_slash { "/" } else { "" }
+                    ))
+                };
                 return Some(format!(
-                    "https://{}:{}/clusters/{}/mina/webrtc/signal",
-                    info.host, info.port, cluster_id
+                    "{scheme}://{host}:{port}{prefix_cow}mina/webrtc/signal",
+                    host = info.host,
+                    port = info.port
                 ));
             }
             _ => return None,
         };
-        Some(format!(
-            "{http}://{}:{}/mina/webrtc/signal",
-            info.host, info.port,
-        ))
+        Some(format!("{http}://{host}:{port}{prefix}mina/webrtc/signal",))
     }
 
     /// Extracts the relay peer ID for P2P signaling methods.
@@ -228,6 +313,11 @@ impl fmt::Display for SignalingMethod {
             }
             Self::HttpsProxy(cluster_id, signaling) => {
                 write!(f, "/https_proxy/{cluster_id}")?;
+                signaling.fmt(f)
+            }
+            Self::Proxied(scheme, PathPrefix(path_prefix), signaling) => {
+                let encoded = utf8_percent_encode(path_prefix, NON_ALPHANUMERIC);
+                write!(f, "/proxied/{scheme}/{encoded}")?;
                 signaling.fmt(f)
             }
             Self::P2p { relay_peer_id } => {
@@ -351,6 +441,38 @@ impl FromStr for SignalingMethod {
                     .parse()
                     .or(Err(SignalingMethodParseError::InvalidClusterId))?;
                 Ok(Self::HttpsProxy(cluster_id, rest.parse()?))
+            }
+            "proxied" => {
+                // Format: /proxied/{scheme}/{encoded_prefix}/{host}/{port}
+                let mut iter = rest.splitn(4, '/').filter(|v| !v.trim().is_empty());
+                let scheme_str = iter
+                    .next()
+                    .ok_or(SignalingMethodParseError::NotEnoughArgs)?;
+                let scheme = match scheme_str {
+                    "http" => ProxyScheme::Http,
+                    "https" => ProxyScheme::Https,
+                    _ => {
+                        return Err(SignalingMethodParseError::UnknownSignalingMethod(format!(
+                            "proxied/{}",
+                            scheme_str
+                        )))
+                    }
+                };
+                let encoded_prefix = iter
+                    .next()
+                    .ok_or(SignalingMethodParseError::NotEnoughArgs)?;
+                let rest = iter
+                    .next()
+                    .ok_or(SignalingMethodParseError::NotEnoughArgs)?;
+                let path_prefix = percent_decode_str(encoded_prefix)
+                    .decode_utf8()
+                    .map_err(|e| SignalingMethodParseError::HostParseError(e.to_string()))?
+                    .into_owned();
+                Ok(Self::Proxied(
+                    scheme,
+                    PathPrefix(path_prefix),
+                    rest.parse()?,
+                ))
             }
             method => Err(SignalingMethodParseError::UnknownSignalingMethod(
                 method.to_owned(),
@@ -760,6 +882,396 @@ mod tests {
                 assert_eq!(info.port, 8443);
             }
             _ => panic!("Expected HttpsProxy variant"),
+        }
+    }
+
+    // Proxied tests
+
+    #[test]
+    fn test_from_str_valid_proxied() {
+        // URL-encoded path prefix: /clusters/123 -> %2Fclusters%2F123
+        let method: SignalingMethod = "/proxied/https/%2Fclusters%2F123/proxy.example.com/443"
+            .parse()
+            .unwrap();
+        match method {
+            SignalingMethod::Proxied(ProxyScheme::Https, PathPrefix(prefix), info) => {
+                assert_eq!(prefix, "/clusters/123");
+                assert_eq!(info.host, Host::Domain("proxy.example.com".to_string()));
+                assert_eq!(info.port, 443);
+            }
+            _ => panic!("Expected Proxied variant"),
+        }
+    }
+
+    #[test]
+    fn test_from_str_proxied_complex_path() {
+        // URL-encoded path: /api/v2/webrtc -> %2Fapi%2Fv2%2Fwebrtc
+        let method: SignalingMethod =
+            "/proxied/https/%2Fapi%2Fv2%2Fwebrtc/gateway.example.com/8443"
+                .parse()
+                .unwrap();
+        match method {
+            SignalingMethod::Proxied(ProxyScheme::Https, PathPrefix(prefix), info) => {
+                assert_eq!(prefix, "/api/v2/webrtc");
+                assert_eq!(info.host, Host::Domain("gateway.example.com".to_string()));
+                assert_eq!(info.port, 8443);
+            }
+            _ => panic!("Expected Proxied variant"),
+        }
+    }
+
+    #[test]
+    fn test_roundtrip_proxied() {
+        let original = SignalingMethod::Proxied(
+            ProxyScheme::Https,
+            PathPrefix("/clusters/789".to_string()),
+            HttpSignalingInfo {
+                host: Host::Domain("proxy.example.com".to_string()),
+                port: 443,
+            },
+        );
+
+        let serialized = original.to_string();
+        // Verify the serialized format contains scheme and URL-encoded path
+        assert!(serialized.contains("/proxied/https/"));
+        assert!(serialized.contains("%2F")); // URL-encoded slashes
+
+        let deserialized: SignalingMethod = serialized.parse().unwrap();
+        assert_eq!(original, deserialized);
+    }
+
+    #[test]
+    fn test_proxied_https_url() {
+        let method = SignalingMethod::Proxied(
+            ProxyScheme::Https,
+            PathPrefix("/custom/path".to_string()),
+            HttpSignalingInfo {
+                host: Host::Domain("gateway.example.com".to_string()),
+                port: 443,
+            },
+        );
+
+        let url = method.http_url().unwrap();
+        assert_eq!(
+            url,
+            "https://gateway.example.com:443/custom/path/mina/webrtc/signal"
+        );
+    }
+
+    #[test]
+    fn test_proxied_https_url_no_leading_slash() {
+        let method = SignalingMethod::Proxied(
+            ProxyScheme::Https,
+            PathPrefix("custom/path".to_string()),
+            HttpSignalingInfo {
+                host: Host::Domain("gateway.example.com".to_string()),
+                port: 443,
+            },
+        );
+
+        let url = method.http_url().unwrap();
+        // Should add leading slash
+        assert_eq!(
+            url,
+            "https://gateway.example.com:443/custom/path/mina/webrtc/signal"
+        );
+    }
+
+    #[test]
+    fn test_proxied_https_url_trailing_slash() {
+        let method = SignalingMethod::Proxied(
+            ProxyScheme::Https,
+            PathPrefix("/custom/path/".to_string()),
+            HttpSignalingInfo {
+                host: Host::Domain("gateway.example.com".to_string()),
+                port: 443,
+            },
+        );
+
+        let url = method.http_url().unwrap();
+        // Should not double the trailing slash
+        assert_eq!(
+            url,
+            "https://gateway.example.com:443/custom/path/mina/webrtc/signal"
+        );
+    }
+
+    #[test]
+    fn test_proxied_with_ipv4() {
+        let method: SignalingMethod = "/proxied/https/%2Ftest/192.168.1.1/8443".parse().unwrap();
+        match method {
+            SignalingMethod::Proxied(ProxyScheme::Https, PathPrefix(prefix), info) => {
+                assert_eq!(prefix, "/test");
+                assert_eq!(info.host, Host::Ipv4(Ipv4Addr::new(192, 168, 1, 1)));
+                assert_eq!(info.port, 8443);
+            }
+            _ => panic!("Expected Proxied variant"),
+        }
+    }
+
+    #[test]
+    fn test_proxied_missing_prefix() {
+        let result: Result<SignalingMethod, _> = "/proxied".parse();
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            SignalingMethodParseError::NotEnoughArgs
+        ));
+    }
+
+    #[test]
+    fn test_proxied_missing_host() {
+        let result: Result<SignalingMethod, _> = "/proxied/https/%2Fprefix".parse();
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            SignalingMethodParseError::NotEnoughArgs
+        ));
+    }
+
+    // HttpsProxy vs Proxied equivalency tests
+
+    #[test]
+    fn test_https_proxy_and_proxied_equivalent_url() {
+        let info = HttpSignalingInfo {
+            host: Host::Domain("gateway.example.com".to_string()),
+            port: 443,
+        };
+
+        let legacy = SignalingMethod::HttpsProxy(123, info.clone());
+        let proxied = SignalingMethod::Proxied(
+            ProxyScheme::Https,
+            PathPrefix("/clusters/123".to_string()),
+            info,
+        );
+
+        assert_eq!(legacy.http_url(), proxied.http_url());
+        assert_eq!(
+            legacy.http_url().unwrap(),
+            "https://gateway.example.com:443/clusters/123/mina/webrtc/signal"
+        );
+    }
+
+    #[test]
+    fn test_proxied_empty_prefix() {
+        let method = SignalingMethod::Proxied(
+            ProxyScheme::Https,
+            PathPrefix("".to_string()),
+            HttpSignalingInfo {
+                host: Host::Domain("gateway.example.com".to_string()),
+                port: 443,
+            },
+        );
+
+        let url = method.http_url().unwrap();
+        // Empty prefix should still result in valid URL with single slash
+        assert_eq!(url, "https://gateway.example.com:443/mina/webrtc/signal");
+    }
+
+    #[test]
+    fn test_proxied_just_slash() {
+        let method = SignalingMethod::Proxied(
+            ProxyScheme::Https,
+            PathPrefix("/".to_string()),
+            HttpSignalingInfo {
+                host: Host::Domain("gateway.example.com".to_string()),
+                port: 443,
+            },
+        );
+
+        let url = method.http_url().unwrap();
+        // Just "/" should work correctly
+        assert_eq!(url, "https://gateway.example.com:443/mina/webrtc/signal");
+    }
+
+    #[test]
+    fn test_proxied_slash_variations() {
+        let info = HttpSignalingInfo {
+            host: Host::Domain("example.com".to_string()),
+            port: 443,
+        };
+
+        // No slashes
+        let m1 = SignalingMethod::Proxied(
+            ProxyScheme::Https,
+            PathPrefix("path".to_string()),
+            info.clone(),
+        );
+        assert_eq!(
+            m1.http_url().unwrap(),
+            "https://example.com:443/path/mina/webrtc/signal"
+        );
+
+        // Leading slash only
+        let m2 = SignalingMethod::Proxied(
+            ProxyScheme::Https,
+            PathPrefix("/path".to_string()),
+            info.clone(),
+        );
+        assert_eq!(
+            m2.http_url().unwrap(),
+            "https://example.com:443/path/mina/webrtc/signal"
+        );
+
+        // Trailing slash only
+        let m3 = SignalingMethod::Proxied(
+            ProxyScheme::Https,
+            PathPrefix("path/".to_string()),
+            info.clone(),
+        );
+        assert_eq!(
+            m3.http_url().unwrap(),
+            "https://example.com:443/path/mina/webrtc/signal"
+        );
+
+        // Both slashes
+        let m4 = SignalingMethod::Proxied(
+            ProxyScheme::Https,
+            PathPrefix("/path/".to_string()),
+            info.clone(),
+        );
+        assert_eq!(
+            m4.http_url().unwrap(),
+            "https://example.com:443/path/mina/webrtc/signal"
+        );
+    }
+
+    #[test]
+    fn test_proxied_multi_segment_path_slash_variations() {
+        let info = HttpSignalingInfo {
+            host: Host::Domain("example.com".to_string()),
+            port: 443,
+        };
+
+        // No outer slashes
+        let m1 = SignalingMethod::Proxied(
+            ProxyScheme::Https,
+            PathPrefix("api/v2/clusters/123".to_string()),
+            info.clone(),
+        );
+        assert_eq!(
+            m1.http_url().unwrap(),
+            "https://example.com:443/api/v2/clusters/123/mina/webrtc/signal"
+        );
+
+        // Both outer slashes
+        let m2 = SignalingMethod::Proxied(
+            ProxyScheme::Https,
+            PathPrefix("/api/v2/clusters/123/".to_string()),
+            info.clone(),
+        );
+        assert_eq!(
+            m2.http_url().unwrap(),
+            "https://example.com:443/api/v2/clusters/123/mina/webrtc/signal"
+        );
+    }
+
+    #[test]
+    fn test_proxied_roundtrip_just_slash() {
+        // %2F is URL-encoded "/"
+        let method: SignalingMethod = "/proxied/https/%2F/example.com/443".parse().unwrap();
+        match &method {
+            SignalingMethod::Proxied(ProxyScheme::Https, PathPrefix(prefix), info) => {
+                assert_eq!(prefix, "/");
+                assert_eq!(info.host, Host::Domain("example.com".to_string()));
+                assert_eq!(info.port, 443);
+            }
+            _ => panic!("Expected Proxied variant"),
+        }
+
+        // Roundtrip
+        let serialized = method.to_string();
+        let deserialized: SignalingMethod = serialized.parse().unwrap();
+        assert_eq!(method, deserialized);
+    }
+
+    #[test]
+    fn test_proxied_roundtrip_empty_prefix() {
+        // Empty string prefix can't roundtrip because the parser filters empty components.
+        // This is acceptable - empty prefix is treated as "no prefix" and produces
+        // the same URL as Https variant. Test verifies the expected parse error.
+        let original = SignalingMethod::Proxied(
+            ProxyScheme::Https,
+            PathPrefix("".to_string()),
+            HttpSignalingInfo {
+                host: Host::Domain("example.com".to_string()),
+                port: 443,
+            },
+        );
+
+        let serialized = original.to_string();
+        // Format is /proxied//example.com/443 - empty prefix component
+        // Parser sees: ["proxied", "example.com", "443"] after filtering empties
+        // This means it tries to parse "example.com" as the prefix, "443" as host
+        let result: Result<SignalingMethod, _> = serialized.parse();
+        assert!(
+            result.is_err(),
+            "Empty prefix can't roundtrip - use just '/' prefix instead"
+        );
+    }
+
+    // HTTP proxy tests (new functionality)
+
+    #[test]
+    fn test_proxied_http_scheme() {
+        let method = SignalingMethod::Proxied(
+            ProxyScheme::Http,
+            PathPrefix("/api/proxy".to_string()),
+            HttpSignalingInfo {
+                host: Host::Domain("gateway.example.com".to_string()),
+                port: 8080,
+            },
+        );
+
+        let url = method.http_url().unwrap();
+        assert_eq!(
+            url,
+            "http://gateway.example.com:8080/api/proxy/mina/webrtc/signal"
+        );
+    }
+
+    #[test]
+    fn test_proxied_http_scheme_roundtrip() {
+        let original = SignalingMethod::Proxied(
+            ProxyScheme::Http,
+            PathPrefix("/dev/proxy".to_string()),
+            HttpSignalingInfo {
+                host: Host::Domain("localhost".to_string()),
+                port: 3000,
+            },
+        );
+
+        let serialized = original.to_string();
+        assert!(serialized.contains("/proxied/http/"));
+
+        let deserialized: SignalingMethod = serialized.parse().unwrap();
+        assert_eq!(original, deserialized);
+    }
+
+    #[test]
+    fn test_from_str_proxied_http() {
+        let method: SignalingMethod = "/proxied/http/%2Fdev%2Fproxy/localhost/3000"
+            .parse()
+            .unwrap();
+        match method {
+            SignalingMethod::Proxied(ProxyScheme::Http, PathPrefix(prefix), info) => {
+                assert_eq!(prefix, "/dev/proxy");
+                assert_eq!(info.host, Host::Domain("localhost".to_string()));
+                assert_eq!(info.port, 3000);
+            }
+            _ => panic!("Expected Proxied variant with Http scheme"),
+        }
+    }
+
+    #[test]
+    fn test_proxied_invalid_scheme() {
+        let result: Result<SignalingMethod, _> = "/proxied/ftp/%2Fpath/example.com/21".parse();
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            SignalingMethodParseError::UnknownSignalingMethod(method) => {
+                assert_eq!(method, "proxied/ftp");
+            }
+            _ => panic!("Expected UnknownSignalingMethod error"),
         }
     }
 }

--- a/crates/p2p/testing/src/lib.rs
+++ b/crates/p2p/testing/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::result_large_err, reason = "non-prod code")]
+
 pub mod event;
 pub mod libp2p_node;
 mod log;

--- a/website/docs/developers/webrtc.md
+++ b/website/docs/developers/webrtc.md
@@ -181,23 +181,72 @@ The Web Node represents a significant advancement in blockchain accessibility,
 enabling truly decentralized participation without requiring users to install
 native applications or manage complex network configurations.
 
-## Address Format Differences
+## Address Formats
 
-The Mina Rust Node uses a custom Multiaddr-like format for WebRTC peer addresses
-that differs from normal Multiaddrs. These addresses are specifically designed
-to encode signaling server information rather than direct network addresses,
-reflecting the different connection model of WebRTC versus direct TCP/UDP
+WebRTC peer addresses use standard
+[multiaddr](https://multiformats.io/multiaddr/) format with the `/webrtc`
+protocol to distinguish them from libp2p addresses. The `/webrtc` protocol
+indicates the address requires WebRTC signaling rather than direct TCP/UDP
 connections.
 
 The address parsing logic is implemented in
-[`p2p/src/connection/outgoing/mod.rs`](https://github.com/o1-labs/mina-rust/blob/develop/p2p/src/connection/outgoing/mod.rs)
-through the `FromStr` implementation for `P2pConnectionOutgoingInitOpts`. The
-parser distinguishes between libp2p addresses (starting with `/ip` or `/dns`)
-and WebRTC addresses (all other formats).
+[`p2p/src/connection/outgoing/mod.rs`](https://github.com/o1-labs/mina-rust/blob/develop/crates/p2p/src/connection/outgoing/mod.rs)
+through the `TryFrom<&Multiaddr>` implementation for
+`P2pConnectionOutgoingInitOpts`.
 
-### WebRTC peer address format
+### Standard multiaddr format (recommended)
 
-WebRTC peer addresses follow this structure:
+WebRTC addresses follow standard multiaddr conventions with the `/webrtc`
+protocol indicating WebRTC signaling:
+
+**HTTP signaling:**
+
+```
+/<dns|dns4|dns6|ip4|ip6>/{host}/tcp/{port}/webrtc/http/p2p/{peer_id}
+```
+
+Example:
+`/dns4/signal.example.com/tcp/8080/webrtc/http/p2p/12D3KooWRTzN7HfmjoUBHokyRZuKdyohVVSGqKBMF24ZC3tGK74R`
+
+**HTTPS signaling:**
+
+```
+/<dns|dns4|dns6|ip4|ip6>/{host}/tcp/{port}/webrtc/https/p2p/{peer_id}
+```
+
+Example:
+`/dns4/signal.example.com/tcp/443/webrtc/https/p2p/12D3KooWRTzN7HfmjoUBHokyRZuKdyohVVSGqKBMF24ZC3tGK74R`
+
+**Proxy signaling with path prefix:**
+
+```
+/<dns|dns4|dns6|ip4|ip6>/{host}/tcp/{port}/webrtc/<http|https>/http-path/{url_encoded_path}/p2p/{peer_id}
+```
+
+Example:
+`/dns4/proxy.example.com/tcp/443/webrtc/https/http-path/clusters%2F123/p2p/12D3KooWRTzN7HfmjoUBHokyRZuKdyohVVSGqKBMF24ZC3tGK74R`
+
+**P2P relay signaling:**
+
+```
+/p2p/{relay_peer_id}/webrtc/p2p-circuit/p2p/{target_peer_id}
+```
+
+Example:
+`/p2p/12D3KooWABC.../webrtc/p2p-circuit/p2p/12D3KooWRTzN7HfmjoUBHokyRZuKdyohVVSGqKBMF24ZC3tGK74R`
+
+### Legacy format (deprecated)
+
+<!-- prettier-ignore-start -->
+
+:::caution Deprecated
+The legacy format below is deprecated and will emit warnings when used. Please
+migrate to the standard multiaddr format above.
+:::
+
+<!-- prettier-ignore-end -->
+
+The legacy format uses a custom structure that differs from standard multiaddr:
 
 ```
 /{peer_id}/{signaling_method}
@@ -206,45 +255,17 @@ WebRTC peer addresses follow this structure:
 Where `{peer_id}` is the base58-encoded peer ID and `{signaling_method}`
 specifies how to reach the signaling server.
 
-### Signaling method formats
+**Legacy signaling method formats:**
 
-The signaling method component can take several forms:
+| Method      | Format                                              | Example                                              |
+| ----------- | --------------------------------------------------- | ---------------------------------------------------- |
+| HTTP        | `/{peer_id}/http/{host}/{port}`                     | `/12D3KooW.../http/localhost/8080`                   |
+| HTTPS       | `/{peer_id}/https/{host}/{port}`                    | `/12D3KooW.../https/signal.example.com/443`          |
+| HTTPS Proxy | `/{peer_id}/https_proxy/{cluster_id}/{host}/{port}` | `/12D3KooW.../https_proxy/123/proxy.example.com/443` |
+| P2P Relay   | `/{peer_id}/p2p/{relay_peer_id}`                    | `/12D3KooW.../p2p/12D3KooWABC...`                    |
 
-**HTTP signaling:**
-
-```
-/http/{host}/{port}
-```
-
-Example:
-`/12D3KooWRTzN7HfmjoUBHokyRZuKdyohVVSGqKBMF24ZC3tGK74R/http/localhost/8080`
-
-**HTTPS signaling:**
-
-```
-/https/{host}/{port}
-```
-
-Example:
-`/12D3KooWRTzN7HfmjoUBHokyRZuKdyohVVSGqKBMF24ZC3tGK74R/https/signal.example.com/443`
-
-**HTTPS proxy signaling:**
-
-```
-/https_proxy/{cluster_id}/{host}/{port}
-```
-
-Example:
-`/12D3KooWRTzN7HfmjoUBHokyRZuKdyohVVSGqKBMF24ZC3tGK74R/https_proxy/123/proxy.example.com/443`
-
-**P2P relay signaling:**
-
-```
-/p2p/{relay_peer_id}
-```
-
-Example:
-`/12D3KooWRTzN7HfmjoUBHokyRZuKdyohVVSGqKBMF24ZC3tGK74R/p2p/12D3KooWABC...`
+The parser continues to accept this format for backward compatibility but logs a
+deprecation warning with the suggested multiaddr equivalent
 
 ## Future Considerations
 

--- a/website/docs/node-operators/web-node/local-web-node-docker.mdx
+++ b/website/docs/node-operators/web-node/local-web-node-docker.mdx
@@ -75,8 +75,8 @@ A comma-separated list of http(s) URLs to fetch initial P2P seeds from. This is
 similar to the `--peer-list-url` flag in the native node, but can take multiple
 comma-separated values to fetch peer lists from multiple sources. Each peer list
 file must contain peer addresses in
-[WebRTC-Multiaddrish format](../../developers/webrtc.md#address-format-differences),
-separated by a newline.
+[WebRTC multiaddr format](../../developers/webrtc.md#address-formats), separated
+by a newline.
 
 Example:
 
@@ -88,15 +88,18 @@ Example:
 ### `MINA_WEBNODE_BOOTNODES`
 
 A comma separated list of
-[WebRTC-Multiaddrish](../../developers/webrtc.md#address-format-differences)
-peer addresses, to attempt to connect to in conjunction to any downloaded from
+[WebRTC multiaddr](../../developers/webrtc.md#address-formats) peer addresses,
+to attempt to connect to in conjunction to any downloaded from
 `MINA_WEBNODE_SEED_URLS`. This is akin to the `--peers` flag in the native node,
 but instead of specifying the flag multiple times, each peer is simply
-comma-separated
+comma-separated.
 
 Example:
 
 ```
--e MINA_WEBNODE_BOOTNODES=/peer_id1/https/signaling.example.com/443
--e MINA_WEBNODE_BOOTNODES=/peer_id1/https/signaling.example.com/443,/peer_id2/p2p/peer_id1
+-e MINA_WEBNODE_BOOTNODES=/dns4/signaling.example.com/tcp/443/webrtc/https/p2p/12D3KooW...
+-e MINA_WEBNODE_BOOTNODES=/dns4/signaling.example.com/tcp/443/webrtc/https/p2p/12D3KooW...,/p2p/12D3KooWRelay.../webrtc/p2p-circuit/p2p/12D3KooWTarget...
 ```
+
+The legacy format (`/{peer_id}/https/{host}/{port}`) is still accepted but
+deprecated.


### PR DESCRIPTION
### Description

Unifies the WebRTC signaling address format with standard multiaddr conventions. This introduces a "new" address format using the `/webrtc` protocol as a distinguisher from standard libp2p multiaddrs, while maintaining backward compatibility with the legacy format through deprecation warnings.

**New multiaddr format:**
- HTTP(S): `/<dns|dns4|dns6|ip4|ip6>/{host}/tcp/{port}/webrtc/<http|https>/p2p/{peer_id}`
- Proxied: `/<dns|dns4|dns6|ip4|ip6>/{host}/tcp/{port}/webrtc/<http|https>/http-path/{path}/p2p/{peer_id}`
- P2P Relay: `/p2p/{relay_peer_id}/webrtc/p2p-circuit/p2p/{target_peer_id}`

**Legacy format (deprecated):**
- `/{peer_id}/{http|https|https_proxy|p2p}/{host}/{port}`

### Related Issue(s)

Closes #2036

### Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
- [x] Refactoring (no functional changes)

### Testing

- [x] All existing signaling_method tests pass (68 tests)
- [x] All existing connection::outgoing tests pass (15 tests)
- [x] New multiaddr parsing/conversion tests added and pass
- [x] Legacy format parsing still works with deprecation warning
- [x] Verified doc changes manually
- [x] Verified deprecation warning appears when running webnode
- [x] Verified web node is able to connect to local Rust node with legacy and standard formats

```bash
cargo test -p mina-p2p signaling_method::tests
cargo test -p mina-p2p connection::outgoing::tests
```

### Changelog

**Changes**
- **Web Node**: Standardized WebRTC peer address to Multiaddr and deprecated
  old "WebRTC-Multiaddrish" format [#2052](https://github.com/o1-labs/mina-rust/pull/2052)