### PR TITLE
Fixing warning regarding num-bigint-dig deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix linter for latest beta Rust
   ([#2097](https://github.com/o1-labs/mina-rust/pull/2097))
+- Bumped up `rsa` from `0.9.7` `0.9.10` and `numb-bigint-dig` from `0.8.4` to
+  `0.8.6` ([#2096](https://github.com/o1-labs/mina-rust/pull/2096/))
 
 ## [0.19.0] - 2026-01-08
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5975,11 +5975,10 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
 dependencies = [
- "byteorder",
  "lazy_static",
  "libm",
  "num-integer",
@@ -7467,9 +7466,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.7"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c75d7c5c6b673e58bf54d8544a9f432e3a925b0e80f7cd3602ab5c50c55519"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
  "const-oid",
  "digest 0.10.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,7 +204,7 @@ redux = { path = "libs/redux", features = ["serde"] }
 regex = "1"
 reqwest = { version = "0.12.8", features = ["blocking", "json"] }
 ring_buffer = "2.0.2"
-rsa = "0.9"
+rsa = "0.9.10"
 rsexp = "0.2.3"
 rsexp-derive = "0.2.3"
 rsprocmaps = "0.3.2"

--- a/website/docs/developers/api-and-data/graphql-api.mdx
+++ b/website/docs/developers/api-and-data/graphql-api.mdx
@@ -4,106 +4,63 @@ description: Complete reference for Mina Rust GraphQL API endpoints and queries
 sidebar_position: 6
 ---
 
-import CodeBlock from "@theme/CodeBlock"; import Tabs from "@theme/Tabs"; import
-TabItem from "@theme/TabItem"; import TestBasicConnectivity from
-"!!raw-loader!./scripts/graphql-api/queries/curl/basic-connectivity.sh"; import
-QuerySyncStatus from
-"!!raw-loader!./scripts/graphql-api/queries/curl/sync-status.sh"; import
-QueryNodeInfo from
-"!!raw-loader!./scripts/graphql-api/queries/curl/node-info.sh"; import
-QueryRecentActivity from
-"!!raw-loader!./scripts/graphql-api/queries/curl/recent-activity.sh"; import
-QueryAccountBalance from
-"!!raw-loader!./scripts/graphql-api/queries/curl/account-balance.sh"; import
-QueryBlock from "!!raw-loader!./scripts/graphql-api/queries/curl/block.sh";
-import QueryGenesisBlock from
-"!!raw-loader!./scripts/graphql-api/queries/curl/genesis-block.sh"; import
-QueryGenesisConstants from
-"!!raw-loader!./scripts/graphql-api/queries/curl/genesis-constants.sh"; import
-QueryPooledUserCommands from
-"!!raw-loader!./scripts/graphql-api/queries/curl/pooled-user-commands.sh";
-import QueryPooledZkappCommands from
-"!!raw-loader!./scripts/graphql-api/queries/curl/pooled-zkapp-commands.sh";
-import QueryTransactionStatus from
-"!!raw-loader!./scripts/graphql-api/queries/examples/transaction-status.sh";
-import QuerySnarkPool from
-"!!raw-loader!./scripts/graphql-api/queries/curl/snark-pool.sh"; import
-QueryPendingSnarkWork from
-"!!raw-loader!./scripts/graphql-api/queries/curl/pending-snark-work.sh"; import
-QueryCurrentSnarkWorker from
-"!!raw-loader!./scripts/graphql-api/queries/curl/current-snark-worker.sh";
-import QueryDaemonStatus from
-"!!raw-loader!./scripts/graphql-api/queries/curl/daemon-status.sh"; import
-QueryNetworkID from
-"!!raw-loader!./scripts/graphql-api/queries/curl/network-id.sh"; import
-QueryVersion from "!!raw-loader!./scripts/graphql-api/queries/curl/version.sh";
-import QueryBestChain from
-"!!raw-loader!./scripts/graphql-api/queries/curl/best-chain.sh"; import
-QueryAccount from "!!raw-loader!./scripts/graphql-api/queries/curl/account.sh";
-import BasicConnectivityQuery from
-"!!raw-loader!./scripts/graphql-api/queries/query/basic-connectivity.graphql";
-import SyncStatusQuery from
-"!!raw-loader!./scripts/graphql-api/queries/query/sync-status.graphql"; import
-NodeInfoQuery from
-"!!raw-loader!./scripts/graphql-api/queries/query/node-info.graphql"; import
-RecentActivityQuery from
-"!!raw-loader!./scripts/graphql-api/queries/query/recent-activity.graphql";
-import AccountBalanceQuery from
-"!!raw-loader!./scripts/graphql-api/queries/query/account-balance.graphql";
-import DaemonStatusQuery from
-"!!raw-loader!./scripts/graphql-api/queries/query/daemon-status.graphql"; import
-NetworkIDQuery from
-"!!raw-loader!./scripts/graphql-api/queries/query/network-id.graphql"; import
-VersionQuery from
-"!!raw-loader!./scripts/graphql-api/queries/query/version.graphql"; import
-BestChainQuery from
-"!!raw-loader!./scripts/graphql-api/queries/query/best-chain.graphql"; import
-BlockQuery from
-"!!raw-loader!./scripts/graphql-api/queries/query/block.graphql"; import
-GenesisBlockQuery from
-"!!raw-loader!./scripts/graphql-api/queries/query/genesis-block.graphql"; import
-GenesisConstantsQuery from
-"!!raw-loader!./scripts/graphql-api/queries/query/genesis-constants.graphql";
-import AccountQuery from
-"!!raw-loader!./scripts/graphql-api/queries/query/account.graphql"; import
-PooledUserCommandsQuery from
-"!!raw-loader!./scripts/graphql-api/queries/query/pooled-user-commands.graphql";
-import PooledZkappCommandsQuery from
-"!!raw-loader!./scripts/graphql-api/queries/query/pooled-zkapp-commands.graphql";
-import TransactionStatusQuery from
-"!!raw-loader!./scripts/graphql-api/queries/examples/transaction-status.graphql";
-import SnarkPoolQuery from
-"!!raw-loader!./scripts/graphql-api/queries/query/snark-pool.graphql"; import
-PendingSnarkWorkQuery from
-"!!raw-loader!./scripts/graphql-api/queries/query/pending-snark-work.graphql";
-import CurrentSnarkWorkerQuery from
-"!!raw-loader!./scripts/graphql-api/queries/query/current-snark-worker.graphql";
-import SendPaymentMutation from
-"!!raw-loader!./scripts/graphql-api/mutations/query/send-payment.graphql";
-import SendDelegationMutation from
-"!!raw-loader!./scripts/graphql-api/mutations/query/send-delegation.graphql";
-import SendZkappMutation from
-"!!raw-loader!./scripts/graphql-api/mutations/query/send-zkapp.graphql"; import
-MutationSendPayment from
-"!!raw-loader!./scripts/graphql-api/mutations/curl/send-payment.sh"; import
-MutationSendDelegation from
-"!!raw-loader!./scripts/graphql-api/mutations/curl/send-delegation.sh"; import
-MutationSendZkapp from
-"!!raw-loader!./scripts/graphql-api/mutations/curl/send-zkapp.sh"; import
-GraphqlList from "!!raw-loader!../scripts/cli/graphql-list.sh"; import
-GraphqlInspect from "!!raw-loader!../scripts/cli/graphql-inspect.sh"; import
-GraphqlInspectRemote from
-"!!raw-loader!../scripts/cli/graphql-inspect-remote.sh"; import GraphqlRunSimple
-from "!!raw-loader!../scripts/cli/graphql-run-simple.sh"; import GraphqlRunStdin
-from "!!raw-loader!../scripts/cli/graphql-run-stdin.sh"; import GraphqlRunFile
-from "!!raw-loader!../scripts/cli/graphql-run-file.sh"; import
-GraphqlRunVariables from "!!raw-loader!../scripts/cli/graphql-run-variables.sh";
-import GraphqlRunRemote from
-"!!raw-loader!../scripts/cli/graphql-run-remote.sh"; import
-GraphqlInspectOcamlProtocolState from
-"!!raw-loader!../scripts/cli/graphql-inspect-ocaml-protocolstate.sh"; import
-GraphqlRunOcamlProtocolState from
-"!!raw-loader!../scripts/cli/graphql-run-ocaml-protocolstate.sh";
+import CodeBlock from "@theme/CodeBlock";
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import TestBasicConnectivity from "!!raw-loader!./scripts/graphql-api/queries/curl/basic-connectivity.sh";
+import QuerySyncStatus from "!!raw-loader!./scripts/graphql-api/queries/curl/sync-status.sh";
+import QueryNodeInfo from "!!raw-loader!./scripts/graphql-api/queries/curl/node-info.sh";
+import QueryRecentActivity from "!!raw-loader!./scripts/graphql-api/queries/curl/recent-activity.sh";
+import QueryAccountBalance from "!!raw-loader!./scripts/graphql-api/queries/curl/account-balance.sh";
+import QueryBlock from "!!raw-loader!./scripts/graphql-api/queries/curl/block.sh";
+import QueryGenesisBlock from "!!raw-loader!./scripts/graphql-api/queries/curl/genesis-block.sh";
+import QueryGenesisConstants from "!!raw-loader!./scripts/graphql-api/queries/curl/genesis-constants.sh";
+import QueryPooledUserCommands from "!!raw-loader!./scripts/graphql-api/queries/curl/pooled-user-commands.sh";
+import QueryPooledZkappCommands from "!!raw-loader!./scripts/graphql-api/queries/curl/pooled-zkapp-commands.sh";
+import QueryTransactionStatus from "!!raw-loader!./scripts/graphql-api/queries/examples/transaction-status.sh";
+import QuerySnarkPool from "!!raw-loader!./scripts/graphql-api/queries/curl/snark-pool.sh";
+import QueryPendingSnarkWork from "!!raw-loader!./scripts/graphql-api/queries/curl/pending-snark-work.sh";
+import QueryCurrentSnarkWorker from "!!raw-loader!./scripts/graphql-api/queries/curl/current-snark-worker.sh";
+import QueryDaemonStatus from "!!raw-loader!./scripts/graphql-api/queries/curl/daemon-status.sh";
+import QueryNetworkID from "!!raw-loader!./scripts/graphql-api/queries/curl/network-id.sh";
+import QueryVersion from "!!raw-loader!./scripts/graphql-api/queries/curl/version.sh";
+import QueryBestChain from "!!raw-loader!./scripts/graphql-api/queries/curl/best-chain.sh";
+import QueryAccount from "!!raw-loader!./scripts/graphql-api/queries/curl/account.sh";
+import BasicConnectivityQuery from "!!raw-loader!./scripts/graphql-api/queries/query/basic-connectivity.graphql";
+import SyncStatusQuery from "!!raw-loader!./scripts/graphql-api/queries/query/sync-status.graphql";
+import NodeInfoQuery from "!!raw-loader!./scripts/graphql-api/queries/query/node-info.graphql";
+import RecentActivityQuery from "!!raw-loader!./scripts/graphql-api/queries/query/recent-activity.graphql";
+import AccountBalanceQuery from "!!raw-loader!./scripts/graphql-api/queries/query/account-balance.graphql";
+import DaemonStatusQuery from "!!raw-loader!./scripts/graphql-api/queries/query/daemon-status.graphql";
+import NetworkIDQuery from "!!raw-loader!./scripts/graphql-api/queries/query/network-id.graphql";
+import VersionQuery from "!!raw-loader!./scripts/graphql-api/queries/query/version.graphql";
+import BestChainQuery from "!!raw-loader!./scripts/graphql-api/queries/query/best-chain.graphql";
+import BlockQuery from "!!raw-loader!./scripts/graphql-api/queries/query/block.graphql";
+import GenesisBlockQuery from "!!raw-loader!./scripts/graphql-api/queries/query/genesis-block.graphql";
+import GenesisConstantsQuery from "!!raw-loader!./scripts/graphql-api/queries/query/genesis-constants.graphql";
+import AccountQuery from "!!raw-loader!./scripts/graphql-api/queries/query/account.graphql";
+import PooledUserCommandsQuery from "!!raw-loader!./scripts/graphql-api/queries/query/pooled-user-commands.graphql";
+import PooledZkappCommandsQuery from "!!raw-loader!./scripts/graphql-api/queries/query/pooled-zkapp-commands.graphql";
+import TransactionStatusQuery from "!!raw-loader!./scripts/graphql-api/queries/examples/transaction-status.graphql";
+import SnarkPoolQuery from "!!raw-loader!./scripts/graphql-api/queries/query/snark-pool.graphql";
+import PendingSnarkWorkQuery from "!!raw-loader!./scripts/graphql-api/queries/query/pending-snark-work.graphql";
+import CurrentSnarkWorkerQuery from "!!raw-loader!./scripts/graphql-api/queries/query/current-snark-worker.graphql";
+import SendPaymentMutation from "!!raw-loader!./scripts/graphql-api/mutations/query/send-payment.graphql";
+import SendDelegationMutation from "!!raw-loader!./scripts/graphql-api/mutations/query/send-delegation.graphql";
+import SendZkappMutation from "!!raw-loader!./scripts/graphql-api/mutations/query/send-zkapp.graphql";
+import MutationSendPayment from "!!raw-loader!./scripts/graphql-api/mutations/curl/send-payment.sh";
+import MutationSendDelegation from "!!raw-loader!./scripts/graphql-api/mutations/curl/send-delegation.sh";
+import MutationSendZkapp from "!!raw-loader!./scripts/graphql-api/mutations/curl/send-zkapp.sh";
+import GraphqlList from "!!raw-loader!../scripts/cli/graphql-list.sh";
+import GraphqlInspect from "!!raw-loader!../scripts/cli/graphql-inspect.sh";
+import GraphqlInspectRemote from "!!raw-loader!../scripts/cli/graphql-inspect-remote.sh";
+import GraphqlRunSimple from "!!raw-loader!../scripts/cli/graphql-run-simple.sh";
+import GraphqlRunStdin from "!!raw-loader!../scripts/cli/graphql-run-stdin.sh";
+import GraphqlRunFile from "!!raw-loader!../scripts/cli/graphql-run-file.sh";
+import GraphqlRunVariables from "!!raw-loader!../scripts/cli/graphql-run-variables.sh";
+import GraphqlRunRemote from "!!raw-loader!../scripts/cli/graphql-run-remote.sh";
+import GraphqlInspectOcamlProtocolState from "!!raw-loader!../scripts/cli/graphql-inspect-ocaml-protocolstate.sh";
+import GraphqlRunOcamlProtocolState from "!!raw-loader!../scripts/cli/graphql-run-ocaml-protocolstate.sh";
 
 # GraphQL API Reference
 
@@ -746,7 +703,10 @@ and inspect endpoints regardless of the node implementation.
 Discover all available GraphQL query and mutation endpoints by querying the
 server's introspection API:
 
-<CodeBlock language="bash" title="website/docs/developers/scripts/cli/graphql-list.sh">
+<CodeBlock
+  language="bash"
+  title="website/docs/developers/scripts/cli/graphql-list.sh"
+>
   {GraphqlList}
 </CodeBlock>
 
@@ -768,7 +728,10 @@ mina internal graphql list --node http://remote-node:3000/graphql
 
 Get detailed schema information for a specific endpoint:
 
-<CodeBlock language="bash" title="website/docs/developers/scripts/cli/graphql-inspect.sh">
+<CodeBlock
+  language="bash"
+  title="website/docs/developers/scripts/cli/graphql-inspect.sh"
+>
   {GraphqlInspect}
 </CodeBlock>
 
@@ -783,7 +746,10 @@ This displays:
 
 To inspect an endpoint on a remote node:
 
-<CodeBlock language="bash" title="website/docs/developers/scripts/cli/graphql-inspect-remote.sh">
+<CodeBlock
+  language="bash"
+  title="website/docs/developers/scripts/cli/graphql-inspect-remote.sh"
+>
   {GraphqlInspectRemote}
 </CodeBlock>
 
@@ -793,7 +759,10 @@ Execute arbitrary GraphQL queries directly from the CLI:
 
 ##### Simple query
 
-<CodeBlock language="bash" title="website/docs/developers/scripts/cli/graphql-run-simple.sh">
+<CodeBlock
+  language="bash"
+  title="website/docs/developers/scripts/cli/graphql-run-simple.sh"
+>
   {GraphqlRunSimple}
 </CodeBlock>
 
@@ -801,7 +770,10 @@ This executes the query and returns the formatted JSON response.
 
 ##### Query from stdin
 
-<CodeBlock language="bash" title="website/docs/developers/scripts/cli/graphql-run-stdin.sh">
+<CodeBlock
+  language="bash"
+  title="website/docs/developers/scripts/cli/graphql-run-stdin.sh"
+>
   {GraphqlRunStdin}
 </CodeBlock>
 
@@ -809,7 +781,10 @@ Useful for piping queries from other commands or scripts.
 
 ##### Query from file
 
-<CodeBlock language="bash" title="website/docs/developers/scripts/cli/graphql-run-file.sh">
+<CodeBlock
+  language="bash"
+  title="website/docs/developers/scripts/cli/graphql-run-file.sh"
+>
   {GraphqlRunFile}
 </CodeBlock>
 
@@ -817,7 +792,10 @@ Convenient for complex queries stored in `.graphql` files.
 
 ##### Query with variables
 
-<CodeBlock language="bash" title="website/docs/developers/scripts/cli/graphql-run-variables.sh">
+<CodeBlock
+  language="bash"
+  title="website/docs/developers/scripts/cli/graphql-run-variables.sh"
+>
   {GraphqlRunVariables}
 </CodeBlock>
 
@@ -826,7 +804,10 @@ for dynamic values.
 
 ##### Query remote node
 
-<CodeBlock language="bash" title="website/docs/developers/scripts/cli/graphql-run-remote.sh">
+<CodeBlock
+  language="bash"
+  title="website/docs/developers/scripts/cli/graphql-run-remote.sh"
+>
   {GraphqlRunRemote}
 </CodeBlock>
 
@@ -876,13 +857,19 @@ This is useful for:
 Some endpoints are only available in OCaml nodes. For example, the
 `protocolState` endpoint provides detailed protocol state information:
 
-<CodeBlock language="bash" title="website/docs/developers/scripts/cli/graphql-inspect-ocaml-protocolstate.sh">
+<CodeBlock
+  language="bash"
+  title="website/docs/developers/scripts/cli/graphql-inspect-ocaml-protocolstate.sh"
+>
   {GraphqlInspectOcamlProtocolState}
 </CodeBlock>
 
 You can query this endpoint directly:
 
-<CodeBlock language="bash" title="website/docs/developers/scripts/cli/graphql-run-ocaml-protocolstate.sh">
+<CodeBlock
+  language="bash"
+  title="website/docs/developers/scripts/cli/graphql-run-ocaml-protocolstate.sh"
+>
   {GraphqlRunOcamlProtocolState}
 </CodeBlock>
 

--- a/website/docs/developers/api-and-data/rpc-api.mdx
+++ b/website/docs/developers/api-and-data/rpc-api.mdx
@@ -4,31 +4,26 @@ description: HTTP RPC endpoints for the Mina Rust node
 sidebar_position: 2
 ---
 
-import CodeBlock from "@theme/CodeBlock"; import Tabs from "@theme/Tabs"; import
-TabItem from "@theme/TabItem"; import RpcStatus from
-"!!raw-loader!./scripts/rpc-api/curl/status.sh"; import RpcHealthz from
-"!!raw-loader!./scripts/rpc-api/curl/healthz.sh"; import RpcReadyz from
-"!!raw-loader!./scripts/rpc-api/curl/readyz.sh"; import RpcPeers from
-"!!raw-loader!./scripts/rpc-api/curl/peers.sh"; import RpcStatsSync from
-"!!raw-loader!./scripts/rpc-api/curl/stats-sync.sh"; import
-RpcStatsBlockProducer from
-"!!raw-loader!./scripts/rpc-api/curl/stats-block-producer.sh"; import
-RpcSnarkPoolJobs from "!!raw-loader!./scripts/rpc-api/curl/snark-pool-jobs.sh";
-import RpcSnarkerWorkers from
-"!!raw-loader!./scripts/rpc-api/curl/snarker-workers.sh"; import
-RpcSnarkerConfig from "!!raw-loader!./scripts/rpc-api/curl/snarker-config.sh";
-import RpcTransactionPool from
-"!!raw-loader!./scripts/rpc-api/curl/transaction-pool.sh"; import RpcAccounts
-from "!!raw-loader!./scripts/rpc-api/curl/accounts.sh"; import
-RpcDiscoveryRoutingTable from
-"!!raw-loader!./scripts/rpc-api/curl/discovery-routing-table.sh"; import
-RpcDiscoveryBootstrapStats from
-"!!raw-loader!./scripts/rpc-api/curl/discovery-bootstrap-stats.sh"; import
-RpcScanStateSummary from
-"!!raw-loader!./scripts/rpc-api/curl/scan-state-summary.sh"; import RpcState
-from "!!raw-loader!./scripts/rpc-api/curl/state.sh"; import RpcMessageProgress
-from "!!raw-loader!./scripts/rpc-api/curl/message-progress.sh"; import
-RpcBuildEnv from "!!raw-loader!./scripts/rpc-api/curl/build-env.sh";
+import CodeBlock from "@theme/CodeBlock";
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import RpcStatus from "!!raw-loader!./scripts/rpc-api/curl/status.sh";
+import RpcHealthz from "!!raw-loader!./scripts/rpc-api/curl/healthz.sh";
+import RpcReadyz from "!!raw-loader!./scripts/rpc-api/curl/readyz.sh";
+import RpcPeers from "!!raw-loader!./scripts/rpc-api/curl/peers.sh";
+import RpcStatsSync from "!!raw-loader!./scripts/rpc-api/curl/stats-sync.sh";
+import RpcStatsBlockProducer from "!!raw-loader!./scripts/rpc-api/curl/stats-block-producer.sh";
+import RpcSnarkPoolJobs from "!!raw-loader!./scripts/rpc-api/curl/snark-pool-jobs.sh";
+import RpcSnarkerWorkers from "!!raw-loader!./scripts/rpc-api/curl/snarker-workers.sh";
+import RpcSnarkerConfig from "!!raw-loader!./scripts/rpc-api/curl/snarker-config.sh";
+import RpcTransactionPool from "!!raw-loader!./scripts/rpc-api/curl/transaction-pool.sh";
+import RpcAccounts from "!!raw-loader!./scripts/rpc-api/curl/accounts.sh";
+import RpcDiscoveryRoutingTable from "!!raw-loader!./scripts/rpc-api/curl/discovery-routing-table.sh";
+import RpcDiscoveryBootstrapStats from "!!raw-loader!./scripts/rpc-api/curl/discovery-bootstrap-stats.sh";
+import RpcScanStateSummary from "!!raw-loader!./scripts/rpc-api/curl/scan-state-summary.sh";
+import RpcState from "!!raw-loader!./scripts/rpc-api/curl/state.sh";
+import RpcMessageProgress from "!!raw-loader!./scripts/rpc-api/curl/message-progress.sh";
+import RpcBuildEnv from "!!raw-loader!./scripts/rpc-api/curl/build-env.sh";
 
 # RPC API reference
 

--- a/website/docs/developers/wallet/index.md
+++ b/website/docs/developers/wallet/index.md
@@ -68,4 +68,4 @@ The wallet commands use the node's GraphQL API:
   (`status` command)
 
 For more details on the GraphQL API, see the
-[GraphQL API](../api-and-data/graphql-api.md) documentation.
+[GraphQL API](../api-and-data/graphql-api.mdx) documentation.

--- a/website/docs/node-operators/testing/overview.md
+++ b/website/docs/node-operators/testing/overview.md
@@ -16,7 +16,8 @@
   - [P2p Outgoing](#p2p-outgoing)
   - [Single Node](#single-node)
   - [Multi Node](#multi-node)
-  - [Record/Reply](#recordreplay)
+  - [Record/Replay Bootstrap](#recordreplay-bootstrap)
+  - [Record/Replay Block Production](#recordreplay-block-production)
 
 ## P2p tests
 

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -234,6 +234,7 @@
       "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.42.0.tgz",
       "integrity": "sha512-NZR7yyHj2WzK6D5X8gn+/KOxPdzYEXOqVdSaK/biU8QfYUpUuEA0sCWg/XlO05tPVEcJelF/oLrrNY3UjRbOww==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.42.0",
         "@algolia/requester-browser-xhr": "5.42.0",
@@ -359,6 +360,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2148,6 +2150,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2170,6 +2173,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2279,6 +2283,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -2700,6 +2705,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -3563,6 +3569,7 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.9.2.tgz",
       "integrity": "sha512-C5wZsGuKTY8jEYsqdxhhFOe1ZDjH0uIYJ9T/jebHwkyxqnr4wW0jTkB72OMqNjsoQRcb0JN3PcSeTwFlVgzCZg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@docusaurus/core": "3.9.2",
         "@docusaurus/logger": "3.9.2",
@@ -4264,6 +4271,7 @@
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
       "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0"
       },
@@ -4582,6 +4590,7 @@
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -4953,6 +4962,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -5303,6 +5313,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5388,6 +5399,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -5433,6 +5445,7 @@
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.42.0.tgz",
       "integrity": "sha512-X5+PtWc9EJIPafT/cj8ZG+6IU3cjRRnlHGtqMHK/9gsiupQbAyYlH5y7qt/FtsAhfX5AICHffZy69ZAsVrxWkQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.8.0",
         "@algolia/client-abtesting": "5.42.0",
@@ -5896,6 +5909,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -6852,6 +6866,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -8234,6 +8249,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -12691,6 +12707,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -13206,6 +13223,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -14109,6 +14127,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -14895,6 +14914,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -14977,6 +14997,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14986,6 +15007,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -15041,6 +15063,7 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-6.0.0.tgz",
       "integrity": "sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/react": "*"
       },
@@ -15069,6 +15092,7 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
       "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -16834,7 +16858,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/type-fest": {
       "version": "2.19.0",
@@ -16897,6 +16922,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17238,6 +17264,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -17445,6 +17472,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.100.2.tgz",
       "integrity": "sha512-QaNKAvGCDRh3wW1dsDjeMdDXwZm2vqq3zn6Pvq4rHOEOGSaUMgOOjG2Y9ZbIGzpfkJk9ZYTHpDqgDfeBDcnLaw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -18031,6 +18059,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
       "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
When we compile, we get the warning:
```
warning: the following packages contain code that will be rejected by a future version of Rust: num-bigint-dig v0.8.4
```

This patch updates using `cargo update rsa`.

Built on top of https://github.com/o1-labs/mina-rust/pull/2097