### PR TITLE
CI: add merge_group trigger for merge queue support

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -4,6 +4,7 @@ on:
     types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
     branches:
       - develop
+  merge_group:
 
 jobs:
   check-changelog:

--- a/.github/workflows/fmt.yaml
+++ b/.github/workflows/fmt.yaml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths-ignore:
       - 'frontend/**'
+  merge_group:
 
 jobs:
   format:

--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches: [ main, develop ]
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths-ignore:
       - 'frontend/**'
+  merge_group:
 
 jobs:
   lint:

--- a/.github/workflows/markdown-format.yaml
+++ b/.github/workflows/markdown-format.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ main, develop ]
   pull_request:
+  merge_group:
 
 jobs:
   markdown-format:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths-ignore:
       - 'frontend/**'
+  merge_group:
   workflow_dispatch:
     inputs:
       refresh_cache:

--- a/.github/workflows/whitespace-check.yaml
+++ b/.github/workflows/whitespace-check.yaml
@@ -5,6 +5,7 @@ on:
     branches: [ main, develop ]
   pull_request:
     branches: [ main, develop ]
+  merge_group:
 
 jobs:
   check-whitespace:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **CI**: Add `merge_group` trigger to workflows for merge queue support
+  ([#2127](https://github.com/o1-labs/mina-rust/pull/2127))
 - **CI**: Add path filtering to skip Rust/backend workflows when only frontend
   files change ([#2115](https://github.com/o1-labs/mina-rust/pull/2115))
 - Updated `proof-systems` dependencies (`kimchi`, `mina-curves`, `mina-hasher`, `mina-poseidon`, `mina-signer`, `o1-utils`, `poly-commitment`) from `0.2.0` to `0.3.0`.


### PR DESCRIPTION
## Summary

- Add `merge_group:` trigger to all workflows that are required checks
- Enables GitHub merge queue to function properly

## Problem

When using GitHub merge queues, workflows must include the `merge_group` event
trigger. Without it, required checks don't run when PRs are added to the queue,
causing them to hang indefinitely waiting for status checks that never start.

## Changes

Added `merge_group:` to:
- `tests.yaml`
- `lint.yaml`
- `fmt.yaml`
- `frontend.yaml`
- `markdown-format.yaml`
- `whitespace-check.yaml`
- `changelog.yaml`

## Test plan

- [ ] Verify workflows run on PR (existing behavior)
- [ ] Verify workflows run when PR is added to merge queue (new behavior)