### PR TITLE
build(deps): bump react and react-dom from 19.2.3 to 19.2.4 in /website

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Dependencies
 
+- Bump react and react-dom from 19.2.3 to 19.2.4 in /website
+  ([#2123](https://github.com/o1-labs/mina-rust/pull/2123),
+  [#2124](https://github.com/o1-labs/mina-rust/pull/2124))
 - Bump aws-config from 1.5.16 to 1.5.18
   ([#2125](https://github.com/o1-labs/mina-rust/pull/2125))
 - Bump serde from 1.0.219 to 1.0.228, update private API usage for compatibility

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -14,8 +14,8 @@
         "clsx": "^2.0.0",
         "docusaurus-theme-github-codeblock": "^2.0.2",
         "prism-react-renderer": "^2.3.0",
-        "react": "^19.2.3",
-        "react-dom": "^19.2.3"
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4"
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "^3.9.2",
@@ -14973,24 +14973,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
-      "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.3"
+        "react": "^19.2.4"
       }
     },
     "node_modules/react-fast-compare": {

--- a/website/package.json
+++ b/website/package.json
@@ -21,8 +21,8 @@
     "clsx": "^2.0.0",
     "docusaurus-theme-github-codeblock": "^2.0.2",
     "prism-react-renderer": "^2.3.0",
-    "react": "^19.2.3",
-    "react-dom": "^19.2.3"
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.9.2",


### PR DESCRIPTION
## Summary

Combines the dependency bumps from #2123 (react-dom) and #2124 (react) into a single update since they depend on each other.

- Bump react from 19.2.3 to 19.2.4
- Bump react-dom from 19.2.3 to 19.2.4

## Related PRs

Supersedes:
- #2123 (react-dom bump)
- #2124 (react bump)

## Release Notes

https://github.com/facebook/react/releases