### PR TITLE
Docs: add o1Labs infrastructure endpoints

### DIFF
--- a/website/docs/developers/scripts/infrastructure/archive-nodes.txt
+++ b/website/docs/developers/scripts/infrastructure/archive-nodes.txt
@@ -1,0 +1,2 @@
+https://devnet-archive-node-api.gcp.o1test.net/
+https://archive-node-api.gcp.o1test.net/

--- a/website/docs/developers/scripts/infrastructure/query-archive-blocks.sh
+++ b/website/docs/developers/scripts/infrastructure/query-archive-blocks.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Query recent blocks from the archive node
+
+ARCHIVE_NODE="${1:-https://devnet-archive-node-api.gcp.o1test.net}"
+
+curl -s -X POST \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "{ blocks(limit: 5) { blockHeight stateHash creatorAccount { publicKey } } }"
+  }' \
+  "${ARCHIVE_NODE}/graphql" | jq .

--- a/website/docs/node-operators/infrastructure/archive-nodes.mdx
+++ b/website/docs/node-operators/infrastructure/archive-nodes.mdx
@@ -4,26 +4,120 @@ description: o1Labs archive node infrastructure for historical data access
 sidebar_position: 3
 ---
 
+import CodeBlock from "@theme/CodeBlock";
+import ArchiveNodesList from "!!raw-loader!../../developers/scripts/infrastructure/archive-nodes.txt";
+import QueryArchiveBlocks from "!!raw-loader!../../developers/scripts/infrastructure/query-archive-blocks.sh";
+
 # Archive Nodes
+
+o1Labs maintains archive node infrastructure that provides access to historical
+blockchain data through a GraphQL API. These nodes store complete transaction
+history and block data.
+
+## Available archive nodes
+
+The following archive node endpoints are officially maintained by o1Labs:
+
+<CodeBlock
+  language="text"
+  title="website/docs/developers/scripts/infrastructure/archive-nodes.txt"
+>
+  {ArchiveNodesList}
+</CodeBlock>
+
+## Node information
+
+- **Availability**: Maintained 24/7 by o1Labs
+- **Purpose**: Historical blockchain data access and queries
+- **Location**: Hetzner Cloud (Europe)
+
+## Using archive nodes
+
+### GraphQL API access
+
+Archive nodes provide a GraphQL API for querying historical blockchain data:
+
+<CodeBlock
+  language="bash"
+  title="website/docs/developers/scripts/infrastructure/query-archive-blocks.sh"
+>
+  {QueryArchiveBlocks}
+</CodeBlock>
+
+### API capabilities
+
+- **Block history**: Query blocks by height, hash, or time range
+- **Transaction history**: Complete transaction records
+- **Account history**: Historical account states and balances
+- **Event data**: Protocol events and state transitions
 
 <!-- prettier-ignore-start -->
 
-:::caution Under Construction
+:::info API documentation
 
-This page is currently under construction. o1Labs archive node infrastructure
-documentation will be added here once the archive nodes are deployed and
-available.
-
-Archive nodes will provide:
-
-- Historical blockchain data access
-- Complete transaction history
-- Block and state archival
-- Database query interfaces
-
-Check back soon for complete documentation on accessing o1Labs archive
-infrastructure.
+For complete API documentation, see the
+[Archive Database Queries](../../developers/api-and-data/archive-database-queries)
+documentation.
 
 :::
 
 <!-- prettier-ignore-stop -->
+
+## Troubleshooting
+
+### Connection issues
+
+If you cannot connect to archive nodes:
+
+1. **Check network connectivity**: Ensure internet access and HTTPS traffic is
+   allowed
+2. **Verify URLs**: Confirm you're using the correct node URLs
+3. **Test manually**: Try accessing the URLs in a browser
+4. **Check node status**: Verify the node is responding to queries
+
+## Updates and maintenance
+
+### Infrastructure updates
+
+o1Labs maintains these archive nodes with:
+
+- **Regular updates**: Nodes are kept current with latest releases
+- **Monitoring**: 24/7 health monitoring and alerting
+- **Data integrity**: Continuous verification of archived data
+- **Performance optimization**: Regular performance tuning
+
+### Communication
+
+Infrastructure maintenance and updates are communicated through:
+
+- GitHub release notes
+- Project documentation updates
+- Community announcements
+
+## Deployment (o1Labs employees only)
+
+<!-- prettier-ignore-start -->
+
+:::caution o1Labs employees only
+
+This section is for o1Labs employees only. If you do not have access to the
+required repositories, contact the platform lead.
+
+:::
+
+<!-- prettier-ignore-stop -->
+
+o1Labs uses [ArgoCD](https://argo-cd.readthedocs.io/) to maintain the
+infrastructure through GitOps.
+
+The archive node infrastructure is configured in:
+`platform/hetzner-rivendell-1/applications/archive-node-api/`
+
+## Reference information
+
+### Related documentation
+
+- [Plain Nodes](./plain-nodes) - API access nodes
+- [Seed Nodes](./seed-nodes) - P2P network bootstrap nodes
+- [Archive Database Queries](../../developers/api-and-data/archive-database-queries) -
+  Query reference

--- a/website/docs/node-operators/infrastructure/frontend.mdx
+++ b/website/docs/node-operators/infrastructure/frontend.mdx
@@ -59,9 +59,44 @@ To update the Node Dashboard deployment:
 The web node is an experimental feature that allows running a Mina node directly
 in the browser using WebAssembly.
 
+### Production instance
+
+- **URL**: https://mina-rust-web-node.gcp.o1test.net
+- **Environment**: Production
+- **Network**: Mina Devnet
+- **Status**: Experimental
+
+### Resources
+
 - [Web node deployment guides](../web-node/) - Step-by-step instructions for
   running a web node using Docker or building from source
 - [Web node developer documentation](../../developers/frontend/web-node) -
   Architecture overview and development workflow
 
 Track progress: [Issue #1474](https://github.com/o1-labs/mina-rust/issues/1474)
+
+### Deployment (o1Labs employees only)
+
+<!-- prettier-ignore-start -->
+
+:::caution o1Labs employees only
+
+This section is for o1Labs employees only. If you do not have access to the
+required repositories, contact the platform lead.
+
+:::
+
+<!-- prettier-ignore-stop -->
+
+To update the Web Node deployment:
+
+1. Access the private repository:
+   `https://github.com/o1-labs/gitops-infrastructure`
+2. Create a new branch for your changes
+3. Edit: `applications/auto-deployed/mina-rust-web-node-app.yaml`
+4. Update the `MINA_RUST_TAG` variable to the desired commit or release tag
+   (must be available as a Docker image on
+   [DockerHub](https://hub.docker.com/r/o1labs/mina-rust-frontend))
+5. Create a pull request with your changes
+6. Ask the platform lead or rust node team lead to review and merge the PR
+7. Once merged, ArgoCD will automatically deploy the update


### PR DESCRIPTION
## Summary

- Add archive node endpoints from gitops-infrastructure to documentation
- Add Web Node production URL to frontend documentation
- Create archive node query example script

## Endpoints added

| Service | Endpoint |
|---------|----------|
| Archive Node (Devnet) | https://devnet-archive-node-api.gcp.o1test.net/ |
| Archive Node (Mainnet) | https://archive-node-api.gcp.o1test.net/ |
| Web Node | https://mina-rust-web-node.gcp.o1test.net |

## Test plan

- [ ] Verify documentation builds: `make docs-build`
- [ ] Verify endpoints are accessible