### PR TITLE
[CONT] ci: add workflow to suggest CHANGELOG entries via Claude

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+test commit please ignore
+
 <div align="center">
   <img src="website/static/img/rust-node-social-card.svg" alt="Mina Rust Node - Fast and secure implementation of the Mina protocol in Rust" width="600px">
 


### PR DESCRIPTION
This is a continuation of [PR #2175](https://github.com/o1-labs/mina-rust/pull/2175), as the prompt needs to be tested. To prevent prompt injection attacks, the workflow has to match the `develop` branch, so we needed to merge #2175 before testing.

I'll include the CHANGELOG entry for #2175 when testing is complete here

- [x] Open a test PR to `develop` without modifying CHANGELOG.md and without the `no changelog` label — the workflow should trigger and Claude should post a comment with suggested entries.
- [ ] Push a new commit to the same PR — the previous comment should be deleted and a new one posted with hidden history
- [ ] Add the `no changelog` label — the workflow should not run
- [ ] Modify `CHANGELOG.md` in a PR — the workflow should skip the suggestion step