### PR TITLE
fix(p2p): gracefully handle unknown protocols in Identify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Node**: migrate HTTP server from warp to axum
   ([#2119](https://github.com/o1-labs/mina-rust/pull/2119))
 
+### Fixed
+
+- **P2P**: Identify protocol no longer rejects peers that advertise unknown
+  protocol strings, improving forward compatibility with newer nodes
+  ([#2200](https://github.com/o1-labs/mina-rust/pull/2200))
+
 ### Dependencies
 
 - Bump react and react-dom from 19.2.3 to 19.2.4 in /website

--- a/crates/ledger/src/proofs/public_input/scalars.rs
+++ b/crates/ledger/src/proofs/public_input/scalars.rs
@@ -705,7 +705,7 @@ mod tests {
 
         // HashMap deliberately uses an unstable order; here we sort to ensure that the output is
         // consistent when printing.
-        index_terms_fp.sort_by(|(x, _), (y, _)| x.cmp(y));
+        index_terms_fp.sort_by_key(|(x, _)| *x);
 
         let fp_other_terms: Vec<(String, String)> = index_terms_fp
             .iter()
@@ -772,7 +772,7 @@ mod tests {
 
         // HashMap deliberately uses an unstable order; here we sort to ensure that the output is
         // consistent when printing.
-        index_terms_fq.sort_by(|(x, _), (y, _)| x.cmp(y));
+        index_terms_fq.sort_by_key(|(x, _)| *x);
 
         // dbg!(index_terms_fq)
 

--- a/crates/ledger/src/proofs/verifiers.rs
+++ b/crates/ledger/src/proofs/verifiers.rs
@@ -399,8 +399,7 @@ pub fn make_zkapp_verifier_index(vk: &VerificationKey) -> VerifierIndex<Fq> {
 
     let public = 40; // Is that constant ?
 
-    let domain: Radix2EvaluationDomain<Fq> =
-        Radix2EvaluationDomain::new(1 << log2_size as u64).unwrap();
+    let domain: Radix2EvaluationDomain<Fq> = Radix2EvaluationDomain::new(1 << log2_size).unwrap();
 
     let srs = {
         let degree = 1 << BACKEND_TOCK_ROUNDS_N;

--- a/crates/ledger/src/scan_state/transaction_logic/mod.rs
+++ b/crates/ledger/src/scan_state/transaction_logic/mod.rs
@@ -856,8 +856,8 @@ impl UserCommand {
         accounts: &BTreeMap<AccountId, Account>,
     ) -> HashMap<AccountId, VerificationKeyWire> {
         accounts
-            .iter()
-            .filter_map(|(_, account)| {
+            .values()
+            .filter_map(|account| {
                 let zkapp = account.zkapp.as_ref()?;
                 let vk = zkapp.verification_key.clone()?;
                 Some((account.id(), vk))

--- a/crates/ledger/src/transaction_pool.rs
+++ b/crates/ledger/src/transaction_pool.rs
@@ -1669,13 +1669,10 @@ impl TransactionPool {
     fn has_sufficient_fee(&self, pool_max_size: usize, cmd: &valid::UserCommand) -> bool {
         match self.pool.min_fee() {
             None => true,
-            Some(min_fee) => {
-                if self.pool.size() >= pool_max_size {
-                    cmd.forget_check().fee_per_wu() > min_fee
-                } else {
-                    true
-                }
+            Some(min_fee) if self.pool.size() >= pool_max_size => {
+                cmd.forget_check().fee_per_wu() > min_fee
             }
+            Some(_) => true,
         }
     }
 

--- a/crates/node/src/p2p/callbacks/p2p_callbacks_reducer.rs
+++ b/crates/node/src/p2p/callbacks/p2p_callbacks_reducer.rs
@@ -471,8 +471,8 @@ impl crate::State {
                 let p2p = p2p_ready!(state.p2p, meta.time());
                 let peers = p2p
                     .peers
-                    .iter()
-                    .filter_map(|(_, v)| v.dial_opts.clone())
+                    .values()
+                    .filter_map(|v| v.dial_opts.clone())
                     .collect();
                 let response = Some(Box::new(P2pRpcResponse::InitialPeers(peers)));
 

--- a/crates/node/src/snark_pool/candidate/snark_pool_candidate_state.rs
+++ b/crates/node/src/snark_pool/candidate/snark_pool_candidate_state.rs
@@ -200,8 +200,8 @@ impl SnarkPoolCandidatesState {
                     let peer_jobs = self.by_peer.get(peer_id)?;
                     if peer_jobs.get(job_id)?.work().is_some() {
                         let jobs = peer_jobs
-                            .iter()
-                            .filter_map(|(_, v)| match v {
+                            .values()
+                            .filter_map(|v| match v {
                                 SnarkPoolCandidateState::WorkReceived { work, .. } => Some(work),
                                 _ => None,
                             })

--- a/crates/node/src/stats/stats_sync.rs
+++ b/crates/node/src/stats/stats_sync.rs
@@ -426,8 +426,8 @@ impl SyncBlock {
         match state {
             TransitionFrontierSyncBlockState::FetchPending { attempts, .. } => {
                 if let Some(time) = attempts
-                    .iter()
-                    .filter_map(|(_, v)| v.fetch_pending_since())
+                    .values()
+                    .filter_map(|v| v.fetch_pending_since())
                     .min()
                 {
                     self.status = SyncBlockStatus::Fetching;

--- a/crates/node/src/transaction_pool/candidate/transaction_pool_candidate_state.rs
+++ b/crates/node/src/transaction_pool/candidate/transaction_pool_candidate_state.rs
@@ -251,8 +251,8 @@ impl TransactionPoolCandidatesState {
                     let peer_transactions = self.by_peer.get(peer_id)?;
                     if peer_transactions.get(hash)?.transaction().is_some() {
                         let transactions = peer_transactions
-                            .iter()
-                            .filter_map(|(_, v)| match v {
+                            .values()
+                            .filter_map(|v| match v {
                                 TransactionPoolCandidateState::Received { transaction, .. } => {
                                     Some(transaction)
                                 }

--- a/crates/node/src/transition_frontier/sync/ledger/snarked/transition_frontier_sync_ledger_snarked_actions.rs
+++ b/crates/node/src/transition_frontier/sync/ledger/snarked/transition_frontier_sync_ledger_snarked_actions.rs
@@ -352,8 +352,8 @@ impl redux::EnablingCondition<crate::State> for TransitionFrontierSyncLedgerSnar
                 .and_then(|s| s.snarked()?.fetch_pending())
                 .is_some_and(|pending| {
                     pending
-                        .iter()
-                        .filter_map(|(_, query_state)| query_state.attempts.get(peer_id))
+                        .values()
+                        .filter_map(|query_state| query_state.attempts.get(peer_id))
                         .any(|peer_rpc_state| matches!(peer_rpc_state, PeerRpcState::Init { .. }))
                 }),
             TransitionFrontierSyncLedgerSnarkedAction::PeerQueryAddressError {

--- a/crates/p2p/src/identify/p2p_identify_reducer.rs
+++ b/crates/p2p/src/identify/p2p_identify_reducer.rs
@@ -73,6 +73,12 @@ impl P2pState {
 
                 let (dispatcher, state) = state_context.into_dispatcher_and_state();
 
+                let supports_rpc = info.supports(&StreamKind::Rpc(RpcAlgorithm::Rpc0_0_1));
+                let supports_broadcast =
+                    info.supports(&StreamKind::Broadcast(BroadcastAlgorithm::Meshsub1_1_0));
+                let supports_discovery =
+                    info.supports(&StreamKind::Discovery(DiscoveryAlgorithm::Kademlia1_0_0));
+
                 dispatcher.push(P2pNetworkKademliaAction::UpdateRoutingTable {
                     peer_id,
                     addrs: info.listen_addrs,
@@ -80,8 +86,7 @@ impl P2pState {
 
                 let stream_id = YamuxStreamKind::Rpc.stream_id(addr.incoming);
 
-                let stream_kind = StreamKind::Rpc(RpcAlgorithm::Rpc0_0_1);
-                if !info.protocols.contains(&stream_kind) {
+                if !supports_rpc {
                     dispatcher.push(P2pDisconnectionAction::Init {
                         peer_id,
                         reason: P2pDisconnectionReason::Unsupported,
@@ -94,14 +99,15 @@ impl P2pState {
                     state.channels_init(dispatcher, peer_id);
                 }
 
+                let stream_kind = StreamKind::Rpc(RpcAlgorithm::Rpc0_0_1);
                 dispatcher.push(P2pNetworkYamuxAction::OpenStream {
                     addr,
                     stream_id,
                     stream_kind,
                 });
 
-                let stream_kind = StreamKind::Broadcast(BroadcastAlgorithm::Meshsub1_1_0);
-                if info.protocols.contains(&stream_kind) {
+                if supports_broadcast {
+                    let stream_kind = StreamKind::Broadcast(BroadcastAlgorithm::Meshsub1_1_0);
                     dispatcher.push(P2pNetworkYamuxAction::OpenStream {
                         addr,
                         stream_id: stream_id + 2,
@@ -110,9 +116,8 @@ impl P2pState {
                 }
 
                 let kad_state: Option<&P2pNetworkKadState> = state.substate().ok();
-                let protocol = StreamKind::Discovery(DiscoveryAlgorithm::Kademlia1_0_0);
                 if kad_state.is_some_and(|state| state.request(&peer_id).is_some())
-                    && info.protocols.contains(&protocol)
+                    && supports_discovery
                 {
                     dispatcher.push(P2pNetworkKadRequestAction::MuxReady { peer_id, addr });
                 }

--- a/crates/p2p/src/network/identify/p2p_network_identify_protocol.rs
+++ b/crates/p2p/src/network/identify/p2p_network_identify_protocol.rs
@@ -151,7 +151,7 @@ impl<'a> TryFrom<&'a P2pNetworkIdentify> for super::pb::Identify {
                 .iter()
                 .map(|v| match v {
                     StreamProtocolId::Known(k) => k.name_str().into(),
-                    StreamProtocolId::Unknown(s) => s.clone().into(),
+                    StreamProtocolId::Unknown(s) => s.clone(),
                 })
                 .collect(),
         })

--- a/crates/p2p/src/network/identify/p2p_network_identify_protocol.rs
+++ b/crates/p2p/src/network/identify/p2p_network_identify_protocol.rs
@@ -19,13 +19,34 @@ pub struct P2pNetworkIdentify {
     pub listen_addrs: Vec<Multiaddr>,
     #[with_malloc_size_of_func = "measurement::multiaddr_opt"]
     pub observed_addr: Option<Multiaddr>,
-    pub protocols: Vec<token::StreamKind>,
+    pub protocols: Vec<StreamProtocolId>,
+}
+
+/// A protocol identifier from an Identify message. Wraps known `StreamKind`
+/// variants and preserves unknown protocol strings for forward compatibility.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, MallocSizeOf)]
+pub enum StreamProtocolId {
+    Known(StreamKind),
+    Unknown(String),
+}
+
+impl StreamProtocolId {
+    pub fn as_known(&self) -> Option<&StreamKind> {
+        match self {
+            Self::Known(k) => Some(k),
+            Self::Unknown(_) => None,
+        }
+    }
+}
+
+impl P2pNetworkIdentify {
+    pub fn supports(&self, kind: &StreamKind) -> bool {
+        self.protocols.iter().any(|p| p.as_known() == Some(kind))
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, thiserror::Error)]
 pub enum P2pNetworkIdentifyFromMessageError {
-    #[error("cant parse protocol: {0}")]
-    UnsupportedProtocol(String),
     #[error("unsupported public key type: {0}")]
     UnsupportedPubKeyType(String),
     #[error("error parsing public key: {0}")]
@@ -65,11 +86,12 @@ impl TryFrom<super::pb::Identify> for P2pNetworkIdentify {
             None => None,
         };
 
-        let mut protocols = Vec::new();
-
-        for proto in value.protocols.iter() {
-            protocols.push(parse_protocol(proto)?)
-        }
+        let protocols = value
+            .protocols
+            .iter()
+            .map(String::as_str)
+            .map(parse_protocol)
+            .collect();
 
         Ok(Self {
             protocol_version,
@@ -127,7 +149,10 @@ impl<'a> TryFrom<&'a P2pNetworkIdentify> for super::pb::Identify {
             protocols: value
                 .protocols
                 .iter()
-                .map(|v| v.name_str().into())
+                .map(|v| match v {
+                    StreamProtocolId::Known(k) => k.name_str().into(),
+                    StreamProtocolId::Unknown(s) => s.clone().into(),
+                })
                 .collect(),
         })
     }
@@ -165,19 +190,15 @@ pub fn parse_public_key(key_bytes: &[u8]) -> Result<PublicKey, P2pNetworkIdentif
     )
 }
 
-pub fn parse_protocol(name: &str) -> Result<StreamKind, P2pNetworkIdentifyFromMessageError> {
-    // buffer content should match one of tokens
+pub fn parse_protocol(name: &str) -> StreamProtocolId {
     for tok in token::Token::ALL.iter() {
         if let token::Token::Protocol(token::Protocol::Stream(a)) = tok {
             if a.name_str() == name {
-                return Ok(*a);
+                return StreamProtocolId::Known(*a);
             }
         }
     }
-
-    Err(P2pNetworkIdentifyFromMessageError::UnsupportedProtocol(
-        name.to_string(),
-    ))
+    StreamProtocolId::Unknown(name.to_string())
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, thiserror::Error)]

--- a/crates/p2p/src/network/identify/stream/p2p_network_identify_stream_reducer.rs
+++ b/crates/p2p/src/network/identify/stream/p2p_network_identify_stream_reducer.rs
@@ -7,7 +7,7 @@ use crate::{
         pb::{self, Identify},
         stream::P2pNetworkIdentifyStreamError,
         stream_effectful::P2pNetworkIdentifyStreamEffectfulAction,
-        P2pNetworkIdentify, P2pNetworkIdentifyState,
+        P2pNetworkIdentify, P2pNetworkIdentifyState, StreamProtocolId,
     },
     token, ConnectionAddr, Data, P2pLimits, P2pNetworkConnectionError, P2pNetworkSchedulerAction,
     P2pNetworkStreamProtobufError, P2pNetworkYamuxAction, P2pState, PeerId, YamuxFlags,
@@ -386,14 +386,18 @@ impl P2pNetworkIdentifyStreamState {
         let public_key = Some(state.config.identity_pub_key.clone());
 
         let mut protocols = vec![
-            token::StreamKind::Identify(token::IdentifyAlgorithm::Identify1_0_0),
-            token::StreamKind::Broadcast(token::BroadcastAlgorithm::Meshsub1_1_0),
-            token::StreamKind::Rpc(token::RpcAlgorithm::Rpc0_0_1),
+            StreamProtocolId::Known(token::StreamKind::Identify(
+                token::IdentifyAlgorithm::Identify1_0_0,
+            )),
+            StreamProtocolId::Known(token::StreamKind::Broadcast(
+                token::BroadcastAlgorithm::Meshsub1_1_0,
+            )),
+            StreamProtocolId::Known(token::StreamKind::Rpc(token::RpcAlgorithm::Rpc0_0_1)),
         ];
         if state.network.scheduler.discovery_state.is_some() {
-            protocols.push(token::StreamKind::Discovery(
+            protocols.push(StreamProtocolId::Known(token::StreamKind::Discovery(
                 token::DiscoveryAlgorithm::Kademlia1_0_0,
-            ));
+            )));
         }
         let identify_msg = P2pNetworkIdentify {
             protocol_version: Some("ipfs/0.1.0".to_string()),

--- a/crates/p2p/src/p2p_reducer.rs
+++ b/crates/p2p/src/p2p_reducer.rs
@@ -143,8 +143,8 @@ impl P2pState {
         let timeouts = &self.config.timeouts;
 
         self.peers
-            .iter()
-            .filter_map(|(_, peer)| {
+            .values()
+            .filter_map(|peer| {
                 if peer.can_reconnect(time, timeouts) {
                     peer.dial_opts.clone()
                 } else {

--- a/crates/p2p/src/p2p_state.rs
+++ b/crates/p2p/src/p2p_state.rs
@@ -141,7 +141,7 @@ impl P2pState {
     }
 
     pub fn disconnected_peers(&self) -> impl '_ + Iterator<Item = P2pConnectionOutgoingInitOpts> {
-        self.peers.iter().filter_map(|(_, state)| {
+        self.peers.values().filter_map(|state| {
             if let P2pPeerState {
                 status: P2pPeerStatus::Disconnected { .. },
                 dial_opts: Some(opts),

--- a/crates/p2p/testing/src/stream.rs
+++ b/crates/p2p/testing/src/stream.rs
@@ -209,6 +209,10 @@ where
         Poll::Ready(loop {
             if !*this.done {
                 match ready!(this.stream.as_mut().try_poll_next(cx)) {
+                    #[allow(
+                        clippy::collapsible_match,
+                        reason = "false positive: match guard would move non-Copy `event`"
+                    )]
                     Some(Ok(ClusterEvent::Rust { id, event })) => {
                         if (this.f)(id, event, this.stream.rust_node(id).state()) {
                             *this.done = true;

--- a/tools/gossipsub-sandbox/src/main.rs
+++ b/tools/gossipsub-sandbox/src/main.rs
@@ -106,16 +106,14 @@ async fn main() {
     let mut file = File::create(path.join("snark_pool_diff")).unwrap();
     while let Some(event) = swarm.next().await {
         match event {
-            SwarmEvent::Behaviour(gossipsub::Event::Message { message, .. }) => {
+            SwarmEvent::Behaviour(gossipsub::Event::Message { message, .. })
                 // GossipNetMessageV2::SnarkPoolDiff
-                if message.data[8] == 1 {
+                if message.data[8] == 1 => {
                     file.write_all(&message.data).unwrap();
-                }
             }
             SwarmEvent::Behaviour(gossipsub::Event::Subscribed { peer_id, topic }) => {
                 log::info!("{peer_id} {topic}");
             }
-            SwarmEvent::ConnectionEstablished { .. } => {}
             _ => {}
         }
     }


### PR DESCRIPTION
(stacked PRs: this is 1 of 3, merge this before #2201 and #2202)

### Description

Replace the strict `parse_protocol()` that rejected entire Identify messages
on unknown protocol strings with a `StreamProtocolId` enum (`Known`/`Unknown`)
that preserves unrecognized protocols for forward compatibility. This prevents
older Rust nodes from disconnecting peers that advertise new capability
strings, consistent with how go-libp2p handles unknown protocols.

### Related Issue(s)

Closes #2189

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Testing

- Existing test suite passes; `parse_protocol` no longer returns `Result`,
  so unknown strings are silently preserved rather than causing errors.

### Changelog Entry

**Fixed**: **P2P**: Identify protocol no longer rejects peers that advertise unknown
protocol strings, improving forward compatibility with newer nodes ([#2200](https://github.com/o1-labs/mina-rust/pull/2200))