### PR TITLE
chore(redux): prefer core/alloc over std

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2092](https://github.com/o1-labs/mina-rust/pull/2092))
 - **Node**: migrate HTTP server from warp to axum
   ([#2119](https://github.com/o1-labs/mina-rust/pull/2119))
+- **Redux**: prefer `core`/`alloc` imports over `std` in the `redux` crate to
+  prepare for `no_std` support
+  ([#2208](https://github.com/o1-labs/mina-rust/pull/2208))
 
 ### Dependencies
 

--- a/libs/redux/src/action/action_id.rs
+++ b/libs/redux/src/action/action_id.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use core::time::Duration;
 
 use crate::Timestamp;
 

--- a/libs/redux/src/action/action_meta.rs
+++ b/libs/redux/src/action/action_meta.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use core::time::Duration;
 
 use crate::{SystemTime, Timestamp};
 

--- a/libs/redux/src/action/action_with_meta.rs
+++ b/libs/redux/src/action/action_with_meta.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use core::time::Duration;
 
 use crate::{SystemTime, Timestamp};
 

--- a/libs/redux/src/callback.rs
+++ b/libs/redux/src/callback.rs
@@ -1,15 +1,15 @@
 #[cfg(feature = "serializable_callbacks")]
 use linkme::distributed_slice;
 
+use alloc::borrow::Cow;
 pub use paste;
 use serde::{Deserialize, Serialize};
-use std::borrow::Cow;
 
-pub struct AnyAction(pub Box<dyn std::any::Any>);
+pub struct AnyAction(pub Box<dyn core::any::Any>);
 
 #[cfg(feature = "serializable_callbacks")]
 #[distributed_slice]
-pub static CALLBACKS: [(&str, fn(&str, Box<dyn std::any::Any>) -> AnyAction)];
+pub static CALLBACKS: [(&str, fn(&str, Box<dyn core::any::Any>) -> AnyAction)];
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Callback<T> {
@@ -46,7 +46,7 @@ impl<T: 'static> Callback<T> {
             // We reach this point only when the callback was deserialized
             for (name, fun) in CALLBACKS {
                 if name == &self.fun_name {
-                    return fun(std::any::type_name::<T>(), Box::new(args)).into();
+                    return fun(core::any::type_name::<T>(), Box::new(args)).into();
                 }
             }
 
@@ -70,11 +70,11 @@ macro_rules! _callback {
                 AnyAction(Box::new(action))
             }
 
-            fn $callback_name(call_type: &str, args: Box<dyn std::any::Any>) -> AnyAction {
+            fn $callback_name(call_type: &str, args: Box<dyn core::any::Any>) -> AnyAction {
                 #[cfg(feature = "serializable_callbacks")]
                 {
                     #[distributed_slice(CALLBACKS)]
-                    static CALLBACK_DESERIALIZE: (&str, fn(&str, Box<dyn std::any::Any>) -> AnyAction) = (
+                    static CALLBACK_DESERIALIZE: (&str, fn(&str, Box<dyn core::any::Any>) -> AnyAction) = (
                         stringify!($callback_name),
                         $callback_name,
                     );

--- a/libs/redux/src/dispatcher.rs
+++ b/libs/redux/src/dispatcher.rs
@@ -1,4 +1,5 @@
-use std::{collections::VecDeque, marker::PhantomData};
+use alloc::collections::VecDeque;
+use core::marker::PhantomData;
 
 use crate::{AnyAction, Callback, EnablingCondition};
 

--- a/libs/redux/src/instant.rs
+++ b/libs/redux/src/instant.rs
@@ -1,4 +1,4 @@
-use std::{
+use core::{
     cell::RefCell,
     cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd},
     ops::{Add, AddAssign, Sub, SubAssign},
@@ -139,8 +139,8 @@ impl SubAssign<Duration> for Instant {
     }
 }
 
-impl std::fmt::Debug for Instant {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Instant {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         self.inner.fmt(f)
     }
 }

--- a/libs/redux/src/lib.rs
+++ b/libs/redux/src/lib.rs
@@ -1,5 +1,7 @@
 #![cfg_attr(feature = "fuzzing", feature(no_coverage))]
 
+extern crate alloc;
+
 mod instant;
 
 mod timestamp;

--- a/libs/redux/src/timestamp.rs
+++ b/libs/redux/src/timestamp.rs
@@ -1,5 +1,5 @@
 pub use crate::instant::Instant;
-use std::time::Duration;
+use core::time::Duration;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use std::time::SystemTime;
@@ -60,7 +60,7 @@ impl From<Timestamp> for SystemTime {
     }
 }
 
-impl std::ops::Add for Timestamp {
+impl core::ops::Add for Timestamp {
     type Output = Timestamp;
     #[inline]
     fn add(self, other: Timestamp) -> Timestamp {
@@ -68,7 +68,7 @@ impl std::ops::Add for Timestamp {
     }
 }
 
-impl std::ops::Add<u64> for Timestamp {
+impl core::ops::Add<u64> for Timestamp {
     type Output = Timestamp;
     #[inline]
     fn add(self, other: u64) -> Timestamp {
@@ -76,7 +76,7 @@ impl std::ops::Add<u64> for Timestamp {
     }
 }
 
-impl std::ops::Add<Duration> for Timestamp {
+impl core::ops::Add<Duration> for Timestamp {
     type Output = Timestamp;
     #[inline]
     fn add(self, other: Duration) -> Timestamp {


### PR DESCRIPTION
### Description

First incremental step toward #1260. Scope is the reusable `libs/redux` crate only — swap `std::X` for `core::X` / `alloc::X` wherever an equivalent exists, and add `extern crate alloc;` at the crate root.

**Changes (8 files, +20/-17):**

- `lib.rs` — add `extern crate alloc;`
- `dispatcher.rs` — `std::collections::VecDeque` → `alloc::collections::VecDeque`; `std::marker::PhantomData` → `core::marker::PhantomData`
- `callback.rs` — `std::borrow::Cow` → `alloc::borrow::Cow`; `std::any::{Any,type_name}` → `core::any::{Any,type_name}` (incl. inside the public `_callback!` macro body)
- `timestamp.rs`, `action/action_id.rs`, `action/action_with_meta.rs`, `action/action_meta.rs` — `std::time::Duration` → `core::time::Duration`; `impl std::ops::Add` → `impl core::ops::Add` (3 impls)
- `instant.rs` — `std::{cell::RefCell, cmp, ops, time::Duration}` → `core::{...}`; `std::fmt::{Debug,Formatter,Result}` → `core::fmt::{...}`

**Left on `std::` (no `core`/`alloc` equivalent):**

- `std::sync::OnceLock` in `store.rs` — needs platform sync primitives
- `std::time::Instant`, `std::time::SystemTime` — not in `core`; existing `wasm-timer` shim already covers `cfg(target_arch = "wasm32")`
- `thread_local!` macro in `instant.rs` — std-only macro

No behaviour change.

### Related Issue(s)

Refs #1260.

Intentionally not a `Closes` — #1260 spans the whole workspace. This PR lands the leaf library first to validate the direction; further crates (`crates/core`, `crates/p2p`, `crates/node`, `crates/ledger`, …) follow in separate PRs.

### Type of Change

- [x] Refactoring (no functional changes)

### Testing

Local, branched off fresh `upstream/develop`:

```
cargo check -p redux
cargo clippy -p redux --all-targets --no-deps -- --deny=warnings
cargo test -p redux
cargo check --workspace
cargo fmt --all --check
make check-trailing-whitespace
```

All green. `cargo check --workspace` produces only pre-existing warnings in `crates/node` and `crates/p2p` unrelated to this diff.

### Changelog Entry

**Changelog Summary:** **Changed** the `redux` library to prefer `core::` and `alloc::` paths over `std::` where possible (refs #1260).