### PR TITLE
chore(alloc-test): prefer core/alloc over std

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2092](https://github.com/o1-labs/mina-rust/pull/2092))
 - **Node**: migrate HTTP server from warp to axum
   ([#2119](https://github.com/o1-labs/mina-rust/pull/2119))
+- **Alloc-test**: prefer `core`/`alloc` imports over `std` in the `alloc-test`
+  library to progress toward `no_std` support
+  ([#2209](https://github.com/o1-labs/mina-rust/pull/2209))
 
 ### Dependencies
 

--- a/libs/alloc-test/src/alloc/allocator.rs
+++ b/libs/alloc-test/src/alloc/allocator.rs
@@ -1,4 +1,4 @@
-use std::alloc::{GlobalAlloc, Layout};
+use core::alloc::{GlobalAlloc, Layout};
 
 #[derive(Debug, Default)]
 pub struct TracingAllocator<H: 'static, A>(A, H)

--- a/libs/alloc-test/src/alloc/measure.rs
+++ b/libs/alloc-test/src/alloc/measure.rs
@@ -1,4 +1,4 @@
-use std::{
+use core::{
     mem,
     sync::atomic::{AtomicBool, Ordering},
 };

--- a/libs/alloc-test/src/perf/measure.rs
+++ b/libs/alloc-test/src/perf/measure.rs
@@ -43,7 +43,7 @@ export function performance_now() {
         }
     }
 
-    use std::{ops::*, time::Duration};
+    use core::{ops::*, time::Duration};
 
     impl Add<Duration> for Instant {
         type Output = Instant;
@@ -98,8 +98,8 @@ impl From<Stats> for PerfStats {
     }
 }
 
-impl std::fmt::Display for Stats {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Stats {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         if f.alternate() {
             todo!()
         } else {
@@ -145,7 +145,7 @@ fn bench_internal<O, F: Fn() -> O>(iters: usize, wu_cd_iters: usize, f: &F) -> P
     stats.into()
 }
 
-use std::time::Duration;
+use core::time::Duration;
 
 use derive_more::Display;
 use serde::{Deserialize, Serialize};

--- a/libs/alloc-test/src/threshold.rs
+++ b/libs/alloc-test/src/threshold.rs
@@ -1,7 +1,6 @@
+use core::fmt::{Debug, Display};
 use std::{
-    env,
-    fmt::{Debug, Display},
-    fs, io,
+    env, fs, io,
     path::{Path, PathBuf},
     process::Command,
 };


### PR DESCRIPTION
### Description

Move imports in the `alloc-test` library off `std::` where `core::` provides the same item. Same `no_std`-readiness pattern as #2208, applied to the next `libs/` crate.

Replaced:
- `std::alloc::{GlobalAlloc, Layout}` → `core::alloc::{GlobalAlloc, Layout}`
- `std::sync::atomic`, `std::mem`, `std::ops`, `std::fmt`, `std::time::Duration` → `core::*` equivalents.

Kept on `std::` because no `core` equivalent exists:
- `std::alloc::System` (platform allocator)
- `std::time::Instant` (needs platform time source)
- `std::env`, `std::fs`, `std::io`, `std::path`, `std::process` (OS APIs)

### Related Issue(s)

Refs #1260.

### Type of Change

- [x] Refactoring (no functional changes)

### Testing

- [x] `cargo check -p alloc-test`
- [x] `cargo clippy -p alloc-test --all-targets -- -D warnings`
- [x] `cargo test -p alloc-test` (3 unit tests pass)
- [x] `cargo check --workspace`

### Changelog Entry

**Changelog Summary:** **Alloc-test**: prefer `core`/`alloc` imports over `std` in the `alloc-test` library to progress toward `no_std` support.
