### PR TITLE
chore(node-common): silence wasm32 build warnings in archive module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#2092](https://github.com/o1-labs/mina-rust/pull/2092))
 - **Node**: migrate HTTP server from warp to axum
   ([#2119](https://github.com/o1-labs/mina-rust/pull/2119))
+- **Node-common**: silence the wasm32 build warnings emitted from the `archive`
+  service module by gating the native-only imports, constants, and helpers
+  behind `#[cfg(not(target_arch = "wasm32"))]`
+  ([#2210](https://github.com/o1-labs/mina-rust/pull/2210))
 
 ### Dependencies
 

--- a/crates/node/common/src/service/archive/mod.rs
+++ b/crates/node/common/src/service/archive/mod.rs
@@ -2,11 +2,17 @@ use mina_node::{
     core::{channels::mpsc, thread},
     ledger::write::BlockApplyResult,
 };
-use mina_p2p_messages::v2::{self};
-use std::{env, io::Write};
 
+#[cfg(not(target_arch = "wasm32"))]
+use mina_p2p_messages::v2::{self};
+#[cfg(not(target_arch = "wasm32"))]
+use std::env;
+
+#[cfg(not(target_arch = "wasm32"))]
 use mina_core::NetworkConfig;
+#[cfg(not(target_arch = "wasm32"))]
 use mina_p2p_messages::v2::PrecomputedBlock;
+#[cfg(not(target_arch = "wasm32"))]
 use std::net::SocketAddr;
 
 use super::NodeService;
@@ -22,8 +28,11 @@ pub mod config;
 
 use config::ArchiveStorageOptions;
 
+#[cfg(not(target_arch = "wasm32"))]
 const ARCHIVE_SEND_RETRIES: u8 = 5;
+#[cfg(not(target_arch = "wasm32"))]
 const MAX_EVENT_COUNT: u64 = 100;
+#[cfg(not(target_arch = "wasm32"))]
 const RETRY_INTERVAL_MS: u64 = 1000;
 
 #[derive(Debug, thiserror::Error)]
@@ -245,9 +254,9 @@ impl ArchiveService {
     // Note: Placeholder for the wasm implementation, if we decide to include an archive mode in the future
     #[cfg(target_arch = "wasm32")]
     fn run(
-        mut archive_receiver: mpsc::UnboundedReceiver<BlockApplyResult>,
-        options: ArchiveStorageOptions,
-        work_dir: String,
+        _archive_receiver: mpsc::UnboundedReceiver<BlockApplyResult>,
+        _options: ArchiveStorageOptions,
+        _work_dir: String,
     ) {
         unimplemented!()
     }
@@ -315,9 +324,11 @@ impl mina_node::transition_frontier::archive::archive_service::ArchiveService fo
 #[cfg(target_arch = "wasm32")]
 mod rpc {}
 
+#[cfg(not(target_arch = "wasm32"))]
 fn write_to_local_storage(base_path: &str, key: &str, data: &[u8]) -> Result<(), Error> {
     use std::{
         fs::{create_dir_all, File},
+        io::Write,
         path::Path,
     };
 


### PR DESCRIPTION
### Description

The `crates/node/common/src/service/archive/mod.rs` module mixes a real native implementation with a wasm32 stub. Imports, constants, and the `write_to_local_storage` helper exist only to support the native path, so on `--target wasm32-unknown-unknown` they trigger 13 `unused_imports` / `dead_code` / `unused_variables` warnings during `make build-wasm`.

This change gates them behind `#[cfg(not(target_arch = "wasm32"))]` and prefixes the unused parameters of the wasm placeholder `run` with `_`. No behavior change on native; wasm32 stops complaining.

First incremental step toward zero warnings under `make build-wasm`. Other crates (notably `mina-p2p` with ~40 warnings) will need follow-up PRs.

### Related Issue(s)

Refs #1193.

### Type of Change

- [x] Refactoring (no functional changes)

### Testing

- [x] `make build-wasm` (the 13 `mina-node-common` source-level warnings are gone; the only remaining `mina-node-common` line is rustc's `unstable feature specified for -Ctarget-feature: atomics`, which comes from `crates/node/web/.cargo/config.toml`, not from this crate)
- [x] `cargo check --workspace` (native, green)
- [x] `cargo clippy -p mina-node-common --all-targets --no-deps -- -D warnings` (green)
- [x] `cargo test -p mina-node-common --lib` (1 test passes)

### Changelog Entry

**Changelog Summary:** **Node-common**: silence the wasm32 build warnings emitted from the `archive` service module by gating the native-only imports, constants, and helpers behind `#[cfg(not(target_arch = "wasm32"))]`.
